### PR TITLE
refactor(secret-input): remove show/hide toggle, keep copy only

### DIFF
--- a/src/components/TySecretInput.vue
+++ b/src/components/TySecretInput.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { ref } from "vue";
 import { useI18n } from "vue-i18n";
 
 /**
  * Text input for sensitive credentials (device UUID, auth key, license, …).
  *
  * Differences from a plain <input>:
- *   - masked by default (the user can toggle visibility with an eye icon)
  *   - one-click copy button writes the value to the clipboard, swapping
  *     the icon to a checkmark for ~1.4s as confirmation
  *   - never auto-completed or remembered by the browser
@@ -26,14 +25,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
-const revealed = ref(false);
 const copied = ref(false);
 let copiedTimer: ReturnType<typeof setTimeout> | undefined;
-
-const inputType = computed(() => (revealed.value ? "text" : "password"));
-const toggleLabel = computed(() =>
-  revealed.value ? t("common.secretHide") : t("common.secretShow"),
-);
 
 function onInput(e: Event) {
   emit("update:modelValue", (e.target as HTMLInputElement).value);
@@ -59,12 +52,12 @@ async function copyValue() {
   <div class="relative flex items-stretch">
     <input
       :id="id"
-      :type="inputType"
+      type="text"
       :value="modelValue"
       :placeholder="placeholder"
       :disabled="disabled"
       :aria-describedby="ariaDescribedby"
-      class="ops-text-input min-w-0 flex-1 pr-[5rem] font-mono py-1.5"
+      class="ops-text-input min-w-0 flex-1 pr-9 font-mono py-1.5"
       spellcheck="false"
       autocomplete="off"
       autocapitalize="off"
@@ -75,23 +68,8 @@ async function copyValue() {
       @input="onInput"
     />
     <div
-      class="pointer-events-none absolute inset-y-0 right-1.5 flex items-center gap-0.5"
+      class="pointer-events-none absolute inset-y-0 right-1.5 flex items-center"
     >
-      <button
-        type="button"
-        class="pointer-events-auto flex size-7 items-center justify-center rounded-md text-[var(--ty-text-muted)] transition-colors hover:bg-[var(--ty-surface-muted)] hover:text-[var(--ty-text)] disabled:opacity-40"
-        :title="toggleLabel"
-        :aria-label="toggleLabel"
-        :aria-pressed="revealed"
-        :disabled="disabled"
-        @click="revealed = !revealed"
-      >
-        <FontAwesomeIcon
-          :icon="['fas', revealed ? 'eye-slash' : 'eye']"
-          class="size-3.5"
-          aria-hidden="true"
-        />
-      </button>
       <button
         type="button"
         class="pointer-events-auto flex size-7 items-center justify-center rounded-md transition-colors hover:bg-[var(--ty-surface-muted)] disabled:opacity-40"


### PR DESCRIPTION
## Summary

- 授权 tab 的 UUID / AuthKey 输入框移除显示/隐藏切换按钮，改为始终明文显示
- 保留一键复制功能（复制后图标短暂切换为 ✓ 确认）
- 输入框右侧 padding 从 `pr-[5rem]`（双按钮）缩减为 `pr-9`（单按钮）

## Test plan

- [ ] 打开固件工具 → 授权 tab，确认 UUID / AuthKey 输入框无眼睛图标
- [ ] 确认复制按钮正常工作，点击后图标变为 ✓
- [ ] 确认输入框内容始终可见（明文）