### PR TITLE
feat(release): add url_gitee/url_tuya mirror fields + release v3.2.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,8 +370,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
-    outputs:
-      notes: ${{ steps.notes.outputs.body }}
     steps:
       - uses: actions/checkout@v6
 
@@ -434,6 +432,14 @@ jobs:
           RELEASE_NOTES: ${{ steps.notes.outputs.body }}
         run: pnpm exec tsx scripts/generate-manifest.ts
 
+      # Shared with sync-gitee: the exact same file is pushed to Gitee unmodified.
+      - uses: actions/upload-artifact@v7
+        with:
+          name: latest-json
+          path: latest.json
+          if-no-files-found: error
+          retention-days: 1
+
       - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
@@ -466,7 +472,7 @@ jobs:
   # Optional repo variable: GITEE_TARGET_COMMITISH. Script: scripts/sync-gitee-release.sh
   sync-gitee:
     name: Sync to Gitee
-    needs: [publish, prepare, create-release]
+    needs: [publish]
     runs-on: self-hosted
     if: startsWith(github.ref, 'refs/tags/')
     continue-on-error: true
@@ -489,46 +495,12 @@ jobs:
       #   if: steps.gate.outputs.skip != 'true'
       #   with: { path: artifacts/ }
 
-      - uses: pnpm/action-setup@v5
+      # Reuse the manifest built in create-release: Gitee gets the identical file
+      # (multi-mirror url/url_gitee/url_tuya fields), no separate regeneration.
+      - uses: actions/download-artifact@v8
         if: steps.gate.outputs.skip != 'true'
         with:
