### PR TITLE
docs(usage-guide): point operator download table at v3.2.2

### DIFF
--- a/docs/usage-guide/en/batch-auth-operator.html
+++ b/docs/usage-guide/en/batch-auth-operator.html
@@ -62,11 +62,11 @@
         </tbody>
       </table>
       <table>
-        <thead><tr><th>OS</th><th>Installer (v3.2.1; check <a href="https://github.com/tuya/tyutool/releases">GitHub Releases</a> for newer versions)</th></tr></thead>
+        <thead><tr><th>OS</th><th>Installer (v3.2.2; check <a href="https://github.com/tuya/tyutool/releases">GitHub Releases</a> for newer versions)</th></tr></thead>
         <tbody>
-          <tr><td>Windows (x64)</td><td><a href="https://github.com/tuya/tyutool/releases/download/v3.2.1/tyutool-gui_windows_x86_64_nsis_3.2.1.exe">tyutool-gui_windows_x86_64_nsis_3.2.1.exe</a></td></tr>
-          <tr><td>macOS (Universal)</td><td><a href="https://github.com/tuya/tyutool/releases/download/v3.2.1/tyutool-gui_macos_universal_dmg_3.2.1.dmg">tyutool-gui_macos_universal_dmg_3.2.1.dmg</a></td></tr>
-          <tr><td>Linux (x64)</td><td><a href="https://github.com/tuya/tyutool/releases/download/v3.2.1/tyutool-gui_linux_x86_64_appimage_3.2.1.AppImage">tyutool-gui_linux_x86_64_appimage_3.2.1.AppImage</a> (<code>chmod +x</code> after download, then run)</td></tr>
+          <tr><td>Windows (x64)</td><td><a href="https://github.com/tuya/tyutool/releases/download/v3.2.2/tyutool-gui_windows_x86_64_nsis_3.2.2.exe">tyutool-gui_windows_x86_64_nsis_3.2.2.exe</a></td></tr>
+          <tr><td>macOS (Universal)</td><td><a href="https://github.com/tuya/tyutool/releases/download/v3.2.2/tyutool-gui_macos_universal_dmg_3.2.2.dmg">tyutool-gui_macos_universal_dmg_3.2.2.dmg</a></td></tr>
+          <tr><td>Linux (x64)</td><td><a href="https://github.com/tuya/tyutool/releases/download/v3.2.2/tyutool-gui_linux_x86_64_appimage_3.2.2.AppImage">tyutool-gui_linux_x86_64_appimage_3.2.2.AppImage</a> (<code>chmod +x</code> after download, then run)</td></tr>
         </tbody>
       </table>
       <div class="callout warn">

--- a/docs/usage-guide/zh/batch-auth-operator.html
+++ b/docs/usage-guide/zh/batch-auth-operator.html
@@ -62,11 +62,11 @@
         </tbody>
       </table>
       <table>
-        <thead><tr><th>系统</th><th>安装包（v3.2.1；新版本以 <a href="https://github.com/tuya/tyutool/releases">GitHub Releases</a> 为准）</th></tr></thead>
+        <thead><tr><th>系统</th><th>安装包（v3.2.2；新版本以 <a href="https://github.com/tuya/tyutool/releases">GitHub Releases</a> 为准）</th></tr></thead>
         <tbody>
-          <tr><td>Windows（x64）</td><td><a href="https://github.com/tuya/tyutool/releases/download/v3.2.1/tyutool-gui_windows_x86_64_nsis_3.2.1.exe">tyutool-gui_windows_x86_64_nsis_3.2.1.exe</a></td></tr>
-          <tr><td>macOS（通用）</td><td><a href="https://github.com/tuya/tyutool/releases/download/v3.2.1/tyutool-gui_macos_universal_dmg_3.2.1.dmg">tyutool-gui_macos_universal_dmg_3.2.1.dmg</a></td></tr>
-          <tr><td>Linux（x64）</td><td><a href="https://github.com/tuya/tyutool/releases/download/v3.2.1/tyutool-gui_linux_x86_64_appimage_3.2.1.AppImage">tyutool-gui_linux_x86_64_appimage_3.2.1.AppImage</a>（下载后 <code>chmod +x</code> 再运行）</td></tr>
+          <tr><td>Windows（x64）</td><td><a href="https://github.com/tuya/tyutool/releases/download/v3.2.2/tyutool-gui_windows_x86_64_nsis_3.2.2.exe">tyutool-gui_windows_x86_64_nsis_3.2.2.exe</a></td></tr>
+          <tr><td>macOS（通用）</td><td><a href="https://github.com/tuya/tyutool/releases/download/v3.2.2/tyutool-gui_macos_universal_dmg_3.2.2.dmg">tyutool-gui_macos_universal_dmg_3.2.2.dmg</a></td></tr>
+          <tr><td>Linux（x64）</td><td><a href="https://github.com/tuya/tyutool/releases/download/v3.2.2/tyutool-gui_linux_x86_64_appimage_3.2.2.AppImage">tyutool-gui_linux_x86_64_appimage_3.2.2.AppImage</a>（下载后 <code>chmod +x</code> 再运行）</td></tr>
         </tbody>
       </table>
       <div class="callout warn">


### PR DESCRIPTION
Update the installer download table (zh + en operator guide) from v3.2.1 to v3.2.2, matching the release published today.
