### PR TITLE
refactor(authorize): chip timing table, firmware detection, batch-flash-auth, UI polish

### DIFF
--- a/crates/tyutool-core/src/authorize.rs
+++ b/crates/tyutool-core/src/authorize.rs
@@ -7,7 +7,7 @@
 //!
 //! `detect_firmware` opens the serial port, drains stale output, hardware-resets
 //! the device, and polls for firmware kind by repeatedly sending `sys_log_enable off`:
-//! - Response `OK: log disable` → new firmware (shell ready; logging disabled)
+//! - Response `OK: log disabled` → new firmware (shell ready; logging disabled)
 //! - Response contains "No command" or a `tuya>` prompt → old firmware (shell ready)
 //! - No recognizable response within `boot_max_wait` → old firmware (timeout fallback)
 //!
@@ -362,6 +362,7 @@ impl<T: AuthIo> AuthSession<T> {
                         }
                         raw_buf.extend_from_slice(&tmp[..read]);
                         last_data = Some(Instant::now());
+                        let mut got_prompt = false;
                         while let Some(pos) = raw_buf.iter().position(|&b| b == b'\n') {
                             let chunk: Vec<u8> = raw_buf.drain(..=pos).collect();
                             let s = String::from_utf8_lossy(&chunk)
@@ -369,8 +370,14 @@ impl<T: AuthIo> AuthSession<T> {
                                 .to_string();
                             let s = strip_ansi(&s).trim().to_string();
                             if !s.is_empty() {
+                                if is_shell_prompt(&s) {
+                                    got_prompt = true;
+                                }
                                 lines.push(s);
                             }
+                        }
+                        if got_prompt {
+                            break;
                         }
                     }
                 }
