### PR TITLE
fix(esp): hard-reset device after flash to exit download mode

### DIFF
--- a/crates/tyutool-core/src/plugins/esp/common.rs
+++ b/crates/tyutool-core/src/plugins/esp/common.rs
@@ -286,6 +286,22 @@ pub(crate) fn run_esp(
         FlashMode::Authorize => unreachable!("Authorize is handled in run_job before plugin.run"),
     }
 
+    // espflash only applies the ResetAfterOperation when asked explicitly (its
+    // CLI calls this after every operation). Without it the chip stays in the
+    // ROM bootloader once the port closes, so a follow-up step that talks to
+    // the application firmware — e.g. batch authorize right after flashing —
+    // fails until someone power-cycles the board. HardReset toggles EN only
+    // (GPIO0 untouched), so the freshly flashed firmware boots normally.
+    log::info!("Resetting ESP device to exit download mode");
+    if let Err(e) = flasher.connection().reset_after(true, def.chip) {
+        log::warn!("ESP reset after operation failed: {e}");
+        progress(FlashEvent::Warning {
+            message: "could not reset the device after the operation; \
+                      power-cycle or reset it manually before authorizing"
+                .to_string(),
+        });
+    }
+
     log::info!("ESP plugin completed successfully");
     Ok(())
 }

--- a/src/stores/batch-flash-auth.test.ts
+++ b/src/stores/batch-flash-auth.test.ts
@@ -204,11 +204,14 @@ describe("slot state machine", () => {
     expect(store.cumulativeStats.flash.fail).toBe(1);
   });
 
