### PR TITLE
feat(vscode): wire platform.pickFile() for firmware file selection in IDE webview

### DIFF
--- a/src/stores/flash.ts
+++ b/src/stores/flash.ts
@@ -9,6 +9,8 @@ import {
 import { chipManifest, rustPluginIdForChip } from '@/features/firmware-flash/chip-manifests';
 import { usePortManagerStore } from '@/stores/port-manager';
 import { type FlashJobPayload, type FlashProgressPayload, isTauriRuntime } from '@/features/firmware-flash/flash-tauri';
+import { getRuntime } from '../runtime';
+import { platform } from '../platform';
 import {
   alignedExclusiveEraseRange4K,
   exclusiveEraseRangeNeeds4KAlignment,
@@ -307,6 +309,13 @@ export const useFlashStore = defineStore('flash', () => {
         }
       } catch {
         /* ignore */
+      }
+      return;
+    }
+    if (getRuntime() === 'vscode') {
+      const path = await platform.pickFile(crypto.randomUUID(), '.bin,.hex,.elf,.img');
+      if (path) {
+        flashSegments.value[index].firmwarePath = path;
       }
       return;
     }


### PR DESCRIPTION
## Summary

In VSCode webview panels, \`<input type="file">\` is blocked by the sandbox. This PR wires \`platform.pickFile()\` (from \`platform.ts\` in #41) into \`flash.ts\`'s \`onPickFile()\`, delegating file selection to the extension host via postMessage.

**The chain:**
\`\`\`
tyutool onPickFile()
  → platform.pickFile()            (VscodePlatform)
  → postMessage({ type: 'pickFile', requestId, accept })
  → extension openDevicesPanel handler
  → vscode.window.showOpenDialog()
  → postMessage({ type: 'pickFileResult', requestId, path })
  → resolve(path) → flashSegments[index].firmwarePath = path
\`\`\`

The extension-side handler is already implemented in \`openDevicesPanel\`.

## Changes

\`src/stores/flash.ts\` — adds VSCode branch in \`onPickFile()\` between Tauri and web fallback. Tauri and web code paths are **unchanged**.

## Depends on

#41 — stacked on \`feat/vscode-runtime-adapter\`. Merge #41 first.

## Test plan

- [ ] 256 tests pass ✓
- [ ] \`pnpm run build\` passes ✓
- [ ] Tauri: file picker unchanged ✓
- [ ] Web: \`<input type="file">\` unchanged ✓
- [ ] VSCode: clicking firmware file picker opens VS Code native open dialog