### PR TITLE
refactor(firmware-flash): 移除手动连接/断开按钮,改为自动管理串口连接

### DIFF
--- a/src/features/firmware-flash/components/FirmwareFlashConnection.vue
+++ b/src/features/firmware-flash/components/FirmwareFlashConnection.vue
@@ -9,7 +9,7 @@ const ctx = useFirmwareFlashContext();
 
 // Only destructure actions (functions) — ref state must be accessed via ctx.xxx
 // to preserve Pinia reactive() wrapper (destructuring unwraps refs into snapshots).
-const { refreshDevice, connect, disconnect } = ctx;
+const { refreshDevice } = ctx;
 
 /** True when the authorize tab is active — baud rate then controls auth baud. */
 const isAuthTab = computed(() => ctx.activeTab === "authorize");
@@ -146,7 +146,7 @@ const chipValue = computed({
           id="serial-port"
           v-model="serialPortValue"
           :options="serialPortOptions"
-          :disabled="ctx.busy || ctx.connected"
+          :disabled="ctx.busy"
           class="w-auto min-w-[8.5rem] max-w-[16rem]"
           @open="refreshDevice"
         />
@@ -164,7 +164,7 @@ const chipValue = computed({
           id="baud-rate"
           v-model="baudSelectVal"
           :options="isAuthTab ? baudOptionsNoCustom : baudOptions"
-          :disabled="ctx.busy || ctx.connected"
+          :disabled="ctx.busy"
           class="w-[8rem] min-w-0"
         />
         <input
@@ -176,7 +176,7 @@ const chipValue = computed({
           max="4000000"
           step="1"
           class="conn-select w-[6.5rem] min-w-0 text-sm"
-          :disabled="ctx.busy || ctx.connected"
+          :disabled="ctx.busy"
         />
       </div>
 
@@ -192,41 +192,10 @@ const chipValue = computed({
           id="chip-select"
           v-model="chipValue"
           :options="chipOptions"
-          :disabled="ctx.busy || ctx.connected"
+          :disabled="ctx.busy"
           class="min-w-0 w-[9rem] max-w-[13rem]"
         />
       </div>
-    </div>
-
-    <!-- 操作按钮 -->
-    <div class="relative flex shrink-0 items-center gap-2">
-      <button
-        v-if="!ctx.connected"
-        type="button"
-        class="conn-btn-action flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all duration-150"
-        :disabled="!ctx.selectedSerialPort || ctx.busy"
-        @click="connect"
-      >
-        <FontAwesomeIcon
-          :icon="['fas', 'plug']"
-          class="size-3.5 shrink-0"
-          aria-hidden="true"
-        />
-        {{ t("flash.connect") }}
-      </button>
-      <button
-        v-else
-        type="button"
-        class="conn-btn-disconnect flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold transition-all duration-150"
-        @click="disconnect"
-      >
-        <FontAwesomeIcon
-          :icon="['fas', 'plug-circle-xmark']"
-          class="size-3.5 shrink-0"
-          aria-hidden="true"
-        />
-        {{ t("flash.disconnect") }}
-      </button>
     </div>
   </section>
 </template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -124,8 +124,6 @@
       "esp32c6": "Hard reset matches post-flash reset; interface type is auto-detected. Free the serial port first.",
       "esp32s3": "Some boards use a USB-JTAG/serial bridge; reset timing matches post-flash reset. Free the serial port first."
     },
-    "connect": "Connect",
-    "disconnect": "Disconnect",
     "deviceOps": "Device & operation",
     "deviceOpsHint": "Chip platform is selected above; fill only task-specific options here.",
     "tabsAria": "Firmware flash tasks",
@@ -353,7 +351,6 @@
       "portBusyKillHint": "Release command: {cmd} (verify this won't affect other running tasks)",
       "portCheckFailed": "Port check failed: {msg}",
       "autoConnecting": "Auto-connecting to {port}…",
-      "autoDisconnected": "Auto-disconnected.",
       "eraseCancelled": "Erase cancelled by user.",
       "readOverwriting": "Overwriting existing file: {path}",
       "readTimestamped": "Saving to timestamped file: {path}",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -124,8 +124,6 @@
       "esp32c6": "复位序列与烧录结束后的硬复位一致；接口类型由系统自动识别。请先释放串口占用。",
       "esp32s3": "部分开发板为 USB-JTAG/串口复合，复位时序与烧录结束后一致。请先释放串口占用。"
     },
-    "connect": "连接",
-    "disconnect": "断开",
     "deviceOps": "设备与操作",
     "deviceOpsHint": "芯片平台在上方连接区已选；此处仅填各子任务参数",
     "tabsAria": "固件烧录子项目",
@@ -353,7 +351,6 @@
       "portBusyKillHint": "释放命令：{cmd}（请确认不会影响其他正在运行的任务）",
       "portCheckFailed": "串口可用性检查失败：{msg}",
       "autoConnecting": "自动连接 {port}…",
-      "autoDisconnected": "已自动断开连接。",
       "eraseCancelled": "用户取消了擦除操作。",
       "readOverwriting": "覆盖已有文件：{path}",
       "readTimestamped": "保存至带时间戳的文件：{path}",

--- a/src/stores/flash.ts
+++ b/src/stores/flash.ts
@@ -566,6 +566,24 @@ export const useFlashStore = defineStore("flash", () => {
     );
   }
 
+  /**
+   * Release the serial port when an operation auto-connected (acquired the
+   * port) but then bailed out before the backend emitted a terminal event —
+   * e.g. the auth-overwrite confirm was cancelled, or `flash_run` threw before
+   * `Done`. On those paths `onOperationSettled` never runs. Idempotent (a
+   * mismatched/absent owner is a PortManager no-op); a no-op for a non-auto
+   * connection. There is no manual disconnect control, so this is what frees
+   * the port and re-enables the form selects on these exits.
+   */
+  function releaseIfAutoConnected(): void {
+    if (!autoConnected.value) {
+      return;
+    }
+    connected.value = false;
+    autoConnected.value = false;
+    usePortManagerStore().release(selectedSerialPort.value, "flash");
+  }
+
   async function startOperation(kind: OpKind): Promise<void> {
     if (flashPhase.value === "running") {
       return;
@@ -767,6 +785,7 @@ export const useFlashStore = defineStore("flash", () => {
             });
             if (!confirmed) {
               appendLog(t("flash.log.authOverwriteCancelled"));
+              releaseIfAutoConnected();
               flashPhase.value = "idle";
               runningOp.value = null;
               return;
@@ -837,6 +856,7 @@ export const useFlashStore = defineStore("flash", () => {
         flashMessage.value = msg;
         appendLog(t("flash.err.withMsg", { msg }));
         logOperationDuration();
+        releaseIfAutoConnected();
       }
     } else {
       try {
@@ -851,6 +871,7 @@ export const useFlashStore = defineStore("flash", () => {
         flashMessage.value = msg;
         appendLog(t("flash.err.withMsg", { msg }));
         logOperationDuration();
+        releaseIfAutoConnected();
       }
     }
   }


### PR DESCRIPTION
## 背景

固件烧录界面的"连接"/"断开"按钮是冗余的:操作开始时 \`startOperation\` 在未连接时会自动调用 \`connect()\`,操作结束(成功/失败/取消)时由 \`onOperationSettled\` 统一重置连接状态并通过 PortManager 释放串口。因此改为**完全自动管理串口连接**,去掉两个手动按钮。

## 改动内容

- **移除按钮**:删除连接区的"连接"/"断开"按钮及整个操作按钮块,清理未使用的 \`connect\`/\`disconnect\` 解构绑定。
- **串口释放兜底**:新增幂等 helper \`releaseIfAutoConnected()\`,在"自动连接成功但未到达 \`onOperationSettled\` 就早退/异常"的路径上释放串口——
  - 授权覆盖确认对话框被取消;
  - \`startOperationTauri\`/\`startOperationWs\` 在 \`Done\` 事件前抛错。

  此前这些路径依赖"断开"按钮恢复;去掉按钮后若不释放,会导致 \`connected\` 卡 true、串口被 PortManager 死锁且无 UI 可恢复。
- **简化禁用条件**:4 处下拉框的 \`:disabled="ctx.busy || ctx.connected"\` 简化为 \`:disabled="ctx.busy"\`(去掉手动连接后,\`connected\` 仅在操作 running 期间为 true,与 \`busy\` 等价)。
- **i18n 清理**:删除已无引用的 \`flash.connect\`、\`flash.disconnect\`,以及改动前就存在的 dead key \`flash.log.autoDisconnected\`(zh-CN / en 同步)。

## 验证

- \`vue-tsc --noEmit\` 类型检查通过
- ESLint 无问题
- vitest:i18n parity + flash 相关测试全部通过(92 项)
- 已经子 agent code review:逻辑正确、等价性成立、无悬挂引用、符合项目约定

## 测试建议(reviewer)

- 正常烧录/擦除/读取/授权:确认无需手动连接、结束后串口自动释放、下拉框恢复可用
- 授权 tab:对已有不同凭证的设备点授权 → 在覆盖确认框点取消 → 确认串口被释放、下拉框可用