### PR TITLE
feat(logging): per-session log files with count and size limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5897,6 +5897,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tar",
+ "tempfile",
  "tokio",
  "tokio-tungstenite",
  "tyutool-core",
@@ -5922,6 +5923,7 @@ name = "tyutool_gui"
 version = "3.0.14"
 dependencies = [
  "calamine",
+ "chrono",
  "log",
  "reqwest 0.12.28",
  "rust_xlsxwriter",

--- a/crates/tyutool-cli/Cargo.toml
+++ b/crates/tyutool-cli/Cargo.toml
@@ -34,3 +34,6 @@ base64 = "0.22"
 anyhow = "1"
 indicatif = "0.17"
 console = "0.15"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/tyutool-cli/src/main.rs
+++ b/crates/tyutool-cli/src/main.rs
@@ -253,41 +253,44 @@ fn parse_hex_addr(s: &str) -> Result<u64, Box<dyn std::error::Error>> {
     u64::from_str_radix(raw, 16).map_err(|e| format!("invalid hex address '{}': {}", s, e).into())
 }
 
-const LOG_MAX_BYTES: u64 = 5 * 1024 * 1024; // 5 MB, matches the GUI cap
-const LOG_KEEP: usize = 3;
+const MAX_LOG_FILES: usize = 100;
+const MAX_LOG_BYTES_TOTAL: u64 = 100 * 1024 * 1024; // 100 MB
 
-/// `tyutool.log` -> `tyutool.log.1`, `.1` -> `.2`, ... up to `keep`.
-fn with_ext_num(log_path: &std::path::Path, n: usize) -> std::path::PathBuf {
-    let mut s = log_path.as_os_str().to_os_string();
-    s.push(format!(".{n}"));
-    std::path::PathBuf::from(s)
-}
+/// Delete the oldest per-session log files until the collection is within both
+/// the file-count and total-size limits. Only manages files whose stem starts
+/// with "tyutool-"; always retains at least one file.
+fn prune_log_files(log_dir: &std::path::Path) {
+    let mut files: Vec<(std::path::PathBuf, u64)> = match std::fs::read_dir(log_dir) {
+        Ok(rd) => rd
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                p.extension().map(|x| x == "log").unwrap_or(false)
+                    && p.file_stem()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s.starts_with("tyutool-"))
+                        .unwrap_or(false)
+            })
+            .filter_map(|p| {
+                let size = std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0);
+                Some((p, size))
+            })
+            .collect(),
+        Err(_) => return,
+    };
 
-/// Ordered (from, to) renames to rotate `log_path`, oldest shifted out last.
-fn rotation_plan(
-    log_path: &std::path::Path,
-    keep: usize,
-) -> Vec<(std::path::PathBuf, std::path::PathBuf)> {
-    let mut moves = Vec::new();
-    for i in (1..keep).rev() {
-        moves.push((with_ext_num(log_path, i), with_ext_num(log_path, i + 1)));
-    }
-    moves.push((log_path.to_path_buf(), with_ext_num(log_path, 1)));
-    moves
-}
+    files.sort_by(|a, b| a.0.file_name().cmp(&b.0.file_name()));
 
-/// Rotate the log if it exceeds `LOG_MAX_BYTES`. Best-effort: rotation failures
-/// are ignored so logging still proceeds.
-fn rotate_if_needed(log_path: &std::path::Path) {
-    let too_big = std::fs::metadata(log_path)
-        .map(|m| m.len() > LOG_MAX_BYTES)
-        .unwrap_or(false);
-    if !too_big {
-        return;
-    }
-    let _ = std::fs::remove_file(with_ext_num(log_path, LOG_KEEP));
-    for (from, to) in rotation_plan(log_path, LOG_KEEP) {
-        let _ = std::fs::rename(&from, &to);
+    let mut count = files.len();
+    let mut total: u64 = files.iter().map(|(_, s)| s).sum();
+
+    for (path, size) in &files {
+        if count <= 1 || (count <= MAX_LOG_FILES && total <= MAX_LOG_BYTES_TOTAL) {
+            break;
+        }
+        let _ = std::fs::remove_file(path);
+        count -= 1;
+        total = total.saturating_sub(*size);
     }
 }
 
@@ -296,9 +299,8 @@ fn init_logging(verbose: bool) -> Result<std::path::PathBuf, Box<dyn std::error:
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join("tyutool");
     std::fs::create_dir_all(&log_dir)?;
-    let log_path = log_dir.join("tyutool.log");
-
-    rotate_if_needed(&log_path);
+    let stem = chrono::Local::now().format("%Y%m%d-%H%M%S");
+    let log_path = log_dir.join(format!("tyutool-{stem}.log"));
 
     let fmt = |out: fern::FormatCallback<'_>,
                message: &std::fmt::Arguments<'_>,
@@ -334,6 +336,7 @@ fn init_logging(verbose: bool) -> Result<std::path::PathBuf, Box<dyn std::error:
     }
 
     dispatch.apply()?;