-  it("handleFlashProgress done/ok clears a stale readError from a prior probe", () => {
+  it("handleFlashProgress done/ok clears stale probe leftovers", () => {
     const store = useBatchFlashAuthStore();
     store.addPorts(["COM3"]);
     store.slots[0].status = "flashing";
     store.slots[0].readError = "read MAC failed";
+    store.slots[0].mac = "AABBCCDDEE00";
+    store.slots[0].authUuid = "uuid-old";
+    store.slots[0].isAuthorized = true;
     store.batchStartTime = Date.now();
     store.handleFlashProgress({
       port: "COM3",
@@ -216,13 +219,37 @@ describe("slot state machine", () => {
     });
     expect(store.slots[0].status).toBe("done");
     expect(store.slots[0].readError).toBeUndefined();
+    expect(store.slots[0].mac).toBeUndefined();
+    expect(store.slots[0].authUuid).toBeUndefined();
+    expect(store.slots[0].isAuthorized).toBeUndefined();
   });
 
-  it("handleAuthProgress no_code clears a stale readError from a prior probe", () => {
+  it("handleFlashProgress done/err clears stale probe leftovers", () => {
+    const store = useBatchFlashAuthStore();
+    store.addPorts(["COM3"]);
+    store.slots[0].status = "flashing";
+    store.slots[0].mac = "AABBCCDDEE00";
+    store.slots[0].authUuid = "uuid-old";
+    store.batchStartTime = Date.now();
+    store.handleFlashProgress({
+      port: "COM3",
+      event: {
+        kind: "done",
+        result: { err: { message: "timeout", elapsed_secs: 5 } },
+      },
+    });
+    expect(store.slots[0].status).toBe("failed");
+    expect(store.slots[0].mac).toBeUndefined();
+    expect(store.slots[0].authUuid).toBeUndefined();
+  });
+
+  it("handleAuthProgress no_code clears stale readError and credentials", () => {
     const store = useBatchFlashAuthStore();
     store.addPorts(["COM3"]);
     store.slots[0].status = "authorizing";
     store.slots[0].readError = "read MAC failed";
+    store.slots[0].authUuid = "uuid-old";
+    store.slots[0].isAuthorized = true;
     store.handleAuthProgress({
       port: "COM3",
       step: "no_code",
@@ -230,6 +257,41 @@ describe("slot state machine", () => {
     });
     expect(store.slots[0].status).toBe("no_code");
     expect(store.slots[0].readError).toBeUndefined();
+    expect(store.slots[0].authUuid).toBeUndefined();
+    expect(store.slots[0].isAuthorized).toBeUndefined();
+  });
+
+  it("handleAuthProgress failed clears stale credentials from a prior run", () => {
+    const store = useBatchFlashAuthStore();
+    store.addPorts(["COM3"]);
+    store.slots[0].status = "authorizing";
+    store.slots[0].authUuid = "uuid-old";
+    store.slots[0].isAuthorized = true;
+    store.handleAuthProgress({
+      port: "COM3",
+      step: "failed",
+      error: "verify failed",
+      mac: "AABBCCDDEEFF",
+    });
+    expect(store.slots[0].status).toBe("failed");
+    expect(store.slots[0].authUuid).toBeUndefined();
+    expect(store.slots[0].isAuthorized).toBeUndefined();
+  });
+
+  it("handleAuthProgress default_mac clears stale credentials from a prior run", () => {
+    const store = useBatchFlashAuthStore();
+    store.addPorts(["COM3"]);
+    store.slots[0].status = "authorizing";
+    store.slots[0].authUuid = "uuid-old";
+    store.slots[0].isAuthorized = true;
+    store.handleAuthProgress({
+      port: "COM3",
+      step: "default_mac",
+      mac: "FFFFFFFFFFFF",
+    });
+    expect(store.slots[0].status).toBe("failed");
+    expect(store.slots[0].authUuid).toBeUndefined();
+    expect(store.slots[0].isAuthorized).toBeUndefined();
   });
 
   it("handleFlashProgress done/cancelled resets slot to idle without incrementing cumulative", () => {

--- a/src/stores/batch-flash-auth.test.ts
+++ b/src/stores/batch-flash-auth.test.ts
@@ -204,6 +204,34 @@ describe("slot state machine", () => {
     expect(store.cumulativeStats.flash.fail).toBe(1);
   });
 
+  it("handleFlashProgress done/ok clears a stale readError from a prior probe", () => {
+    const store = useBatchFlashAuthStore();
+    store.addPorts(["COM3"]);
+    store.slots[0].status = "flashing";
+    store.slots[0].readError = "read MAC failed";
+    store.batchStartTime = Date.now();
+    store.handleFlashProgress({
+      port: "COM3",
+      event: { kind: "done", result: { ok: { elapsed_secs: 10 } } },
+    });
+    expect(store.slots[0].status).toBe("done");
+    expect(store.slots[0].readError).toBeUndefined();
+  });
+
+  it("handleAuthProgress no_code clears a stale readError from a prior probe", () => {
+    const store = useBatchFlashAuthStore();
+    store.addPorts(["COM3"]);
+    store.slots[0].status = "authorizing";
+    store.slots[0].readError = "read MAC failed";
+    store.handleAuthProgress({
+      port: "COM3",
+      step: "no_code",
+      mac: "AABBCCDDEEFF",
+    });
+    expect(store.slots[0].status).toBe("no_code");
+    expect(store.slots[0].readError).toBeUndefined();
+  });
+
   it("handleFlashProgress done/cancelled resets slot to idle without incrementing cumulative", () => {
     const store = useBatchFlashAuthStore();
     store.addPorts(["COM3"]);

--- a/src/stores/batch-flash-auth.ts
+++ b/src/stores/batch-flash-auth.ts
@@ -632,7 +632,14 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
     } else if (e.kind === "done") {
       const r = e.result;
       if ("ok" in r) {
-        updateSlot(port, { status: "done", progress: 100, currentPhase: "" });
+        updateSlot(port, {
+          status: "done",
+          progress: 100,
+          currentPhase: "",
+          // A fresh successful flash supersedes any stale "read failed" flag
+          // left by a pre-batch read probe (e.g. device was in download mode).
+          readError: undefined,
+        });
         cumulativeStats.value.flash.total++;
         cumulativeStats.value.flash.success++;
       } else if ("err" in r) {
@@ -696,6 +703,7 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
         mac: ev.mac,
         error: undefined,
         excelError: undefined,
+        readError: undefined,
       });
       checkBatchCompletion();
     } else if (step === "skipped") {

--- a/src/stores/batch-flash-auth.ts
+++ b/src/stores/batch-flash-auth.ts
@@ -369,6 +369,10 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
     archiveError.value = "";
     lastArchivePath.value = "";
 
+    // A new batch means a new device on the port — clear the previous run's
+    // outcome flags, including the quarantine flag (the quarantined device is
+    // expected to have been physically removed by now). Leaving it set would
+    // mislabel the next device on the port and poison the archive CSV.
     for (const slot of slots.value.filter(
       (s) => !ACTIVE_STATUSES.includes(s.status),
     )) {
@@ -378,6 +382,7 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
         currentPhase: "",
         error: undefined,
         excelError: undefined,
+        cancelledAfterWrite: undefined,
       });
     }
 
@@ -392,6 +397,7 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
         currentPhase: "reading_mac",
         error: undefined,
         excelError: undefined,
+        cancelledAfterWrite: undefined,
       });
     }
 
@@ -631,19 +637,30 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
       updateSlot(port, { currentPhase: normalizePhase(e.phase) });
     } else if (e.kind === "done") {
       const r = e.result;
+      // Flash-only runs never read the device identity, so a terminal outcome
+      // must drop probe leftovers (readError, mac, credentials) — they belong
+      // to whatever device was on the port when the probe ran, not to this one.
       if ("ok" in r) {
         updateSlot(port, {
           status: "done",
           progress: 100,
           currentPhase: "",
-          // A fresh successful flash supersedes any stale "read failed" flag
-          // left by a pre-batch read probe (e.g. device was in download mode).
           readError: undefined,
+          mac: undefined,
+          authUuid: undefined,
+          isAuthorized: undefined,
         });
         cumulativeStats.value.flash.total++;
         cumulativeStats.value.flash.success++;
       } else if ("err" in r) {
-        updateSlot(port, { status: "failed", error: r.err.message });
+        updateSlot(port, {
+          status: "failed",
+          error: r.err.message,
+          readError: undefined,
+          mac: undefined,
+          authUuid: undefined,
+          isAuthorized: undefined,
+        });
         cumulativeStats.value.flash.total++;
         cumulativeStats.value.flash.fail++;
       } else {
@@ -691,6 +708,10 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
         error: ev.error ?? "Unknown auth error",
         excelError: ev.excelError,
         mac: ev.mac,
+        // This outcome supersedes credential info from a prior run/probe —
+        // a stale uuid would otherwise leak into the archive CSV.
+        authUuid: ev.uuid,
+        isAuthorized: undefined,
       });
       cumulativeStats.value.auth.total++;
       cumulativeStats.value.auth.fail++;
@@ -704,6 +725,9 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
         error: undefined,
         excelError: undefined,
         readError: undefined,
+        // The event carries no credential info; drop values from a prior run.
+        authUuid: undefined,
+        isAuthorized: undefined,
       });
       checkBatchCompletion();
     } else if (step === "skipped") {
@@ -752,6 +776,10 @@ export const useBatchFlashAuthStore = defineStore("batch-flash-auth", () => {
         currentPhase: "",
         mac: ev.mac,
         error: t("batchFlashAuth.defaultMacError"),
+        // Factory-default MAC means the device identity is unknown; drop
+        // credential info from a prior run.
+        authUuid: undefined,
+        isAuthorized: undefined,
       });
       cumulativeStats.value.auth.total++;
       cumulativeStats.value.auth.fail++;


### PR DESCRIPTION
## 问题 1:烧录完成后停留在下载模式,授权失败

批量烧录授权(以及任何"烧完紧接着授权"的流程)在 ESP 系列芯片上失败:烧录时通过 GPIO0 拉低进入 ROM 下载模式,**烧录完成后芯片仍停在 bootloader,应用固件没有运行**,后续授权走的是应用固件的串口协议,于是失败;人工稍后(设备被复位后)再授权就成功。

**根因**:`run_esp()` 构造 espflash `Connection` 时传了 `ResetAfterOperation::HardReset`,但 espflash 作为库不会自动执行操作后复位——它的 CLI 每次操作结束都显式调用 `connection.reset_after()`,我们从没调过。

**修复**(`d6fa371`):Flash/Erase/Read 任一操作成功后调用 `flasher.connection().reset_after(true, def.chip)`。HardReset 只拉 EN(RTS)、不动 GPIO0,复位后直接运行刚烧的固件,授权无缝衔接。复位失败不影响烧录结果,记 warn 日志并以 `FlashEvent::Warning` 提示手动复位。

## 问题 2:"读取失败"残留

读取探测失败(如设备当时在 bootloader)后槽位挂上"读取失败";手动重启设备再跑批量,成功后"读取失败"黄字仍残留。

**根因**:store 的设计是在终态事件里清探测残留(auth `done`/`skipped` 都显式清 `readError`),但纯烧录成功(`handleFlashProgress` done-ok)和 `no_code` 两个终态漏了。

**修复**(`e26931c`):这两个终态补上 `readError: undefined`。

## 问题 3:同类残留状态排查(`2b10bfb`)

顺着同一模式全面排查 batch store,又修了三处(此前 `86a09cc` 修过反方向的同类问题):

1. **`cancelledAfterWrite`(写入后取消/隔离标志)只置位、永不清除**:换新设备重跑批量后,新设备一旦失败会被误挂"写入后取消"徽标、隐藏重试按钮,且归档 CSV 永远导出 `true` 污染生产记录。→ `startAuth` 的两个重置循环补清(新一轮 = 新设备,被隔离设备应已物理移除;`retryFailed`/`retryPort` 本就跳过隔离槽位,无需改)。
2. **auth `failed` / `default_mac` / `no_code` 终态不清 `authUuid`/`isAuthorized`**:失败行在归档 CSV 里导出的是上一台设备的授权码,与新设备 MAC 错配。→ 三个分支补清。
3. **纯烧录终态(done/err)不清身份字段**:烧录环节不读 MAC,残留的 `mac`/`authUuid`/`isAuthorized` 属于探测时在此端口的旧设备,会错误归属到新设备的归档行。→ 两个分支统一清除。

## 验证

- `cargo test -p tyutool-core` 191 项全过
- batch-flash-auth 相关前端测试 138 项全过(新增 5 条终态清理用例);ESLint 干净;`pnpm run build`(vue-tsc)通过
- 硬件行为需实机回归:烧一块 ESP32 确认烧完自动重启进应用、批量烧录授权一次通过、各残留标签消失

## 说明

- 烧录失败/取消路径未加复位(设备状态未知,保持现状)
- `startAuth` 的隔离标志清理无法在单测覆盖(函数入口被 `isTauriRuntime` 门禁挡住,测试环境 mock 为 false),实机回归时注意验证