### PR TITLE
i18n(batch-flash-auth): 剩余硬编码中文国际化

### DIFF
--- a/src/features/batch-flash-auth/components/BatchFlashAuthDashboard.vue
+++ b/src/features/batch-flash-auth/components/BatchFlashAuthDashboard.vue
@@ -31,7 +31,7 @@ onUnmounted(() => clearInterval(ticker));
 
 const bannerBg = computed(() => {
   const k = store.completionBanner?.kind;
-  if (k === "success")
+  if (k === "all-success")
     return "color-mix(in srgb, var(--ty-success) 10%, transparent)";
   if (k === "all-failed")
     return "color-mix(in srgb, var(--ty-danger) 10%, transparent)";
@@ -40,9 +40,27 @@ const bannerBg = computed(() => {
 
 const bannerTextColor = computed(() => {
   const k = store.completionBanner?.kind;
-  if (k === "success") return "var(--ty-success)";
+  if (k === "all-success") return "var(--ty-success)";
   if (k === "all-failed") return "var(--ty-danger)";
   return "var(--ty-accent)";
+});
+
+const bannerText = computed(() => {
+  const b = store.completionBanner;
+  if (!b) return "";
+  switch (b.kind) {
+    case "all-skipped":
+      return t("batchFlashAuth.completion.allSkipped", { count: b.count });
+    case "all-success":
+      return t("batchFlashAuth.completion.allSuccess", { count: b.count });
+    case "all-failed":
+      return t("batchFlashAuth.completion.allFailed");
+    case "partial":
+      return t("batchFlashAuth.completion.partial", {
+        done: b.done,
+        failed: b.failed,
+      });
+  }
 });
 </script>
 
@@ -54,7 +72,7 @@ const bannerTextColor = computed(() => {
       class="flex items-center justify-between rounded-lg px-3 py-2 text-sm font-medium"
       :style="{ backgroundColor: bannerBg, color: bannerTextColor }"
     >
-      <span>{{ store.completionBanner.message }}</span>
+      <span>{{ bannerText }}</span>
       <button
         type="button"
         class="ml-3 flex size-6 shrink-0 cursor-pointer items-center justify-center rounded opacity-60 transition-opacity hover:opacity-100"
@@ -95,7 +113,7 @@ const bannerTextColor = computed(() => {
           </div>
           <div class="flex gap-4 text-xs text-[var(--ty-text-muted)]">
             <span
-              >总计
+              >{{ t("batchFlashAuth.dashboard.total") }}
               <strong class="text-[var(--ty-text)]">{{
                 store.cumulativeStats.flash.total
               }}</strong></span
@@ -140,7 +158,7 @@ const bannerTextColor = computed(() => {
           </div>
           <div class="flex gap-4 text-xs text-[var(--ty-text-muted)]">
             <span
-              >总计
+              >{{ t("batchFlashAuth.dashboard.total") }}
               <strong class="text-[var(--ty-text)]">{{
                 store.cumulativeStats.auth.total
               }}</strong></span

--- a/src/features/batch-flash-auth/components/BatchFlashAuthDonutChart.vue
+++ b/src/features/batch-flash-auth/components/BatchFlashAuthDonutChart.vue
@@ -1,6 +1,9 @@
 <!-- src/features/batch-flash/components/BatchDonutChart.vue -->
 <script setup lang="ts">
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
 
 const props = defineProps<{
   total: number;
@@ -84,7 +87,7 @@ const pct = computed(() =>
       font-size="11"
       fill="var(--ty-text-muted)"
     >
-      成功率
+      {{ t("batchFlashAuth.dashboard.successRate") }}
     </text>
   </svg>
 </template>

--- a/src/features/batch-flash-auth/components/BatchFlashAuthPortFilterModal.vue
+++ b/src/features/batch-flash-auth/components/BatchFlashAuthPortFilterModal.vue
@@ -1,7 +1,10 @@
 <!-- src/features/batch-flash/components/BatchPortFilterModal.vue -->
 <script setup lang="ts">
 import { ref } from "vue";
+import { useI18n } from "vue-i18n";
 import { useBatchFlashAuthStore } from "@/stores/batch-flash-auth";
+
+const { t } = useI18n();
 
 defineProps<{ open: boolean }>();
 defineEmits<{ close: [] }>();
@@ -29,12 +32,12 @@ function addPort() {
       >
         <div class="mb-4 flex items-center justify-between">
           <h2 class="text-base font-semibold text-[var(--ty-text)]">
-            串口过滤
+            {{ t("batchFlashAuth.filter.title") }}
           </h2>
           <button
             type="button"
             class="cursor-pointer text-xl text-[var(--ty-text-muted)] hover:text-[var(--ty-text)]"
-            aria-label="关闭"
+            :aria-label="t('common.closeDialog')"
             @click="$emit('close')"
           >
             ×
@@ -42,8 +45,7 @@ function addPort() {
         </div>
 
         <p class="mb-3 text-xs text-[var(--ty-text-muted)]">
-          添加要屏蔽的串口名称（精确匹配，Windows 不区分大小写）。
-          规则生效后，自动分配时将跳过这些串口。
+          {{ t("batchFlashAuth.filter.hint") }}
         </p>
 
         <!-- Add port input -->
@@ -51,7 +53,7 @@ function addPort() {
           <input
             v-model="newPort"
             type="text"
-            placeholder="如 COM1 或 /dev/ttyS0"
+            :placeholder="t('batchFlashAuth.filter.placeholder')"
             class="min-w-0 flex-1 rounded-lg border border-[var(--ty-border)] bg-[var(--ty-surface-muted)] px-2.5 py-1.5 text-sm text-[var(--ty-text)] placeholder:text-[var(--ty-text-muted)]"
             @keydown.enter="addPort"
           />
@@ -60,7 +62,7 @@ function addPort() {
             class="ty-btn-secondary px-3 text-sm"
             @click="addPort"
           >
-            添加
+            {{ t("batchFlashAuth.filter.add") }}
           </button>
         </div>
 
@@ -80,14 +82,16 @@ function addPort() {
             <button
               type="button"
               class="cursor-pointer text-sm text-[var(--ty-text-muted)] hover:text-[var(--ty-danger)]"
-              aria-label="移除"
+              :aria-label="t('batchFlashAuth.filter.remove')"
               @click="store.removeBlockedPort(port)"
             >
               ×
             </button>
           </div>
         </div>
-        <p v-else class="text-xs text-[var(--ty-text-muted)]">暂无过滤规则</p>
+        <p v-else class="text-xs text-[var(--ty-text-muted)]">
+          {{ t("batchFlashAuth.filter.empty") }}
+        </p>
       </div>
     </div>
   </Teleport>

--- a/src/features/batch-flash-auth/components/BatchFlashAuthToolbar.vue
+++ b/src/features/batch-flash-auth/components/BatchFlashAuthToolbar.vue
@@ -13,16 +13,27 @@ const filterOpen = ref(false);
 async function handleStart() {
   const idleCount = store.slots.filter((s) => s.status === "idle").length;
   if (idleCount > 8) {
-    const excelInfo = store.authConfig.excelPath
-      ? `\n授权表：${store.authConfig.excelPath}`
-      : "";
-    const firmwareInfo =
-      store.opMode === "flash-then-auth" && store.firmwarePath
-        ? `\n固件：${store.firmwarePath}`
-        : "";
+    const parts: string[] = [
+      t("batchFlashAuth.dialog.aboutToOperate", { count: idleCount }),
+    ];
+    if (store.opMode === "flash-then-auth" && store.firmwarePath) {
+      parts.push(
+        t("batchFlashAuth.dialog.firmwareLine", { path: store.firmwarePath }),
+      );
+    }
+    if (store.authConfig.excelPath) {
+      parts.push(
+        t("batchFlashAuth.dialog.excelLine", {
+          path: store.authConfig.excelPath,
+        }),
+      );
+    }
     const ok = await showConfirmDialog({
-      title: store.opMode === "auth-only" ? "确认批量授权" : "确认批量烧录",
-      message: `即将对 ${idleCount} 个端口并行操作${firmwareInfo}${excelInfo}`,
+      title:
+        store.opMode === "auth-only"
+          ? t("batchFlashAuth.dialog.confirmAuthOnly")
+          : t("batchFlashAuth.dialog.confirmFlashThenAuth"),
+      message: parts.join("\n"),
       kind: "warning",
     });
     if (!ok) return;
@@ -44,7 +55,9 @@ async function handleAutoAssign() {
         class="ty-btn-secondary flex items-center gap-1.5 text-sm"
         :disabled="store.isBusy"
         :title="
-          store.isBusy ? '任务进行中，不可自动分配' : '扫描并添加可用串口'
+          store.isBusy
+            ? t('batchFlashAuth.toolbar.autoAssignBusy')
+            : t('batchFlashAuth.toolbar.autoAssignHint')
         "
         @click="handleAutoAssign"
       >
@@ -85,7 +98,11 @@ async function handleAutoAssign() {
         type="button"
         class="ty-btn-secondary text-sm"
         :disabled="!store.canRetry"
-        :title="!store.canRetry ? '暂无失败端口' : undefined"
+        :title="
+          !store.canRetry
+            ? t('batchFlashAuth.toolbar.noFailedPorts')
+            : undefined
+        "
         @click="store.retryFailed()"
       >
         {{ t("batchFlashAuth.toolbar.retry") }}
@@ -97,9 +114,9 @@ async function handleAutoAssign() {
         :disabled="!store.canStart"
         :title="
           !store.authConfig.excelPath
-            ? '请先选择授权表'
+            ? t('batchFlashAuth.toolbar.selectExcelFirst')
             : !store.slots.some((s) => s.status === 'idle')
-              ? '暂无空闲串口'
+              ? t('batchFlashAuth.toolbar.noIdlePorts')
               : undefined
         "
         @click="handleStart"

--- a/src/features/batch-flash-auth/types.ts
+++ b/src/features/batch-flash-auth/types.ts
@@ -82,9 +82,10 @@ export interface ExcelStats {
   remaining: number;
 }
 
-export type CompletionBannerKind = "success" | "partial" | "all-failed";
-
-export interface CompletionBanner {
-  kind: CompletionBannerKind;
-  message: string;
-}
+/** Discriminated by `kind`; carries the counts the UI needs to render a
+ *  localized message (no preformatted string — translation happens in the view). */
+export type CompletionBanner =
+  | { kind: "all-skipped"; count: number }
+  | { kind: "all-success"; count: number }
+  | { kind: "all-failed" }
+  | { kind: "partial"; done: number; failed: number };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -513,7 +513,9 @@
       "success": "Success",
       "fail": "Failed",
       "reset": "Reset",
-      "elapsed": "Elapsed"
+      "elapsed": "Elapsed",
+      "total": "Total",
+      "successRate": "Success rate"
     },
     "config": {
       "chip": "Chip",
@@ -537,7 +539,12 @@
       "filter": "Port Filter",
       "start": "Start All",
       "cancel": "Cancel",
-      "retry": "Retry Failed"
+      "retry": "Retry Failed",
+      "autoAssignBusy": "Busy — auto-assign unavailable",
+      "autoAssignHint": "Scan and add available ports",
+      "noFailedPorts": "No failed ports",
+      "selectExcelFirst": "Select an auth table first",
+      "noIdlePorts": "No idle ports"
     },
     "slot": {
       "port": "Port",
@@ -560,6 +567,27 @@
       "done": "Done",
       "failed": "Failed",
       "skipped": "Skipped"
+    },
+    "filter": {
+      "title": "Port Filter",
+      "hint": "Add port names to block (exact match, case-insensitive on Windows). Auto-assign will skip these ports.",
+      "placeholder": "e.g. COM1 or /dev/ttyS0",
+      "add": "Add",
+      "empty": "No filter rules",
+      "remove": "Remove"
+    },
+    "dialog": {
+      "confirmAuthOnly": "Confirm Batch Authorization",
+      "confirmFlashThenAuth": "Confirm Batch Flash",
+      "aboutToOperate": "About to operate on {count} ports in parallel",
+      "firmwareLine": "Firmware: {path}",
+      "excelLine": "Auth table: {path}"
+    },
+    "completion": {
+      "allSkipped": "Batch complete: {count} skipped (already authorized)",
+      "allSuccess": "Batch complete: all {count} succeeded",
+      "allFailed": "Batch failed entirely — check connections and retry",
+      "partial": "Batch complete: {done} succeeded, {failed} failed — click Retry Failed"
     }
   },
   "toolbox": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -513,7 +513,9 @@
       "success": "成功",
       "fail": "失败",
       "reset": "重置",
-      "elapsed": "已用时"
+      "elapsed": "已用时",
+      "total": "总计",
+      "successRate": "成功率"
     },
     "config": {
       "chip": "芯片型号",
@@ -537,7 +539,12 @@
       "filter": "串口过滤",
       "start": "全部开始",
       "cancel": "取消",
-      "retry": "重试失败"
+      "retry": "重试失败",
+      "autoAssignBusy": "任务进行中，不可自动分配",
+      "autoAssignHint": "扫描并添加可用串口",
+      "noFailedPorts": "暂无失败端口",
+      "selectExcelFirst": "请先选择授权表",
+      "noIdlePorts": "暂无空闲串口"
     },
     "slot": {
       "port": "串口",
@@ -560,6 +567,27 @@
       "done": "成功",
       "failed": "失败",
       "skipped": "已跳过"
+    },
+    "filter": {
+      "title": "串口过滤",
+      "hint": "添加要屏蔽的串口名称（精确匹配，Windows 不区分大小写）。规则生效后，自动分配时将跳过这些串口。",
+      "placeholder": "如 COM1 或 /dev/ttyS0",
+      "add": "添加",
+      "empty": "暂无过滤规则",
+      "remove": "移除"
+    },
+    "dialog": {
+      "confirmAuthOnly": "确认批量授权",
+      "confirmFlashThenAuth": "确认批量烧录",
+      "aboutToOperate": "即将对 {count} 个端口并行操作",
+      "firmwareLine": "固件：{path}",
+      "excelLine": "授权表：{path}"
+    },
+    "completion": {
+      "allSkipped": "本次批次完成：{count} 台已跳过（设备已授权）",
+      "allSuccess": "本次批次完成：{count} 台全部成功",
+      "allFailed": "本次批次全部失败，请检查连接后重试",
+      "partial": "本次批次完成：{done} 成功，{failed} 失败，可点击「重试失败」"
     }
   },
   "toolbox": {

--- a/src/stores/batch-flash-auth.test.ts
+++ b/src/stores/batch-flash-auth.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { useBatchFlashAuthStore } from "./batch-flash-auth";
+import type { BatchSlotState } from "@/features/batch-flash-auth/types";
 
 vi.mock("@/runtime", () => ({
   isTauriRuntime: () => false,
@@ -228,7 +229,7 @@ describe("completionBanner", () => {
       port: "COM5",
       event: { kind: "done", result: { ok: { elapsed_secs: 5 } } },
     });
-    expect(store.completionBanner?.kind).toBe("success");
+    expect(store.completionBanner?.kind).toBe("all-success");
   });
 
   it("shows partial banner on mixed outcome", () => {
@@ -264,6 +265,55 @@ describe("resetFlashStats", () => {
       total: 0,
       success: 0,
       fail: 0,
+    });
+  });
+});
+
+const slot = (
+  port: string,
+  status: BatchSlotState["status"],
+): BatchSlotState => ({
+  port,
+  status,
+  progress: 0,
+  currentPhase: "",
+});
+
+describe("checkBatchCompletion banner", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  function runWith(slots: BatchSlotState[]) {
+    const store = useBatchFlashAuthStore();
+    store.slots = slots;
+    store.batchStartTime = 1; // non-null so checkBatchCompletion proceeds
+    store.currentBatchPorts = slots.map((s) => s.port);
+    store.checkBatchCompletion();
+    return store.completionBanner;
+  }
+
+  it("all-success when every device done", () => {
+    expect(runWith([slot("a", "done"), slot("b", "done")])).toEqual({
+      kind: "all-success",
+      count: 2,
+    });
+  });
+
+  it("all-failed when every device failed", () => {
+    expect(runWith([slot("a", "failed")])).toEqual({ kind: "all-failed" });
+  });
+
+  it("all-skipped when only skipped", () => {
+    expect(runWith([slot("a", "skipped"), slot("b", "skipped")])).toEqual({
+      kind: "all-skipped",
+      count: 2,
+    });
+  });
+
+  it("partial when mixed done and failed", () => {
+    expect(runWith([slot("a", "done"), slot("b", "failed")])).toEqual({
+      kind: "partial",
+      done: 1,
+      failed: 1,
     });
   });
 });

--- a/src/stores/batch-flash-auth.ts
+++ b/src/stores/batch-flash-auth.ts
@@ -150,7 +150,7 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
       updateSlot(port, {
         status: "reading_mac",
         progress: 0,
-        currentPhase: "读取MAC",
+        currentPhase: "reading_mac",
         error: undefined,
       });
     }
@@ -229,7 +229,7 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
     if (!findSlot(port)) return;
 
     if (step === "reading_mac") {
-      updateSlot(port, { status: "reading_mac", currentPhase: "读取MAC" });
+      updateSlot(port, { status: "reading_mac", currentPhase: "reading_mac" });
     } else if (
       step === "reading_auth" ||
       step === "writing_auth" ||
@@ -270,7 +270,7 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
         updateSlot(port, {
           status: "reading_mac",
           progress: 0,
-          currentPhase: "读取MAC",
+          currentPhase: "reading_mac",
         });
       }
       // err/cancelled: the subsequent auth 'failed'/'skipped' step handles final state.
@@ -296,26 +296,13 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
     const skipped = batchSlots.filter((s) => s.status === "skipped").length;
 
     if (done === 0 && failed === 0 && skipped > 0) {
-      // All devices were already authorized and skipped
-      completionBanner.value = {
-        kind: "partial",
-        message: `本次批次完成：${skipped} 台已跳过（设备已授权）`,
-      };
+      completionBanner.value = { kind: "all-skipped", count: skipped };
     } else if (failed === 0) {
-      completionBanner.value = {
-        kind: "success",
-        message: `本次批次完成：${done} 台全部成功`,
-      };
+      completionBanner.value = { kind: "all-success", count: done };
     } else if (done === 0) {
-      completionBanner.value = {
-        kind: "all-failed",
-        message: `本次批次全部失败，请检查连接后重试`,
-      };
+      completionBanner.value = { kind: "all-failed" };
     } else {
-      completionBanner.value = {
-        kind: "partial",
-        message: `本次批次完成：${done} 成功，${failed} 失败，可点击「重试失败」`,
-      };
+      completionBanner.value = { kind: "partial", done, failed };
     }
   }
 
@@ -442,5 +429,7 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
     // Internal (exposed for testing)
     handleFlashProgress,
     handleAuthProgress,
+    checkBatchCompletion,
+    currentBatchPorts,
   };
 });


### PR DESCRIPTION
## 目的

将 batch-flash-auth 工具中**除 `BatchFlashAuthConfig.vue` 外**的所有硬编码中文 i18n 化，支持多语言。（`BatchFlashAuthConfig.vue` 已在 #49 / `feature/auth-firmware-download` 分支处理。）

## 改动（4 个 commit）

- **Task 1** (`0cad508`): 在 `src/locales/{zh-CN,en}.json` 的 `batchFlashAuth` 下新增全部文案 key —— `filter.*`、`dialog.*`、`completion.*`、`toolbar.*`、`dashboard.{total,successRate}`，en/zh key 集合一致。
- **Task 2** (`3ee84fe`): `BatchFlashAuthPortFilterModal.vue` + `BatchFlashAuthDonutChart.vue` 纯文案 → `t()`。
- **Task 3** (`fb7c74e`): `BatchFlashAuthToolbar.vue` 确认对话框（`parts.join("\n")` 参数化拼接）+ 3 处 `title` 提示 → `t()`。
- **Task 4** (`e21b77b`): `CompletionBanner` 重构为判别式联合（`kind` 区分），store `checkBatchCompletion` 改为产出结构化计数（不再在 store 内拼接中文）；Dashboard 用 `bannerText` computed（穷尽 switch + 字面量 `t()`）渲染本地化文案，替换两处「总计」；清理 write-only 死字段 `currentPhase: "读取MAC"` → `"reading_mac"`。

## 设计要点

- 所有 `t()` 均用**字面量 key**（非动态模板字符串），确保被 i18n 守护测试 `src/i18n/index.test.ts` 覆盖。
- 本地化从 store 移至 view 层：store 只携带结构化数据，组件负责翻译。
- 纯 i18n + 死字段清理，**无功能/行为变更**（`currentPhase` 已确认全程只写不读）。

## 验证

- `pnpm run test`：**497 passed (36 files)**，含 i18n parity 守护。
- `pnpm run build`：类型检查通过（判别式联合穷尽 narrow）。
- 全分支 `rg` 复查：batch-flash-auth 源文件 0 残留硬编码中文。
- 逐任务 review + 全分支最终 review 均通过（Ready to merge）。
- `src/stores/batch-flash-auth.test.ts` 追加 4 个 banner 用例（直接调用 `checkBatchCompletion` 断言产出的联合类型），未改动原有测试。