+    prune_log_files(&log_dir);
     Ok(log_path)
 }
 
@@ -741,66 +744,77 @@ mod tests {
 }
 
 #[cfg(test)]
-mod rotation_tests {
+mod prune_tests {
     use super::*;
-    use std::path::Path;
 
-    #[test]
-    fn with_ext_num_appends_numeric_suffix() {
-        let base = Path::new("/var/log/tyutool.log");
-        assert_eq!(
-            with_ext_num(base, 1).display().to_string(),
-            "/var/log/tyutool.log.1"
-        );
-        assert_eq!(
-            with_ext_num(base, 3).display().to_string(),
-            "/var/log/tyutool.log.3"
-        );
+    fn touch(dir: &std::path::Path, name: &str, size: u64) {
+        let path = dir.join(name);
+        let f = std::fs::File::create(&path).unwrap();
+        f.set_len(size).unwrap();
+    }
+
+    fn names(dir: &std::path::Path) -> Vec<String> {
+        let mut v: Vec<String> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        v.sort();
+        v
     }
 
     #[test]
-    fn rotation_plan_keep_1_only_moves_base() {
-        let base = Path::new("/tmp/tyutool.log");
-        let moves: Vec<(String, String)> = rotation_plan(base, 1)
-            .iter()
-            .map(|(a, b): &(std::path::PathBuf, std::path::PathBuf)| {
-                (a.display().to_string(), b.display().to_string())
-            })
-            .collect();
-        assert_eq!(
-            moves,
-            vec![(
-                "/tmp/tyutool.log".to_string(),
-                "/tmp/tyutool.log.1".to_string()
-            )]
-        );
+    fn prune_removes_oldest_when_over_count_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 1..=(MAX_LOG_FILES + 2) {
+            touch(dir.path(), &format!("tyutool-20240101-{i:06}.log"), 1024);
+        }
+        prune_log_files(dir.path());
+        assert_eq!(names(dir.path()).len(), MAX_LOG_FILES);
+        // The oldest two should be gone.
+        assert!(!dir.path().join("tyutool-20240101-000001.log").exists());
+        assert!(!dir.path().join("tyutool-20240101-000002.log").exists());
     }
 
     #[test]
-    fn rotation_plan_keep_3_shifts_oldest_last() {
-        let base = Path::new("/tmp/tyutool.log");
-        let moves: Vec<(String, String)> = rotation_plan(base, 3)
+    fn prune_removes_oldest_when_over_size_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        // 5 files each 15 MB → total 75 MB > 50 MB limit
+        for i in 1..=5 {
+            touch(
+                dir.path(),
+                &format!("tyutool-20240101-{i:06}.log"),
+                15 * 1024 * 1024,
+            );
+        }
+        prune_log_files(dir.path());
+        let remaining = names(dir.path());
+        let total: u64 = remaining
             .iter()
-            .map(|(a, b): &(std::path::PathBuf, std::path::PathBuf)| {
-                (a.display().to_string(), b.display().to_string())
-            })
-            .collect();
-        assert_eq!(
-            moves,
-            vec![
-                (
-                    "/tmp/tyutool.log.2".to_string(),
-                    "/tmp/tyutool.log.3".to_string()
-                ),
-                (
-                    "/tmp/tyutool.log.1".to_string(),
-                    "/tmp/tyutool.log.2".to_string()
-                ),
-                (
-                    "/tmp/tyutool.log".to_string(),
-                    "/tmp/tyutool.log.1".to_string()
-                ),
-            ]
+            .map(|n| std::fs::metadata(dir.path().join(n)).unwrap().len())
+            .sum();
+        assert!(total <= MAX_LOG_BYTES_TOTAL);
+    }
+
+    #[test]
+    fn prune_always_keeps_at_least_one_file() {
+        let dir = tempfile::tempdir().unwrap();
+        // One enormous file that exceeds both limits by itself.
+        touch(
+            dir.path(),
+            "tyutool-20240101-000001.log",
+            MAX_LOG_BYTES_TOTAL + 1,
         );
+        prune_log_files(dir.path());
+        assert_eq!(names(dir.path()).len(), 1);
+    }
+
+    #[test]
+    fn prune_ignores_legacy_tyutool_log() {
+        let dir = tempfile::tempdir().unwrap();
+        // Legacy file should not be touched.
+        touch(dir.path(), "tyutool.log", 1024);
+        prune_log_files(dir.path());
+        assert!(dir.path().join("tyutool.log").exists());
     }
 }

--- a/crates/tyutool-cli/src/main.rs
+++ b/crates/tyutool-cli/src/main.rs
@@ -271,9 +271,9 @@ fn prune_log_files(log_dir: &std::path::Path) {
                         .map(|s| s.starts_with("tyutool-"))
                         .unwrap_or(false)
             })
-            .filter_map(|p| {
+            .map(|p| {
                 let size = std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0);
-                Some((p, size))
+                (p, size)
             })
             .collect(),
         Err(_) => return,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ calamine = { version = "0.26", features = ["dates"] }
 rust_xlsxwriter = "0.79"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 sha2 = "0.10"
+chrono = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1465,6 +1465,54 @@ fn collect_log_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
         .collect()
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LogFileInfo {
+    name: String,
+    size_bytes: u64,
+    modified_ms: i64,
+}
+
+fn list_log_files_impl(dir: &std::path::Path) -> Vec<LogFileInfo> {
+    let mut files: Vec<LogFileInfo> = std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension().map(|x| x == "log").unwrap_or(false)
+                && p.file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.starts_with("tyutool"))
+                    .unwrap_or(false)
+        })
+        .filter_map(|p| {
+            let meta = std::fs::metadata(&p).ok()?;
+            let name = p.file_name()?.to_str()?.to_owned();
+            let size_bytes = meta.len();
+            let modified_ms = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0);
+            Some(LogFileInfo {
+                name,
+                size_bytes,
+                modified_ms,
+            })
+        })
+        .collect();
+    files.sort_by(|a, b| b.modified_ms.cmp(&a.modified_ms));
+    files
+}
+
+#[tauri::command]
+fn list_log_files(app: AppHandle) -> Result<Vec<LogFileInfo>, String> {
+    let dir = app.path().app_log_dir().map_err(|e| e.to_string())?;
+    Ok(list_log_files_impl(&dir))
+}
+
 fn build_report_info(name: &str, version: &str, install: &str, session_id: &str) -> String {
     format!(
         "tyutool report-info\nname: {name}\nversion: {version}\nos: {}\narch: {}\nfamily: {}\ninstall: {install}\nsession: {session_id}\n",
@@ -1755,6 +1803,7 @@ pub fn run() {
             serial_debug_state,
             write_text_file,
             append_text_file,
+            list_log_files,
             read_log_tail,
             export_logs_zip,
             open_external_url,
@@ -2026,6 +2075,36 @@ mod log_tools_tests {
         assert!(names.contains(&"report-info.txt".to_string()));
         assert!(names.contains(&"tyutool.log".to_string()));
         assert!(!names.contains(&"notes.txt".to_string()));
+    }
+
+    #[test]
+    fn list_log_files_impl_returns_tyutool_logs_sorted_newest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create two tyutool-* logs with different sizes (mtime may be identical in fast tests)
+        std::fs::write(dir.path().join("tyutool-20250101-100000.log"), b"old").unwrap();
+        std::fs::write(dir.path().join("tyutool-20250629-120000.log"), b"new").unwrap();
+        // Non-matching file must be excluded
+        std::fs::write(dir.path().join("other.log"), b"x").unwrap();
+
+        let files = list_log_files_impl(dir.path());
+        // Must include only tyutool*.log files
+        assert!(files.iter().all(|f| f.name.starts_with("tyutool")));
+        assert!(!files.iter().any(|f| f.name == "other.log"));
+        assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn list_log_files_impl_returns_empty_for_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(list_log_files_impl(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn list_log_files_impl_size_bytes_matches_file_size() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("tyutool.log"), b"hello").unwrap();
+        let files = list_log_files_impl(dir.path());
+        assert_eq!(files[0].size_bytes, 5);
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1970,6 +1970,8 @@ mod log_tools_tests {
     fn pick_active_log_prefers_exact_name() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("tyutool_2026-06-18_10-00-00.log"), b"old").unwrap();
+        // Sleep to ensure tyutool.log has a strictly newer mtime on all platforms.
+        std::thread::sleep(std::time::Duration::from_millis(10));
         std::fs::write(dir.path().join("tyutool.log"), b"current").unwrap();
         let picked = pick_active_log(dir.path()).unwrap();
         assert_eq!(picked.file_name().unwrap(), "tyutool.log");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1524,7 +1524,11 @@ fn list_log_files_impl(dir: &std::path::Path) -> Vec<LogFileInfo> {
             })
         })
         .collect();
-    files.sort_by(|a, b| b.modified_ms.cmp(&a.modified_ms));
+    files.sort_by(|a, b| {
+        b.modified_ms
+            .cmp(&a.modified_ms)
+            .then_with(|| b.name.cmp(&a.name))
+    });
     files
 }
 
