### PR TITLE
fix: reduce high CPU usage in serial monitor

### DIFF
--- a/tyutool/cli/cli_monitor.py
+++ b/tyutool/cli/cli_monitor.py
@@ -90,18 +90,24 @@ def cli(device, port, baud, save):
 def receive_data(ser, stop_event, logger, log_file=None):
     try:
         while not stop_event.is_set():
-            if ser.in_waiting:
-                data = ser.readline().decode('utf-8', errors='ignore').strip()
-                if data:
-                    print(data)
-                    if log_file:
-                        try:
-                            log_file.write(data + '\n')
-                            log_file.flush()
-                        except Exception as e:
-                            logger.error(f"Write log error: {e}")
+            data = ser.readline()   # 阻塞
+
+            if not data:
+                continue
+
+            data = data.decode('utf-8', errors='ignore').strip()
+            if data:
+                print(data)
+
+                if log_file:
+                    try:
+                        log_file.write(data + '\n')
+                        # 不要每次 flush
+                    except Exception as e:
+                        logger.error(f"Write log error: {e}")
+
     except Exception as e:
-        logger.error(f"Recive error: {e}")
+        logger.error(f"Receive error: {e}")
 
 
 def send_data(ser, stop_event, logger):

--- a/tyutool/cli/cli_monitor.py
+++ b/tyutool/cli/cli_monitor.py
@@ -102,7 +102,7 @@ def receive_data(ser, stop_event, logger, log_file=None):
                 if log_file:
                     try:
                         log_file.write(data + '\n')
-                        # 不要每次 flush
+                        log_file.flush()
                     except Exception as e:
                         logger.error(f"Write log error: {e}")
 


### PR DESCRIPTION
Description:

## Problem
The current implementation uses `ser.in_waiting` inside a tight loop:

    while not stop_event.is_set():
        if ser.in_waiting:
            ...

``` shell

cfm880@cfm880:~$ py-spy top --pid 34326


Collecting samples from 'python /home/cfm880/sources/git_clone/TuyaOpen/tools/tyCollecting samples from 'python /home/cfm880/sources/git_clone/TuyaOpen/tools/tyCollecting samples from 'python 
.
.
.
/home/cfm880/sources/git_clone/TuyaOpen/tools/tyCollecting samples from 'python /home/cfm880/sources/git_clone/TuyaOpen/tools/tyutool/tyutool_cli.py monitor -d T5AI' (python v3.13.5)
Total Samples 5592
GIL: 48.00%, Active: 102.00%, Threads: 3

  %Own   %Total  OwnTime  TotalTime  Function (filename)                        
100.00% 100.00%   55.29s    55.29s   in_waiting (serial/serialposix.py)
  1.00%   1.00%    1.21s     1.21s   join (threading.py)
  1.00%   1.00%    1.20s     1.20s   send_data (tyutool/cli/cli_monitor.py)
  0.00% 100.00%   0.520s    55.91s   receive_data (tyutool/cli/cli_monitor.py)
  0.00%   0.00%   0.100s    0.100s   is_set (threading.py)
  0.00% 101.00%   0.000s    57.11s   _bootstrap_inner (threading.py)
  0.00% 101.00%   0.000s    57.11s   _bootstrap (threading.py)
  0.00% 101.00%   0.000s    57.11s   run (threading.py)
  0.00%   1.00%   0.000s     1.21s   <module> (tyutool_cli.py)
  0.00%   1.00%   0.000s     1.21s   __call__ (click/core.py)
  0.00%   1.00%   0.000s     1.21s   cli (tyutool/cli/cli_monitor.py)
  0.00%   1.00%   0.000s     1.21s   cli (tyutool/cli/__init__.py)
  0.00%   1.00%   0.000s     1.21s   main (click/core.py)
  0.00%   1.00%   0.000s     1.21s   invoke (click/core.py)



Press Control-C to quit, or ? for help.

```






## Solution
- Remove `ser.in_waiting` polling
- Use blocking `ser.readline()` instead
- Reduce unnecessary `flush()` calls

## Benefits
- CPU usage reduced from ~100% to <1%
- More efficient and power-friendly
- Cleaner and more idiomatic pyserial usage

## Testing
- Verified serial communication works as expected
- Ctrl+C exits correctly
- Log file writing is preserved
- cpu result
```shell
// after

cfm880@cfm880:~$ py-spy top --pid 50451


Collecting samples from 'python /home/cfm880/sources/git_clone/TuyaOpen/tools/tyCollecting samples from 'python /home/cfm880/sources/git_clone/TuyaOpen/tools/tyCollecting samples from 'python 
.
.
.
/home/cfm880/sources/git_clone/TuyaOpen/tools/tyCollecting samples from 'python /home/cfm880/sources/git_clone/TuyaOpen/tools/tyutool/tyutool_cli.py monitor -d T5AI' (python v3.13.5)
Total Samples 1227
GIL: 0.00%, Active: 15.00%, Threads: 3

  %Own   %Total  OwnTime  TotalTime  Function (filename)                        
  7.00%   7.00%   0.570s    0.570s   join (threading.py)
  8.00%   8.00%   0.410s    0.410s   send_data (tyutool/cli/cli_monitor.py)
  0.00%   0.00%   0.360s    0.360s   read (serial/serialposix.py)
  0.00%   7.00%   0.000s    0.570s   __call__ (click/core.py)
  0.00%   8.00%   0.000s    0.770s   _bootstrap (threading.py)
  0.00%   8.00%   0.000s    0.770s   _bootstrap_inner (threading.py)
  0.00%   7.00%   0.000s    0.570s   main (click/core.py)
  0.00%   7.00%   0.000s    0.570s   <module> (tyutool_cli.py)
  0.00%   7.00%   0.000s    0.570s   cli (tyutool/cli/cli_monitor.py)
  0.00%   0.00%   0.000s    0.360s   receive_data (tyutool/cli/cli_monitor.py)
  0.00%   7.00%   0.000s    0.570s   invoke (click/core.py)
  0.00%   8.00%   0.000s    0.770s   run (threading.py)
  0.00%   7.00%   0.000s    0.570s   cli (tyutool/cli/__init__.py)
```

## Notes
`timeout=1` ensures the thread remains responsive to stop_event





