### PR TITLE
fix(esp): auto-detect chip instead of failing on mismatch

### DIFF
--- a/crates/tyutool-core/src/plugins/esp/common.rs
+++ b/crates/tyutool-core/src/plugins/esp/common.rs
@@ -188,18 +188,25 @@ pub(crate) fn run_esp(
     }
 
     let mut flasher = Flasher::connect(
-        conn,
-        true,           // use_stub — loads RAM stub for faster flash ops
-        false,          // verify — we do our own progress reporting
-        false,          // skip
-        Some(def.chip), // expected chip; mismatch → error
-        None,           // baud — will change after stub loads if needed
+        conn, true,  // use_stub — loads RAM stub for faster flash ops
+        false, // verify — we do our own progress reporting
+        false, // skip
+        None,  // auto-detect chip; firmware image header enforces compatibility
+        None,  // baud — will change after stub loads if needed
     )
     .map_err(esp_err)?;
 
-    // Log device information
+    // Log device information and warn if detected chip differs from requested
     match flasher.device_info() {
         Ok(info) => {
+            if info.chip != def.chip {
+                progress(FlashEvent::Warning {
+                    message: format!(
+                        "Requested chip ({}) differs from detected chip ({}); proceeding with detected chip",
+                        def.id, info.chip
+                    ),
+                });
+            }
             progress(FlashEvent::Milestone {
                 milestone: FlashMilestone::Connected {
                     chip_info: Some(format!("{} (revision {:?})", info.chip, info.revision)),


### PR DESCRIPTION
When the caller passes a chip ID that doesn't match the actual detected chip (e.g. tos.py passes -d esp32 but the device is esp32s3), the previous code failed immediately via espflash's strict chip validation.

Change Flasher::connect to pass None for the expected chip so espflash auto-detects the actual chip. If the detected chip differs from what was requested, emit a Warning event and proceed — the firmware image header still enforces binary compatibility at flash time.