### PR TITLE
fix(gui): cap espflash log output at INFO to stop log flooding

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2941,6 +2941,10 @@ pub fn run() {
                 .rotation_strategy(RotationStrategy::KeepAll)
                 .timezone_strategy(TimezoneStrategy::UseLocal)
                 .level(log::LevelFilter::Debug)
+                // espflash dumps every protocol command's full payload as hex at DEBUG
+                // (~10 MB per ESP flash), drowning the session log. Cap it at INFO;
+                // use the CLI with --verbose to capture ESP protocol frames instead.
+                .level_for("espflash", log::LevelFilter::Info)
                 .build(),
         )
         .plugin(tauri_plugin_store::Builder::default().build())


### PR DESCRIPTION
## 问题

烧录 ESP 系列芯片时,GUI 会话日志被 `espflash` 库(v4.3)的 DEBUG 输出灌爆:它把每个协议命令的**完整数据负载按十六进制逐字节打印**——`FlashDeflData` 每行约 4KB(一次烧录近 2000 行)、`MemData`(stub loader 上传)单行最大 14KB。

用户导出的 logs.zip 实测:**烧一次 ESP ≈ 10MB 日志**,直接打满单文件 10MB 上限触发滚动;滚动文件里 99.8% 的字节是 `espflash::connection` 的 DEBUG 行。这会让日志无法阅读,并加速耗尽 100MB 跨会话总量上限、挤掉有价值的历史日志。

根因:GUI 文件日志是全局 `LevelFilter::Debug`(`lib.rs`),无按模块过滤;espflash 作为第三方库不遵守本项目"载荷不进日志"的规约。CLI 不受影响(Info 级)。

## 修复

tauri-plugin-log 增加一行按模块过滤:

```rust
.level_for("espflash", log::LevelFilter::Info)
```

- tyutool 自身的 DEBUG 诊断日志全部保留
- espflash 只留 INFO 及以上;过滤在 fern 派发层生效,开发者设置调到 trace 也不会重新放开
- 需要抓 ESP 协议帧时,用 CLI `--verbose`

## 验证

`cargo check`(src-tauri)通过。