@@ -2112,6 +2116,8 @@ mod log_tools_tests {
         assert!(files.iter().all(|f| f.name.starts_with("tyutool")));
         assert!(!files.iter().any(|f| f.name == "other.log"));
         assert_eq!(files.len(), 2);
+        // Newest-first: secondary sort by name descending when mtime is equal
+        assert_eq!(files[0].name, "tyutool-20250629-120000.log");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use serde::Deserialize;
 use tauri::{AppHandle, Emitter, LogicalSize, Manager, PhysicalPosition, RunEvent, State};
-use tauri_plugin_log::{RotationStrategy, Target, TargetKind, TimezoneStrategy};
+use tauri_plugin_log::{Target, TargetKind, TimezoneStrategy};
 use tyutool_core::{DebugChunk, DebugConfig, SerialDebugSession};
 
 /// Set once at startup; included in exported issue-report metadata.
@@ -1377,12 +1377,50 @@ fn append_text_file(path: String, content: String) -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
-/// Prefer the active log file by exact name; fall back to newest `*.log` by mtime.
-fn pick_active_log(dir: &std::path::Path) -> Option<std::path::PathBuf> {
-    let active = dir.join("tyutool.log");
-    if active.is_file() {
-        return Some(active);
+const MAX_LOG_FILES: usize = 100;
+const MAX_LOG_BYTES_TOTAL: u64 = 100 * 1024 * 1024; // 100 MB
+
+/// Delete the oldest per-session log files until the collection is within both
+/// the file-count and total-size limits. Only manages files whose stem starts
+/// with "tyutool-" (per-session naming); legacy "tyutool.log" is left untouched.
+/// Always retains at least one file.
+fn prune_log_files(log_dir: &std::path::Path) {
+    let mut files: Vec<(std::path::PathBuf, u64)> = std::fs::read_dir(log_dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension().map(|x| x == "log").unwrap_or(false)
+                && p.file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.starts_with("tyutool-"))
+                    .unwrap_or(false)
+        })
+        .filter_map(|p| {
+            let size = std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0);
+            Some((p, size))
+        })
+        .collect();
+
+    // Timestamped filenames are lexicographically chronological.
+    files.sort_by(|a, b| a.0.file_name().cmp(&b.0.file_name()));
+
+    let mut count = files.len();
+    let mut total: u64 = files.iter().map(|(_, s)| s).sum();
+
+    for (path, size) in &files {
+        if count <= 1 || (count <= MAX_LOG_FILES && total <= MAX_LOG_BYTES_TOTAL) {
+            break;
+        }
+        let _ = std::fs::remove_file(path);
+        count -= 1;
+        total = total.saturating_sub(*size);
     }
+}
+
+/// Return the most recently modified `*.log` file in `dir`.
+fn pick_active_log(dir: &std::path::Path) -> Option<std::path::PathBuf> {
     std::fs::read_dir(dir)
         .ok()?
         .filter_map(|e| e.ok())
@@ -1638,15 +1676,16 @@ fn open_external_url_linux(url: &str) -> Result<(), String> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let session_log_name = format!("tyutool-{}", chrono::Local::now().format("%Y%m%d-%H%M%S"));
     tauri::Builder::default()
         .plugin(
             tauri_plugin_log::Builder::new()
                 .targets([
-                    Target::new(TargetKind::LogDir { file_name: None }),
+                    Target::new(TargetKind::LogDir {
+                        file_name: Some(session_log_name),
+                    }),
                     Target::new(TargetKind::Stdout),
                 ])
-                .rotation_strategy(RotationStrategy::KeepAll)
-                .max_file_size(5 * 1024 * 1024) // 5MB
                 .timezone_strategy(TimezoneStrategy::UseLocal)
                 .level(log::LevelFilter::Info)
                 .build(),
@@ -1683,6 +1722,9 @@ pub fn run() {
                 Some(&install_type),
             );
             let _ = SESSION_ID.set(session_id);
+            if let Ok(log_dir) = app.path().app_log_dir() {
+                prune_log_files(&log_dir);
+            }
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1449,10 +1449,31 @@ fn read_log_tail_impl(dir: &std::path::Path, max_bytes: u64) -> std::io::Result<
     tail_bytes(&path, max_bytes)
 }
 
+fn read_named_log_impl(
+    dir: &std::path::Path,
+    filename: &str,
+    max_bytes: u64,
+) -> std::io::Result<String> {
+    if filename.contains('/') || filename.contains('\\') {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "filename must not contain path separators",
+        ));
+    }
+    tail_bytes(&dir.join(filename), max_bytes)
+}
+
 #[tauri::command]