-          version: 10
-
-      - uses: actions/setup-node@v6
-        if: steps.gate.outputs.skip != 'true'
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Install dependencies
-        if: steps.gate.outputs.skip != 'true'
-        run: pnpm install --frozen-lockfile
-
-      - name: Build Gitee latest.json
-        if: steps.gate.outputs.skip != 'true'
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-          GITHUB_REPO: ${{ github.repository }}
-          TAG: ${{ github.ref_name }}
-          RELEASE_NOTES: ${{ needs.create-release.outputs.notes }}
-          GITEE_USER: ${{ secrets.GITEE_USER }}
-          GITEE_REPO: ${{ secrets.GITEE_REPO }}
-          SKIP_COMPLETENESS_CHECK: "1"
-        run: |
-          set -euo pipefail
-          if [[ "${GITEE_REPO}" == */* ]]; then
-            GO="${GITEE_REPO%%/*}"
-            GR="${GITEE_REPO#*/}"
-          else
-            GO="${GITEE_USER}"
-            GR="${GITEE_REPO}"
-          fi
-          if [[ -z "${GO}" || -z "${GR}" ]]; then
-            echo "::error::Invalid Gitee coordinates: use GITEE_USER + repo-only GITEE_REPO, or set GITEE_REPO to owner/repo."
-            exit 1
-          fi
-          export MANIFEST_BASE_URL="https://gitee.com/${GO}/${GR}/releases/download/${TAG}"
-          pnpm exec tsx scripts/generate-manifest.ts
+          name: latest-json
 
       - name: Flatten assets for Gitee upload
         if: steps.gate.outputs.skip != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 本项目所有重要变更记录于此 / All notable changes are documented here.
 
+## [3.2.3] - 2026-07-21
+
+### 新功能
+
+- `release`：`latest.json` 的每个下载条目新增 `url_gitee`（Gitee 镜像）与 `url_tuya`（Tuya OSS 镜像）字段，供外部系统按镜像源获取产物；应用内更新逻辑不变，仍使用 `url`
+- `release`：同步到 Gitee 的 `latest.json` 现在与 GitHub Release 上的完全一致，不再单独生成 Gitee 专属版本
+
+---
+
+### Features
+
+- `release`: Each download entry in `latest.json` now carries `url_gitee` (Gitee mirror) and `url_tuya` (Tuya OSS mirror) fields so external systems can fetch artifacts from a mirror; in-app updaters are unchanged and keep using `url`
+- `release`: The `latest.json` synced to Gitee is now byte-identical to the one on the GitHub Release instead of a separately generated Gitee-specific variant
+
 ## [3.2.2] - 2026-07-17
 
 ### 新功能

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5874,7 +5874,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "tyutool-cli"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5906,7 +5906,7 @@ dependencies = [
 
 [[package]]
 name = "tyutool-core"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "crc32fast",
  "espflash",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "tyutool_gui"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "calamine",
  "chrono",

--- a/crates/tyutool-cli/Cargo.toml
+++ b/crates/tyutool-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tyutool-cli"
-version = "3.2.2"
+version = "3.2.3"
 edition = "2021"
 description = "tyutool CLI — shared tyutool-core flash API (no Tauri)"
 

--- a/crates/tyutool-core/Cargo.toml
+++ b/crates/tyutool-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tyutool-core"
-version = "3.2.2"
+version = "3.2.3"
 edition = "2021"
 description = "Shared flash/erase plugin registry and serial helpers for tyutool CLI and GUI"
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -72,5 +72,6 @@ git tag -d v3.0.14
 ## 范围说明
 
 - Beta：`workflow_dispatch` 仅构建产物自测，不创建 Release。
-- Gitee：当前仅同步 `latest.json`。
+- Gitee：当前仅同步 `latest.json`，且推送的是与 GitHub Release 完全相同的一份文件（不再单独生成 Gitee 版本）。
+- `latest.json` 每个条目含三个下载地址：`url`（GitHub）、`url_gitee`（Gitee，产物未同步前不可用）、`url_tuya`（Tuya OSS，由外部 tuyaopen-oss-publish 流水线上传产物）。客户端更新逻辑仅使用 `url`；镜像字段供外部系统读取。
 - `latest.json` 的更新说明为中英双语同一文本块，不按应用语言切换。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tyutool",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "type": "module",
   "scripts": {
     "clean": "node -e \"try { require('fs').rmSync('dist', { recursive: true, force: true }); } catch (e) { if (e && e.code !== 'ENOENT') throw e; }\"",

--- a/scripts/generate-manifest.ts
+++ b/scripts/generate-manifest.ts
@@ -11,16 +11,24 @@ import { findFilesUnderArtifacts } from './lib/artifacts-glob.js';
 const VERSION = process.env.VERSION;
 const GITHUB_REPO = process.env.GITHUB_REPO;
 const TAG = process.env.TAG;
-const MANIFEST_BASE_URL = process.env.MANIFEST_BASE_URL?.replace(/\/$/, '');
 
 if (!VERSION || !GITHUB_REPO || !TAG) {
   console.error('ERROR: VERSION, GITHUB_REPO, and TAG must be set.');
   process.exit(1);
 }
 
-const BASE_URL =
-  MANIFEST_BASE_URL ??
-  `https://github.com/${GITHUB_REPO}/releases/download/${TAG}`;
+const BASE_URL = `https://github.com/${GITHUB_REPO}/releases/download/${TAG}`;
+const GITEE_BASE_URL = `https://gitee.com/tuya-open/tyutool/releases/download/${TAG}`;
+// "pruduct" is the actual key spelling on the Tuya OSS bucket — do not fix.
+const TUYA_BASE_URL = `https://airtake-public-data-1254153901.cos.ap-shanghai.myqcloud.com/smart/embed/pruduct/tyutool/${TAG}`;
+
+function mirrorUrls(filename: string): { url: string; url_gitee: string; url_tuya: string } {
+  return {
+    url: `${BASE_URL}/${filename}`,
+    url_gitee: `${GITEE_BASE_URL}/${filename}`,
+    url_tuya: `${TUYA_BASE_URL}/${filename}`,
+  };
+}
 
 function sha256File(path: string): string {
   const h = createHash('sha256');
@@ -41,7 +49,10 @@ const GUI_PLATFORM_PATTERNS: Record<string, [string, string][]> = {
   'windows-x86_64': [[`tyutool-gui_windows_x86_64_nsis_${VERSION}.exe`, 'windows-x86_64']],
 };
 
-const platforms: Record<string, { url: string; signature: string }> = {};
+const platforms: Record<
+  string,
+  { url: string; url_gitee: string; url_tuya: string; signature: string }
+> = {};
 
 for (const [platformKey, patterns] of Object.entries(GUI_PLATFORM_PATTERNS)) {
   for (const [filename] of patterns) {
@@ -51,7 +62,7 @@ for (const [platformKey, patterns] of Object.entries(GUI_PLATFORM_PATTERNS)) {
     if (assetMatches.length > 0 && existsSync(sigPath)) {
       const signature = readSig(sigPath);
       platforms[platformKey] = {
-        url: `${BASE_URL}/${filename}`,
+        ...mirrorUrls(filename),
         signature,
       };
     } else {
@@ -70,14 +81,17 @@ const CLI_PATTERNS: Record<string, string> = {
   'windows-x86_64': `tyutool-cli_windows_x86_64_${VERSION}.zip`,
 };
 
-const cli: Record<string, { url: string; sha256: string }> = {};
+const cli: Record<
+  string,
+  { url: string; url_gitee: string; url_tuya: string; sha256: string }
+> = {};
 
 for (const [platformKey, filename] of Object.entries(CLI_PATTERNS)) {
   const matches = findFilesUnderArtifacts(filename);
   if (matches.length > 0) {
     const path = matches[0];
     cli[platformKey] = {
-      url: `${BASE_URL}/${filename}`,
+      ...mirrorUrls(filename),
       sha256: sha256File(path),
     };
   }
@@ -91,14 +105,12 @@ const PORTABLE_PATTERNS: Record<string, string> = {
   'windows-x86_64': `tyutool-gui_windows_x86_64_portable_${VERSION}.zip`,
 };
 
-const portable: Record<string, { url: string }> = {};
+const portable: Record<string, { url: string; url_gitee: string; url_tuya: string }> = {};
 
 for (const [platformKey, filename] of Object.entries(PORTABLE_PATTERNS)) {
   const matches = findFilesUnderArtifacts(filename);
   if (matches.length > 0) {
-    portable[platformKey] = {
-      url: `${BASE_URL}/${filename}`,
-    };
+    portable[platformKey] = mirrorUrls(filename);
   }
 }
 
@@ -119,16 +131,12 @@ const manifest = {
   portable,
 };
 
-// The Gitee sync step regenerates the manifest without artifacts present and
-// sets SKIP_COMPLETENESS_CHECK=1 to opt out; the primary GitHub path never sets it.
-if (process.env.SKIP_COMPLETENESS_CHECK !== '1') {
-  const completenessErrors = assertManifestComplete(manifest);
-  if (completenessErrors.length > 0) {
-    console.error('ERROR: latest.json 不完整，缺少平台条目：');
-    for (const e of completenessErrors) console.error(`  - ${e}`);
-    console.error('（某些平台的产物或 .sig 在 artifacts/ 中缺失，见上方 WARN）');
-    process.exit(1);
-  }
+const completenessErrors = assertManifestComplete(manifest);
+if (completenessErrors.length > 0) {
+  console.error('ERROR: latest.json 不完整，缺少平台条目：');
+  for (const e of completenessErrors) console.error(`  - ${e}`);
+  console.error('（某些平台的产物或 .sig 在 artifacts/ 中缺失，见上方 WARN）');
+  process.exit(1);
 }
 
 writeFileSync('latest.json', `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tyutool_gui"
-version = "3.2.2"
+version = "3.2.3"
 description = "tyutool — Tauri shell for tyutool-core (firmware / serial tooling)"
 authors = ["tyutool contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tyutool",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "identifier": "com.tyutool.desktop",
   "build": {
     "beforeDevCommand": "pnpm run dev",


### PR DESCRIPTION
## 背景

latest.json 目前每个条目只有一个指向 GitHub Release 的 `url`。为了让同一份 manifest 可以原样分发到 GitHub / Gitee / Tuya OSS 三处并供外部系统读取，每个条目（platforms / cli / portable）新增 `url_gitee`、`url_tuya` 两个镜像地址。

## 变更

- **scripts/generate-manifest.ts**：每个条目输出 `url` / `url_gitee` / `url_tuya` 三个地址（Gitee 指向 `gitee.com/tuya-open/tyutool` release；Tuya 指向 Tuya OSS，路径中 `pruduct` 为 OSS 实际 key 拼写）。移除 `MANIFEST_BASE_URL` / `SKIP_COMPLETENESS_CHECK`（唯一使用方已删除），完整性检查改为无条件执行。
- **release.yml**：create-release 把 latest.json 存为 workflow artifact；sync-gitee 直接下载复用这份**完全相同**的文件，不再单独重新生成 Gitee 版 manifest（原先生成的版本因无产物而条目为空）。
- **docs/release.md**：更新 Gitee 同步与三 url 字段说明。

## 兼容性

所有消费方均忽略未知字段，对现有更新功能无影响：Tauri updater 插件、前端版本检查、CLI 自更新仍只使用 `url`；镜像字段供外部系统（如 Tuya 下载页）读取。`url_gitee` 为预留字段（Gitee 产物上传仍处于禁用状态）；Tuya OSS 产物由外部 tuyaopen-oss-publish 流水线上传。

## 验证

- 本地假产物干跑 `generate-manifest.ts`：5 平台 × 3 分组均生成三个 url，basename 一致，`url_tuya` 前缀正确；缺产物时仍 exit 1。
- `vitest run scripts/lib/release-check.test.ts` 9/9 通过；`eslint`、`vue-tsc --noEmit` 通过。
- sync-gitee 的实际效果需在下一次打 tag 发布时观察确认。

---

**追加**:本 PR 现在还包含 v3.2.3 的版本升级与 CHANGELOG(`chore(release): bump version to 3.2.3 and update changelog`)。合并后在 `refactor/v3` 上打 tag `v3.2.3` 即触发发布 CI。