@@ -461,7 +468,7 @@ impl<T: AuthIo> AuthSession<T> {
     ///
     /// Polls by repeatedly sending `sys_log_enable off` starting at
     /// `timing.boot_probe_start` after reset, every `timing.boot_probe_interval`:
-    /// - `OK: log disable` in response → new firmware; returns immediately.
+    /// - `OK: log disabled` in response → new firmware; returns immediately.
     /// - "No command" or `tuya>` in response → old firmware; returns immediately.
     /// - No recognizable response by `timing.boot_max_wait` → old firmware fallback.
     fn detect_firmware(&mut self, cancel: &AtomicBool) -> Result<FirmwareKind, FlashError> {
@@ -497,7 +504,7 @@ impl<T: AuthIo> AuthSession<T> {
 
             let is_new = lines
                 .iter()
-                .any(|l| l.to_lowercase().contains("ok: log disable"));
+                .any(|l| l.to_lowercase().contains("ok: log disabled"));
             let is_old = !is_new
                 && lines.iter().any(|l| {
                     let lower = l.to_lowercase();
@@ -1455,7 +1462,7 @@ mod tests {
     fn detect_firmware_new_returns_new_kind() {
         let mut io = MockAuthIo::new();
         // Response 0: sys_log_enable off → OK
-        io.add_response("OK: log disable\r\n");
+        io.add_response("OK: log disabled\r\n");
         // Response 1: wake_shell clear_input → empty
         io.add_response("");
         // Response 2: version command
@@ -1524,7 +1531,7 @@ mod tests {
         use crate::job::FlashMode;
         let mut io = MockAuthIo::new();
         // detect_firmware: sys_log_enable off → OK, wake_shell, version
-        io.add_response("OK: log disable\r\n"); // sys_log_enable off
+        io.add_response("OK: log disabled\r\n"); // sys_log_enable off
         io.add_response(""); // wake_shell clear_input
         io.add_response("CLI version: 1.0.0\r\n"); // version
                                                    // auth_read (check existing) → None (device fresh)
@@ -1599,7 +1606,7 @@ mod tests {
     #[test]
     fn run_authorize_new_firmware_conflict_cancelled() {
         let mut io = MockAuthIo::new();
-        io.add_response("OK: log disable\r\n");
+        io.add_response("OK: log disabled\r\n");
         io.add_response("");
         io.add_response("CLI version: 1.0.0\r\n");
         // auth_read → existing different credentials

--- a/crates/tyutool-core/src/authorize.rs
+++ b/crates/tyutool-core/src/authorize.rs
@@ -82,8 +82,11 @@ struct AuthTiming {
 // To add a chip: append one row; record the measurement date in the comment.
 //
 // columns:  chips                              start  int   max   idle settle drain_q
+// columns: chips, start, interval, max_wait, idle, settle, drain_quiet (all ms)
+type ChipTimingRow = (&'static [&'static str], u64, u64, u64, u64, u64, u64);
+
 #[rustfmt::skip]
-const CHIP_TIMING: &[(&[&str], u64, u64, u64, u64, u64, u64)] = &[
+const CHIP_TIMING: &[ChipTimingRow] = &[
     (&["T5AI", "T5"],                              600,  50,  2100,  50,  3000,   800), // ready ~703ms,  RTT ~11ms
     (&["ESP32", "ESP32C3", "ESP32C6", "ESP32S3"], 1000,  50,  3500, 120,  3000,   400), // ready ~1108ms, RTT 20–40ms (2026-06-25)
 ];
@@ -93,7 +96,7 @@ impl AuthTiming {
     fn for_chip(chip_id: &str) -> Self {
         let id = chip_id.to_ascii_uppercase();
         for &(chips, start, interval, max_wait, idle, settle, drain_q) in CHIP_TIMING {
-            if chips.iter().any(|&c| c == id.as_str()) {
+            if chips.contains(&id.as_str()) {
                 return Self {
                     boot_probe_start: Duration::from_millis(start),
                     boot_probe_interval: Duration::from_millis(interval),


### PR DESCRIPTION
## Summary

This branch consolidates several months of authorize-flow work, UI improvements, and the new batch-flash-auth toolbox feature.

### Authorization flow

- Detect firmware generation (new vs. old) via `sys_log_enable` + version string, and branch `run_authorize` accordingly
- Add `AuthConflict` milestone + `confirm_override` so the frontend can prompt before overwriting existing credentials
- Remove `probe_device` call; instead validate on first write
- Extend init wait to 1 000 ms for reliable new-firmware detection
- Emit `AuthWriteSkipped` when credentials are already present and override is declined

### Per-chip auth timing

- Replace per-chip `match` arms with a `CHIP_TIMING` lookup table (`adea6be`)
- Tune ESP32 timings from measurements: `drain_quiet` 400 ms, `cmd_idle` 120 ms (`6ce7af8`)
- Exit the read loop immediately on the `tuya>` prompt (`0923bf6`)
- Inject `AuthTiming` into `AuthSession` per chip (replaces hard-coded constants)

### `--device` flag & chip aliases

- Add `--device` flag to `authorize` subcommand
- Case-insensitive chip matching for all chips
- Rename `T5 → T5AI` everywhere; accept legacy `t5` alias

### Batch flash-auth toolbox

- Auth-firmware release pipeline + manifest module
- Default firmware source UI with store persistence
- Port filter modal, toolbar, start-confirm dialog, dashboard totals, donut chart (i18n)
- Single "copy all" button for credentials; T5AI added to batch flow

### UI polish

- `TyConnectionBar` shell + extract `useSerialAutoSave`
- Inline hex-address validation on flash / erase / read tabs
- Sidebar quick toggles + masked credential inputs (Bitwarden-ignore)
- Extract `FlashSegmentTable`; drop JS `matchMedia` branch
- Visual theme picker + collapsible batch controls
- Fix text selection, i18n window title, CSS token polish

### Other fixes

- Move blocking serial-port ops off GTK main thread (IPC deadlock)
- Exclude auto-generated build artifacts from ESLint
- Remove show/hide toggle from secret inputs (copy-only)
- Register missing Font Awesome icons
- Add `.vite/` to `.gitignore`

## Test plan

- [ ] Rust: `cargo test -p tyutool-core -p tyutool-cli` — 214 passed
- [ ] Frontend: `pnpm run test` — 530 passed
- [ ] Manual: authorize flow on new-firmware and old-firmware devices
- [ ] Manual: `--device` flag with lowercase / alias input
- [ ] Manual: batch-flash-auth default firmware source + completion dashboard