-fn read_log_tail(app: AppHandle, max_bytes: usize) -> Result<String, String> {
+fn read_log_tail(
+    app: AppHandle,
+    max_bytes: usize,
+    filename: Option<String>,
+) -> Result<String, String> {
     let dir = app.path().app_log_dir().map_err(|e| e.to_string())?;
-    read_log_tail_impl(&dir, max_bytes as u64).map_err(|e| e.to_string())
+    match filename {
+        None => read_log_tail_impl(&dir, max_bytes as u64).map_err(|e| e.to_string()),
+        Some(name) => read_named_log_impl(&dir, &name, max_bytes as u64).map_err(|e| e.to_string()),
+    }
 }
 
 fn collect_log_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
@@ -2105,6 +2126,36 @@ mod log_tools_tests {
         std::fs::write(dir.path().join("tyutool.log"), b"hello").unwrap();
         let files = list_log_files_impl(dir.path());
         assert_eq!(files[0].size_bytes, 5);
+    }
+
+    #[test]
+    fn read_named_log_impl_reads_specified_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("tyutool-old.log"), b"old content").unwrap();
+        std::fs::write(dir.path().join("tyutool-new.log"), b"new content").unwrap();
+        let result = read_named_log_impl(dir.path(), "tyutool-old.log", 1000).unwrap();
+        assert_eq!(result, "old content");
+    }
+
+    #[test]
+    fn read_named_log_impl_rejects_path_traversal_forward_slash() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = read_named_log_impl(dir.path(), "../secret.log", 100).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn read_named_log_impl_rejects_path_traversal_backslash() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = read_named_log_impl(dir.path(), "..\\secret.log", 100).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn read_named_log_impl_errors_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = read_named_log_impl(dir.path(), "tyutool-ghost.log", 100).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     }
 }
 

