### PR TITLE
feat(vscode): runtime detection and platform adapter for IDE webview

### DIFF
--- a/src/features/firmware-flash/ws-transport.ts
+++ b/src/features/firmware-flash/ws-transport.ts
@@ -7,10 +7,15 @@
 
 import type { FlashJobPayload, FlashProgressPayload } from './flash-tauri';
 import type { TauriSerialPortRow } from './serial-port-label';
+import { platform } from '../../platform';
 
 const WS_PORT = '9527';
 
 function wsUrl(): string {
+  // In VS Code webview, read the injected wsUrl (may include port-forwarded URL
+  // for Remote SSH). Fall back to localhost for plain web / dev mode.
+  const injected = platform.getWsUrl();
+  if (injected) return injected;
   const host = typeof window !== 'undefined' && window.location.hostname ? window.location.hostname : '127.0.0.1';
   return `ws://${host}:${WS_PORT}`;
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,65 @@
+import { getRuntime } from './runtime'
+
+export interface Platform {
+  /** Returns absolute local file path, or null if cancelled / unsupported. */
+  pickFile(requestId: string, accept: string): Promise<string | null>
+  getWsUrl(): string
+}
+
+class TauriPlatform implements Platform {
+  async pickFile(_requestId: string, accept: string): Promise<string | null> {
+    const { open } = await import('@tauri-apps/plugin-dialog')
+    const extensions = accept.split(',').map(e => e.trim().replace(/^\./, ''))
+    const selected = await open({ multiple: false, filters: [{ name: 'Firmware', extensions }] })
+    return selected ?? null
+  }
+  getWsUrl(): string { return '' }
+}
+
+class VscodePlatform implements Platform {
+  private readonly _api: { postMessage: (msg: unknown) => void } | null
+
+  constructor() {
+    this._api = (window as any).acquireVsCodeApi?.() ?? null
+  }
+
+  async pickFile(requestId: string, accept: string): Promise<string | null> {
+    if (!this._api) return null
+    return new Promise<string | null>(resolve => {
+      const timer = setTimeout(() => {
+        window.removeEventListener('message', handler)
+        resolve(null)
+      }, 30_000)
+
+      const handler = (e: MessageEvent) => {
+        if (e.data?.type === 'pickFileResult' && e.data.requestId === requestId) {
+          clearTimeout(timer)
+          window.removeEventListener('message', handler)
+          resolve(e.data.path ?? null)
+        }
+      }
+      window.addEventListener('message', handler)
+      this._api!.postMessage({ type: 'pickFile', requestId, accept })
+    })
+  }
+
+  getWsUrl(): string {
+    return (window as any).__TUYAOPEN_IDE_CONFIG?.wsUrl ?? ''
+  }
+}
+
+class WebPlatform implements Platform {
+  // Web mode uses a hidden <input type="file"> element triggered by the caller;
+  // pickFile() returns null to signal "use DOM input fallback".
+  async pickFile(_requestId: string, _accept: string): Promise<string | null> { return null }
+  getWsUrl(): string { return '' }
+}
+
+export function createPlatform(): Platform {
+  const rt = getRuntime()
+  if (rt === 'tauri') return new TauriPlatform()
+  if (rt === 'vscode') return new VscodePlatform()
+  return new WebPlatform()
+}
+
+export const platform: Platform = createPlatform()

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,10 +1,14 @@
-import { createRouter, createWebHistory } from 'vue-router';
+import { createRouter, createWebHistory, createMemoryHistory } from 'vue-router';
 import FirmwareFlashPage from '@/features/firmware-flash/FirmwareFlashPage.vue';
 import SerialDebugPage from '@/features/serial-debug/SerialDebugPage.vue';
 import { SettingsPage } from '@/features/settings';
+import { getRuntime } from '../runtime';
 
 export const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  // createMemoryHistory for VS Code webview: the vscode-webview:// URL scheme
+  // confuses createWebHistory base resolution, preventing the / → /flash redirect.
+  // Memory history keeps all navigation in-process and works in any URL scheme.
+  history: getRuntime() === 'vscode' ? createMemoryHistory() : createWebHistory(import.meta.env.BASE_URL),
   routes: [
     { path: '/', redirect: '/flash' },
     { path: '/flash', name: 'flash', component: FirmwareFlashPage, meta: { title: '固件烧录', layout: 'fullBleed' } },

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,10 @@
+import { isTauriRuntime } from '@/features/firmware-flash/flash-tauri'
+
+export type RuntimeType = 'tauri' | 'vscode' | 'web'
+
+export function getRuntime(): RuntimeType {
+  if (typeof window === 'undefined') return 'web'
+  if (isTauriRuntime()) return 'tauri'
+  if ((window as any).__TUYAOPEN_IDE_CONFIG?.runtime === 'vscode') return 'vscode'
+  return 'web'
+}


### PR DESCRIPTION
## Summary

Adds proper environment separation so tyutool behaves correctly when embedded as a VSCode webview panel inside tuyaopen-ide, without breaking Tauri desktop or web browser modes.

- **`src/runtime.ts`** (new): `getRuntime()` → `'tauri' | 'vscode' | 'web'`
  - Tauri: detected via `window.__TAURI_INTERNALS__`
  - VSCode: detected via `window.__TUYAOPEN_IDE_CONFIG.runtime === 'vscode'` (injected by the extension's `buildDevicesHtml`)
  - Web: fallback

- **`src/platform.ts`** (new): `Platform` interface with `pickFile()` + `getWsUrl()` per-runtime implementations
  - `VscodePlatform.getWsUrl()` reads `window.__TUYAOPEN_IDE_CONFIG.wsUrl`, which contains the correct port-forwarded URL (supports Remote SSH)
  - `TauriPlatform` / `WebPlatform` return `''` → existing behavior unchanged

- **`src/router/index.ts`**: `createMemoryHistory()` for VSCode, `createWebHistory()` for Tauri/web
  - Fixes: in VSCode webview panels the URL scheme is `vscode-webview://`, which breaks `createWebHistory` base resolution — the `/` → `/flash` redirect never fires and the nav sidebar shows nothing selected

- **`src/features/firmware-flash/ws-transport.ts`**: reads `platform.getWsUrl()` first, falls back to `ws://${window.location.hostname}:9527` if empty
  - Fixes: `window.location.hostname` in a VSCode webview is the webview UUID, not `localhost`, causing WebSocket connections to fail

## Impact on existing environments

| Environment | Router | WS transport |
|---|---|---|
| Tauri desktop | `createWebHistory` — unchanged | not used (Tauri IPC) |
| Web (`dev:web`) | `createWebHistory` — unchanged | fallback to old behavior (`''` from `WebPlatform`) |
| VSCode webview | `createMemoryHistory` — fixed | reads injected `wsUrl` — fixed |

## Test plan

- [ ] `pnpm run test` — all 256 tests pass (verified locally)
- [ ] `pnpm run build` — TypeScript + Vite build passes
- [ ] Tauri desktop: flash and serial debug work as before
- [ ] Web dev mode (`pnpm dev:web`): flash and serial debug work as before
- [ ] VSCode webview (via tuyaopen-ide): nav shows "固件烧录" selected on open, WS connects to correct port