### PR TITLE
feat(t5): add support for Ziguang flash chip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5885,7 +5885,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "tyutool-cli"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5914,7 +5914,7 @@ dependencies = [
 
 [[package]]
 name = "tyutool-core"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "crc32fast",
  "espflash",
@@ -5928,7 +5928,7 @@ dependencies = [
 
 [[package]]
 name = "tyutool_gui"
-version = "3.0.11"
+version = "3.0.12"
 dependencies = [
  "log",
  "reqwest 0.12.28",

--- a/crates/tyutool-core/src/plugins/beken/flash_table.rs
+++ b/crates/tyutool-core/src/plugins/beken/flash_table.rs
@@ -517,6 +517,16 @@ static FLASH_TABLE: &[FlashParams] = &[
         block_size: 64 * KB,
         wp: wp2(SR12_READ, SR12_WRITE_SINGLE, 0x407c, 0x0007),
     },
+    // ── ZG ─────────────────────────────────────────
+    FlashParams {
+        mid: 0x1760cd,
+        name: "ZG25Q64B",
+        vendor: "ZG",
+        total_size: 64 * MB / 8,
+        sector_size: 4 * KB,
+        block_size: 64 * KB,
+        wp: wp2(SR12_READ, SR12_WRITE, 0x0038, 0x0038),
+    },
 ];
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -582,5 +592,22 @@ mod tests {
         assert_eq!(p.mid, 0xABCDEF);
         assert_eq!(p.total_size, 2 * 1024 * 1024);
         assert!(p.wp.is_none());
+    }
+
+    #[test]
+    fn lookup_zg25q64b() {
+        let p = lookup(0x1760cd).unwrap();
+        assert_eq!(p.name, "ZG25Q64B");
+        assert_eq!(p.vendor, "ZG");
+        assert_eq!(p.total_size, 8 * 1024 * 1024); // 64 Mbit = 8 MiB
+        assert_eq!(p.sector_size, 4096);
+        assert_eq!(p.block_size, 65536);
+        let wp = p.wp.unwrap();
+        assert_eq!(wp.sr_bytes, 2);
+        assert_eq!(wp.read_sr_cmds, &[0x05, 0x35]);
+        assert_eq!(wp.write_sr_cmds, &[0x01, 0x31]);
+        assert_eq!(wp.protect_mask, 0x0038);
+        assert_eq!(wp.unprotect_value, 0x0000);
+        assert_eq!(wp.protect_value, 0x0038);
     }
 }


### PR DESCRIPTION
Add flash table entry for Ziguang ZG25Q64B SPI-NOR flash (MID 0x1760cd, 8 MiB) with correct write-protection register config.

WP config derived from vendor tool USB packet capture:
- SR1 protect bits: BP2/BP1/BP0 (mask 0x0038)
- SR2: no protection bits
- SR read: 0x05/0x35, SR write: 0x01/0x31