--- a/src/features/settings/LogViewerDialog.vue
+++ b/src/features/settings/LogViewerDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref, watch, computed, nextTick } from "vue";
 import { useI18n } from "vue-i18n";
 import { isTauriRuntime } from "@/runtime";
 import { exportLogsAndReport } from "./report-issue";
@@ -8,33 +8,189 @@ const props = defineProps<{ open: boolean }>();
 const emit = defineEmits<{ close: [] }>();
 
 const { t } = useI18n();
-const content = ref("");
-const loading = ref(false);
-const copied = ref(false);
 
-const MAX_TAIL_BYTES = 256 * 1024;
+// ── Types ─────────────────────────────────────────────────────────────────────
 
-async function load(): Promise<void> {
+// Mirrors src-tauri/src/lib.rs LogFileInfo
+interface LogFileInfo {
+  name: string;
+  sizeBytes: number;
+  modifiedMs: number;
+}
+
+type LogLevel = "error" | "warn" | "info" | "debug" | "trace" | "default";
+
+// ── View state ─────────────────────────────────────────────────────────────────
+
+const view = ref<"list" | "content">("list");
+
+// ── File list state ────────────────────────────────────────────────────────────
+
+const fileList = ref<LogFileInfo[]>([]);
+const listLoading = ref(false);
+const listError = ref("");
+
+async function loadFileList(): Promise<void> {
   if (!isTauriRuntime()) {
-    content.value = "";
+    fileList.value = [];
     return;
   }
-  loading.value = true;
+  listLoading.value = true;
+  listError.value = "";
   try {
     const { invoke } = await import("@tauri-apps/api/core");
-    content.value = await invoke<string>("read_log_tail", {
-      maxBytes: MAX_TAIL_BYTES,
-    });
+    fileList.value = await invoke<LogFileInfo[]>("list_log_files");
   } catch (e) {
-    content.value = String(e);
+    listError.value = String(e);
   } finally {
-    loading.value = false;
+    listLoading.value = false;
   }
 }
 
+// ── Content state ──────────────────────────────────────────────────────────────
+
+const MAX_TAIL_BYTES = 256 * 1024;
+
+const selectedFile = ref<LogFileInfo | null>(null);
+const rawContent = ref("");
+const contentLoading = ref(false);
+const contentError = ref("");
+const isTruncated = ref(false);
+const contentEl = ref<HTMLElement | null>(null);
+
+async function openFile(file: LogFileInfo): Promise<void> {
+  if (!isTauriRuntime()) return;
+  selectedFile.value = file;
+  searchQuery.value = "";
+  currentMatchIndex.value = 0;
+  rawContent.value = "";
+  contentError.value = "";
+  isTruncated.value = false;
+  contentLoading.value = true;
+  view.value = "content";
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    rawContent.value = await invoke<string>("read_log_tail", {
+      maxBytes: MAX_TAIL_BYTES,
+      filename: file.name,
+    });
+    isTruncated.value = file.sizeBytes > MAX_TAIL_BYTES;
+  } catch (e) {
+    contentError.value = String(e);
+  } finally {
+    contentLoading.value = false;
+    await nextTick();
+    scrollToBottom();
+  }
+}
+
+function backToList(): void {
+  view.value = "list";
+  searchQuery.value = "";
+}
+
+function scrollToBottom(): void {
+  if (contentEl.value) {
+    contentEl.value.scrollTop = contentEl.value.scrollHeight;
+  }
+}
+
+// ── Search state ───────────────────────────────────────────────────────────────
+
+const searchQuery = ref("");
+const currentMatchIndex = ref(0);
+
+// ── Log line processing ────────────────────────────────────────────────────────
+
+const LEVEL_RE = /\b(ERROR|WARN|INFO|DEBUG|TRACE)\b/;
+
+function getLineLevel(line: string): LogLevel {
+  const m = LEVEL_RE.exec(line);
+  if (!m) return "default";
+  return m[1].toLowerCase() as LogLevel;
+}
+
+const LEVEL_CLASS: Record<LogLevel, string> = {
+  error: "text-red-400",
+  warn: "text-yellow-400",
+  info: "text-green-200",
+  debug: "text-gray-500",
+  trace: "text-gray-600",
+  default: "text-green-200",
+};
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function highlightMatch(raw: string, query: string): string {
+  const escaped = escapeHtml(raw);
+  if (!query) return escaped;
+  const re = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "gi");
+  return escaped.replace(
+    re,
+    (m) => `<mark class="bg-yellow-300 text-black rounded-sm">${m}</mark>`,
+  );
+}
+
+interface DisplayLine {
+  level: LogLevel;
+  html: string;
+  originalIndex: number;
+}
+
+const displayLines = computed((): DisplayLine[] => {
+  if (!rawContent.value) return [];
+  const lines = rawContent.value.split("\n");
+  const q = searchQuery.value;
+  const result: DisplayLine[] = [];
+  lines.forEach((raw, i) => {
+    if (q && !raw.toLowerCase().includes(q.toLowerCase())) return;
+    result.push({
+      level: getLineLevel(raw),
+      html: highlightMatch(raw, q),
+      originalIndex: i,
+    });
+  });
+  return result;
+});
+
+const matchTotal = computed(() => displayLines.value.length);
+
+function clampIndex(idx: number): number {
+  if (matchTotal.value === 0) return 0;
+  return ((idx % matchTotal.value) + matchTotal.value) % matchTotal.value;
+}
+
+function jumpNext(): void {
+  currentMatchIndex.value = clampIndex(currentMatchIndex.value + 1);
+  scrollToMatch(currentMatchIndex.value);
+}
+
+function jumpPrev(): void {
+  currentMatchIndex.value = clampIndex(currentMatchIndex.value - 1);
+  scrollToMatch(currentMatchIndex.value);
+}
+
+function scrollToMatch(idx: number): void {
+  nextTick(() => {
+    const el =
+      contentEl.value?.querySelectorAll<HTMLElement>("[data-line]")[idx];
+    el?.scrollIntoView({ block: "center" });
+  });
+}
+
+watch(searchQuery, () => {
+  currentMatchIndex.value = 0;
+});
+
+// ── Copy ───────────────────────────────────────────────────────────────────────
+
+const copied = ref(false);
+
 async function copy(): Promise<void> {
   try {
-    await navigator.clipboard.writeText(content.value);
+    await navigator.clipboard.writeText(rawContent.value);
     copied.value = true;
     setTimeout(() => (copied.value = false), 1500);
   } catch {
@@ -42,10 +198,31 @@ async function copy(): Promise<void> {
   }
 }
 
+// ── Utils ──────────────────────────────────────────────────────────────────────
+
+function formatSize(bytes: number): string {
+  if (bytes >= 1024 * 1024) return (bytes / 1024 / 1024).toFixed(1) + " MB";
+  return Math.ceil(bytes / 1024) + " KB";
+}
+
+function formatDate(ms: number): string {
+  if (ms === 0) return "—";
+  return new Date(ms).toLocaleString();
+}
+
+function fileStem(name: string): string {
+  return name.replace(/\.log$/, "");
+}
+
+// ── Dialog open/close ──────────────────────────────────────────────────────────
+
 watch(
   () => props.open,
   (open) => {
-    if (open) void load();
+    if (open) {
+      view.value = "list";
+      void loadFileList();
+    }
   },
 );
 </script>
@@ -57,8 +234,9 @@ watch(
     @click.self="emit('close')"
   >
     <div
-      class="ty-card flex max-h-[80vh] w-full max-w-3xl flex-col gap-3 rounded-xl p-4 sm:p-5"
+      class="ty-card flex max-h-[85vh] w-full max-w-3xl flex-col gap-3 rounded-xl p-4 sm:p-5"
     >
+      <!-- ── Header ── -->
       <div class="flex items-center justify-between">
         <h2 class="ty-section-title">{{ t("settings.logViewer.title") }}</h2>
         <button
@@ -69,34 +247,233 @@ watch(
           {{ t("settings.logViewer.close") }}
         </button>
       </div>
-      <pre
-        class="min-h-0 flex-1 overflow-auto rounded-lg bg-black/80 p-3 font-mono text-xs text-green-200"
-        >{{ content || t("settings.logViewer.empty") }}</pre
-      >
-      <div class="flex flex-wrap gap-2">
-        <button
-          type="button"
-          class="ty-btn-sm ty-btn-secondary"
-          :disabled="loading"
-          @click="load"
+
+      <!-- ════════════════════ FILE LIST VIEW ════════════════════ -->
+      <template v-if="view === 'list'">
+        <!-- Loading -->
+        <div
+          v-if="listLoading"
+          class="flex flex-1 items-center justify-center py-8"
         >
-          {{ t("settings.logViewer.refresh") }}
-        </button>
-        <button type="button" class="ty-btn-sm ty-btn-secondary" @click="copy">
-          {{
-            copied
-              ? t("settings.logViewer.copied")
-              : t("settings.logViewer.copy")
-          }}
-        </button>
-        <button
-          type="button"
-          class="ty-btn-sm ty-btn-primary-solid"
-          @click="exportLogsAndReport(t)"
+          <span class="loading loading-spinner loading-md opacity-60" />
+        </div>
+
+        <!-- Error -->
+        <div
+          v-else-if="listError"
+          class="rounded-lg bg-red-950/40 p-3 text-sm text-red-400"
         >
-          {{ t("settings.reportIssue.button") }}
-        </button>
-      </div>
+          {{ listError }}
+        </div>
+
+        <!-- Empty -->
+        <div
+          v-else-if="fileList.length === 0"
+          class="flex flex-1 items-center justify-center py-8 text-sm opacity-50"
+        >
+          {{ t("settings.logViewer.empty") }}
+        </div>
+
+        <!-- Table -->
+        <div v-else class="min-h-0 flex-1 overflow-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-white/10 text-left text-xs opacity-60">
+                <th class="pb-1 pr-4 font-medium">
+                  {{ t("settings.logViewer.fileName") }}
+                </th>
+                <th class="pb-1 pr-4 font-medium">
+                  {{ t("settings.logViewer.size") }}
+                </th>
+                <th class="pb-1 font-medium">
+                  {{ t("settings.logViewer.modifiedTime") }}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="(file, idx) in fileList"
+                :key="file.name"
+                class="cursor-pointer border-b border-white/5 hover:bg-white/5"
+                @click="openFile(file)"
+              >
+                <td class="py-1.5 pr-4 font-mono text-xs">
+                  {{ fileStem(file.name) }}
+                  <span
+                    v-if="idx === 0"
+                    class="ml-1.5 rounded bg-blue-600/40 px-1 py-0.5 text-[10px] text-blue-300"
+                  >
+                    {{ t("settings.logViewer.currentSession") }}
+                  </span>
+                </td>
+                <td class="py-1.5 pr-4 tabular-nums opacity-60">
+                  {{ formatSize(file.sizeBytes) }}
+                </td>
+                <td class="py-1.5 tabular-nums opacity-60">
+                  {{ formatDate(file.modifiedMs) }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Footer -->
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="ty-btn-sm ty-btn-secondary"
+            :disabled="listLoading"
+            @click="loadFileList"
+          >
+            {{ t("settings.logViewer.refresh") }}
+          </button>
+          <button
+            type="button"
+            class="ty-btn-sm ty-btn-primary-solid"
+            @click="exportLogsAndReport(t)"
+          >
+            {{ t("settings.reportIssue.button") }}
+          </button>
+        </div>
+      </template>
+
+      <!-- ════════════════════ CONTENT VIEW ════════════════════ -->
+      <template v-else>
+        <!-- Breadcrumb -->
+        <div class="flex items-center gap-1 text-sm">
+          <button
+            type="button"
+            class="text-blue-400 hover:underline"
+            @click="backToList"
+          >
+            {{ t("settings.logViewer.fileList") }}
+          </button>
+          <span class="opacity-40">/</span>
+          <span class="font-mono text-xs opacity-70">{{
+            fileStem(selectedFile?.name ?? "")
+          }}</span>
+        </div>
+
+        <!-- Truncation notice -->
+        <div
+          v-if="isTruncated"
+          class="rounded bg-yellow-900/30 px-3 py-1.5 text-xs text-yellow-400"
+        >
+          {{ t("settings.logViewer.truncated") }}
+        </div>
+
+        <!-- Search bar -->
+        <div class="flex items-center gap-2">
+          <input
+            v-model="searchQuery"
+            type="text"
+            class="ty-input flex-1 font-mono text-xs"
+            :placeholder="t('settings.logViewer.searchPlaceholder')"
+          />
+          <span v-if="searchQuery" class="shrink-0 text-xs opacity-60">
+            <template v-if="matchTotal === 0">{{
+              t("settings.logViewer.noMatches")
+            }}</template>
+            <template v-else>
+              {{
+                t("settings.logViewer.matchCount", {
+                  current: currentMatchIndex + 1,
+                  total: matchTotal,
+                })
+              }}
+            </template>
+          </span>
+          <button
+            v-if="searchQuery"
+            type="button"
+            class="ty-btn-sm ty-btn-secondary px-2"
+            :disabled="matchTotal === 0"
+            @click="jumpPrev"
+          >
+            ↑
+          </button>
+          <button
+            v-if="searchQuery"
+            type="button"
+            class="ty-btn-sm ty-btn-secondary px-2"
+            :disabled="matchTotal === 0"
+            @click="jumpNext"
+          >
+            ↓
+          </button>
+        </div>
+
+        <!-- Log content -->
+        <div
+          v-if="contentLoading"
+          class="flex flex-1 items-center justify-center py-8"
+        >
+          <span class="loading loading-spinner loading-md opacity-60" />
+        </div>
+
+        <div
+          v-else-if="contentError"
+          class="min-h-0 flex-1 overflow-auto rounded-lg bg-black/80 p-3 font-mono text-xs text-red-400"
+        >
+          {{ contentError }}
+        </div>
+
+        <div
+          v-else
+          ref="contentEl"
+          class="min-h-0 flex-1 overflow-auto rounded-lg bg-black/80 p-3 font-mono text-xs leading-relaxed"
+        >
+          <div v-if="displayLines.length === 0" class="opacity-40">
+            {{
+              searchQuery
+                ? t("settings.logViewer.noMatches")
+                : t("settings.logViewer.empty")
+            }}
+          </div>
+          <div
+            v-for="(line, idx) in displayLines"
+            :key="line.originalIndex"
+            data-line
+            :class="[
+              LEVEL_CLASS[line.level],
+              idx === currentMatchIndex && searchQuery
+                ? 'bg-white/10 rounded'
+                : '',
+            ]"
+            v-html="line.html"
+          />
+        </div>
+
+        <!-- Footer -->
+        <div class="flex flex-wrap gap-2">
+          <button
+            type="button"
+            class="ty-btn-sm ty-btn-secondary"
+            :disabled="contentLoading"
+            @click="openFile(selectedFile!)"
+          >
+            {{ t("settings.logViewer.refresh") }}
+          </button>
+          <button
+            type="button"
+            class="ty-btn-sm ty-btn-secondary"
+            @click="copy"
+          >
+            {{
+              copied
+                ? t("settings.logViewer.copied")
+                : t("settings.logViewer.copy")
+            }}
+          </button>
+          <button
+            type="button"
+            class="ty-btn-sm ty-btn-primary-solid"
+            @click="exportLogsAndReport(t)"
+          >
+            {{ t("settings.reportIssue.button") }}
+          </button>
+        </div>
+      </template>
     </div>
   </div>
 </template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -99,7 +99,16 @@
       "copy": "Copy",
       "copied": "Copied",
       "refresh": "Refresh",
-      "close": "Close"
+      "close": "Close",
+      "fileList": "App Logs",
+      "currentSession": "Current session",
+      "fileName": "File",
+      "size": "Size",
+      "modifiedTime": "Modified",
+      "searchPlaceholder": "Search logs…",
+      "matchCount": "{current} of {total}",
+      "noMatches": "No matches",
+      "truncated": "Showing last 256 KB only"
     },
     "reportIssue": {
       "title": "Report an Issue",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -99,7 +99,16 @@
       "copy": "复制",
       "copied": "已复制",
       "refresh": "刷新",
-      "close": "关闭"
+      "close": "关闭",
+      "fileList": "应用日志",
+      "currentSession": "当前会话",
+      "fileName": "文件名",
+      "size": "大小",
+      "modifiedTime": "修改时间",
+      "searchPlaceholder": "搜索日志…",
+      "matchCount": "第 {current} / 共 {total} 条",
+      "noMatches": "无匹配",
+      "truncated": "仅显示最后 256 KB"
     },
     "reportIssue": {
       "title": "报告问题",


### PR DESCRIPTION
Each startup now creates a new tyutool-YYYYMMDD-HHMMSS.log file instead of appending to a single tyutool.log. After creating the session file, old files are pruned so the collection stays within 100 files and 100 MB total; at least one file (the current session) is always retained.

Legacy tyutool.log files from the old rotation scheme are left untouched. pick_active_log now selects by newest mtime rather than fixed filename, which works correctly for both old and new naming.