### PR TITLE
ci(release): collapse Linux GUI matrix and merge manifest job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,8 @@ jobs:
           if-no-files-found: error
 
   # ── GUI (7 installers + 4 portables) ────────────────────────────────────────
-  # Tauri 2 desktop app, each distribution type as a separate artifact
+  # Tauri 2 desktop app. One job per platform/arch; a single compile emits every
+  # bundle format for that target (Linux deb+appimage+rpm share one build).
   # Binary name = tyutool_gui (set by src-tauri/Cargo.toml [package].name)
   # Artifacts: tyutool-gui_{platform}_{arch}_{type}_{ver}.ext
   build-gui:
@@ -128,17 +129,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux x86_64
-          - { os: ubuntu-22.04,     target: x86_64-unknown-linux-gnu,  platform: linux,   arch: x86_64,   bundles: deb,       install_type: deb,      with_portable: true  }
-          - { os: ubuntu-22.04,     target: x86_64-unknown-linux-gnu,  platform: linux,   arch: x86_64,   bundles: appimage,  install_type: appimage, with_portable: false }
-          - { os: ubuntu-22.04,     target: x86_64-unknown-linux-gnu,  platform: linux,   arch: x86_64,   bundles: rpm,       install_type: rpm,      with_portable: false }
+          # Linux x86_64 — all bundle formats produced from a single compile
+          - { os: ubuntu-22.04,     target: x86_64-unknown-linux-gnu,  platform: linux,   arch: x86_64,   bundles: "deb,appimage,rpm", install_types: "deb appimage rpm", install_type: installers, with_portable: true }
           # Linux aarch64 (native ARM runner — no cross-compilation needed)
-          - { os: ubuntu-22.04-arm, target: aarch64-unknown-linux-gnu, platform: linux,   arch: aarch64,  bundles: deb,       install_type: deb,      with_portable: true  }
-          - { os: ubuntu-22.04-arm, target: aarch64-unknown-linux-gnu, platform: linux,   arch: aarch64,  bundles: appimage,  install_type: appimage, with_portable: false }
+          - { os: ubuntu-22.04-arm, target: aarch64-unknown-linux-gnu, platform: linux,   arch: aarch64,  bundles: "deb,appimage",     install_types: "deb appimage",     install_type: installers, with_portable: true }
           # macOS Universal Binary (single build covers Intel + Apple Silicon)
           # bundle_prefix: Tauri places universal artifacts under target/universal-apple-darwin/release/
           # tauri_args:    passed verbatim to `npx @tauri-apps/cli build`
-          - { os: macos-latest, target: universal-apple-darwin, platform: macos, arch: universal, bundles: "dmg,app", install_type: dmg, with_portable: true, with_updater: true, bundle_prefix: "target/universal-apple-darwin/release", tauri_args: "--target universal-apple-darwin" }
+          - { os: macos-latest, target: universal-apple-darwin, platform: macos, arch: universal, bundles: "dmg,app", install_types: "dmg", install_type: dmg, with_portable: true, with_updater: true, bundle_prefix: "target/universal-apple-darwin/release", tauri_args: "--target universal-apple-darwin" }
           # Windows x86_64 — NSIS installer + portable (MSI removed; NSIS is simpler and matches sftool-gui)
           - { os: windows-2022,     target: x86_64-pc-windows-msvc,    platform: windows, arch: x86_64,   bundles: nsis,      install_type: nsis,     with_portable: true  }
     env:
@@ -175,9 +173,10 @@ jobs:
           targets: ${{ matrix.target == 'universal-apple-darwin' && 'aarch64-apple-darwin,x86_64-apple-darwin' || matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
-          key: "gui-${{ matrix.target }}"
+          # shared-key replaces the per-job key suffix so a target's cache is reusable
+          # across runs; each target now compiles in a single job, so always persist it.
           shared-key: "gui-${{ matrix.target }}"
-          save-if: ${{ matrix.install_type == 'deb' || matrix.platform != 'linux' }}
+          save-if: true
 
       # ── Frontend + Tauri build ──
       - run: pnpm install --frozen-lockfile
@@ -190,28 +189,36 @@ jobs:
       # ── Installer: locate Tauri output and rename uniformly ──
       # Use release-pkg/ instead of dist/ to avoid collision with Vite build output.
       # bundle_prefix is set in the matrix for non-default layouts (e.g. universal-apple-darwin).
+      # A single Tauri compile can emit several bundle formats (e.g. deb+appimage+rpm
+      # on Linux), so loop over each one in matrix.install_types and rename uniformly.
       - name: Package installer (Unix)
         if: runner.os != 'Windows'
         run: |
           mkdir -p release-pkg
           BUNDLE_BASE="${{ matrix.bundle_prefix || 'target/release' }}"
-          BUNDLE_DIR="${BUNDLE_BASE}/bundle/${{ matrix.install_type }}"
-          case "${{ matrix.install_type }}" in
-            deb)      GLOB="*.deb" ;;
-            rpm)      GLOB="*.rpm" ;;
-            appimage) GLOB="*.AppImage" ;;
-            dmg)      GLOB="*.dmg" ;;
-            *)        GLOB="*" ;;
-          esac
-          SRC=$(find "$BUNDLE_DIR" -maxdepth 1 -name "$GLOB" -type f | head -1)
-          EXT="${SRC##*.}"
-          DEST="${PREFIX}_${{ matrix.install_type }}_${VERSION}.${EXT}"
-          cp "$SRC" "release-pkg/${DEST}"
-          # Copy .sig file if it exists (needed by generate-manifest.ts for GUI updater)
-          SIG="${SRC}.sig"
-          if [ -f "$SIG" ]; then
-            cp "$SIG" "release-pkg/${DEST}.sig"
-          fi
+          for IT in ${{ matrix.install_types }}; do
+            BUNDLE_DIR="${BUNDLE_BASE}/bundle/${IT}"
+            case "$IT" in
+              deb)      GLOB="*.deb" ;;
+              rpm)      GLOB="*.rpm" ;;
+              appimage) GLOB="*.AppImage" ;;
+              dmg)      GLOB="*.dmg" ;;
+              *)        GLOB="*" ;;
+            esac
+            SRC=$(find "$BUNDLE_DIR" -maxdepth 1 -name "$GLOB" -type f | head -1)
+            if [ -z "$SRC" ]; then
+              echo "::error::No ${IT} bundle found in ${BUNDLE_DIR}"
+              exit 1
+            fi
+            EXT="${SRC##*.}"
+            DEST="${PREFIX}_${IT}_${VERSION}.${EXT}"
+            cp "$SRC" "release-pkg/${DEST}"
+            # Copy .sig file if it exists (needed by generate-manifest.ts for GUI updater)
+            SIG="${SRC}.sig"
+            if [ -f "$SIG" ]; then
+              cp "$SIG" "release-pkg/${DEST}.sig"
+            fi
+          done
 
       - name: Package installer (Windows)
         if: runner.os == 'Windows'
@@ -280,9 +287,9 @@ jobs:
           path: release-portable/
           if-no-files-found: error
 
-  # ── GitHub Release (tag trigger only) ───────────────────────────────────────
+  # ── GitHub Release + latest.json manifest (tag trigger only) ────────────────
   create-release:
-    name: Create GitHub Release
+    name: Create Release + manifest
     needs: [prepare, build-cli, build-gui]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
@@ -338,38 +345,15 @@ jobs:
             echo "__TYUTOOL_NOTES_EOF__"
           } >> "$GITHUB_OUTPUT"
 
-  # ── Generate latest.json update manifest ────────────────────────────────────
-  generate-manifest:
-    name: Generate latest.json
-    needs: [prepare, create-release]
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/download-artifact@v8
-        with: { path: artifacts/ }
-
-      - uses: pnpm/action-setup@v5
-        with:
-          version: 10
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
+      # ── latest.json update manifest ──
+      # Generated in this same job: artifacts/ is already downloaded and the draft
+      # release exists, so no second runner / artifact download / pnpm install is needed.
       - name: Generate manifest
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
           GITHUB_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
-          RELEASE_NOTES: ${{ needs.create-release.outputs.notes }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.body }}
         run: pnpm exec tsx scripts/generate-manifest.ts
 
       - uses: softprops/action-gh-release@v3
@@ -380,7 +364,7 @@ jobs:
   # ── Verify draft release, then publish ──────────────────────────────────────
   publish:
     name: Verify & Publish
-    needs: [prepare, create-release, generate-manifest]
+    needs: [prepare, create-release]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
@@ -404,7 +388,7 @@ jobs:
   # Optional repo variable: GITEE_TARGET_COMMITISH. Script: scripts/sync-gitee-release.sh
   sync-gitee:
     name: Sync to Gitee
-    needs: [publish, generate-manifest, prepare, create-release]
+    needs: [publish, prepare, create-release]
     runs-on: self-hosted
     if: startsWith(github.ref, 'refs/tags/')
     continue-on-error: true

--- a/src/features/serial-debug/transport.test.ts
+++ b/src/features/serial-debug/transport.test.ts
@@ -50,9 +50,9 @@ import { wsTransport } from "@/transport/ws-transport";
 const cfg: DebugConfig = {
   port: "/dev/ttyUSB0",
   baudRate: 115200,
-  dataBits: 8,
+  dataBits: "eight",
   parity: "none",
-  stopBits: 1,
+  stopBits: "one",
 };
 
 describe("serialDebugTransport factory", () => {

--- a/src/features/settings/report-issue.test.ts
+++ b/src/features/settings/report-issue.test.ts
@@ -5,7 +5,9 @@ import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 const { showConfirmDialog, save, invoke } = vi.hoisted(() => ({
   showConfirmDialog: vi.fn(async () => true),
   save: vi.fn(async () => "/home/u/logs.zip"),
-  invoke: vi.fn(async () => undefined),
+  invoke: vi.fn(
+    async (_cmd: string, _args?: Record<string, unknown>) => undefined,
+  ),
 }));
 
 vi.mock("@/runtime", async (importOriginal) => ({
@@ -112,7 +114,7 @@ describe("exportLogsAndReport", () => {
 
   it("Tauri mode: copies the issue URL to the clipboard and opens it externally", async () => {
     vi.mocked(isTauriRuntime).mockReturnValue(true);
-    const writeText = vi.fn(async () => undefined);
+    const writeText = vi.fn(async (_text: string) => undefined);
     vi.stubGlobal("navigator", {
       userAgent: "Mozilla/5.0 (X11; Linux x86_64)",
       clipboard: { writeText },


### PR DESCRIPTION
## What

Three optimizations to `release.yml` that cut runner time without changing release output.

### #1 — Collapse the Linux GUI matrix (biggest win)
The `build-gui` matrix split Linux bundle formats into separate jobs, each doing a full `pnpm build` + Tauri/Rust compile of the same target:
- x86_64: `deb` + `appimage` + `rpm` → 3 jobs
- aarch64: `deb` + `appimage` → 2 jobs

Tauri emits all formats from one compile (`--bundles deb,appimage,rpm`). Now **one job per arch** (5 → 2), driven by an `install_types` list that the shared Unix packaging step loops over. **Linux GUI compiles: 6 → 2.** Also removes the prior cache-save race where parallel same-target jobs started before `deb` saved its cache.

### #2 — Merge `generate-manifest` into `create-release`
Both jobs downloaded the full artifact set and ran `pnpm install`. `create-release` already has `artifacts/` downloaded and the draft release created, so `latest.json` is now generated in-place. Drops a redundant runner, a full artifact download, and a pnpm install. `publish` / `sync-gitee` `needs` updated.

### #3 — rust-cache cleanup
Dropped the redundant `key` on the GUI `Swatinem/rust-cache` (`shared-key` alone governs cross-run reuse); `save-if: true` now that each target is a single job.

## Output unchanged
Release assets and filenames are identical (7 installers + 4 portables). Bundle filename labels still come from each bundle type (`deb`/`appimage`/`rpm`/`dmg`), not the job.

## Validation
- `release.yml` parses as valid YAML.
- No dangling references to the removed `generate-manifest` job.
- macOS/Windows build paths, updater artifact, and portable logic untouched.