### PR TITLE
feat(cli): add monitor command and auth alias for authorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ tyutool authorize -p /dev/ttyUSB0 --uuid <UUID> --authkey <AUTHKEY>
 tyutool reset -p /dev/ttyUSB0 -d bk7231n
 ```
 
+### Serial monitor
+
+```bash
+# Stream device output (quit with Ctrl+] or Ctrl+C)
+tyutool monitor -p /dev/ttyUSB0
+
+# T5AI default monitor baud (460800), tee output to a file
+tyutool monitor -p /dev/ttyUSB0 -d t5ai -l device.log
+```
+
 ### Self-update
 
 ```bash

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -114,6 +114,16 @@ tyutool authorize -p /dev/ttyUSB0 --uuid <UUID> --authkey <AUTHKEY>
 tyutool reset -p /dev/ttyUSB0 -d bk7231n
 ```
 
+### 串口监视
+
+```bash
+# 实时查看设备输出（按 Ctrl+] 或 Ctrl+C 退出）
+tyutool monitor -p /dev/ttyUSB0
+
+# T5AI 默认监视波特率（460800），同时把输出写入文件
+tyutool monitor -p /dev/ttyUSB0 -d t5ai -l device.log
+```
+
 ### 自升级
 
 ```bash

--- a/crates/tyutool-cli/src/main.rs
+++ b/crates/tyutool-cli/src/main.rs
@@ -12,6 +12,7 @@ use tyutool_core::{
     FlashMode,
 };
 
+mod monitor;
 mod reporter;
 use reporter::CliReporter;
 mod serve;
@@ -126,7 +127,23 @@ enum Commands {
         #[arg(long, default_value_t = 9527)]
         port: u16,
     },
-    /// TuyaOpen device authorization via UART shell (auth-read / auth write)
+    /// Live serial monitor — stream device output to the terminal (Ctrl+] or Ctrl+C to quit)
+    Monitor {
+        /// Serial port (default: first available)
+        #[arg(short = 'p', long = "port")]
+        port: Option<String>,
+        /// Uart baud rate (default: chip-specific monitor baud; 115200 without -d)
+        #[arg(short = 'b', long = "baud")]
+        baud: Option<u32>,
+        /// Chip type — selects the default monitor baud (t5ai: 460800, others: 115200)
+        #[arg(short = 'd', long = "device", value_parser = chip_value_parser())]
+        device: Option<String>,
+        /// Append received data to this file
+        #[arg(short = 'l', long = "log")]
+        log: Option<String>,
+    },
+    /// TuyaOpen device authorization via UART shell (auth-read / auth write, KV storage only)
+    #[command(visible_alias = "auth")]
     Authorize {
         /// Serial port (default: first available)
         #[arg(short = 'p', long = "port")]
@@ -187,6 +204,15 @@ fn default_baud(device: &str) -> u32 {
         "ln882h" => 115200,
         "esp32" | "esp32c3" | "esp32c6" | "esp32p4" | "esp32s3" => 460800,
         _ => 921600,
+    }
+}
+
+// Matches TuyaOpen `cli_monitor.py` `_CHIP_MONITOR_BAUDRATE`: T5/T5AI monitor
+// at 460800, every other chip (and no `-d`) at 115200.
+fn monitor_default_baud(device: Option<&str>) -> u32 {
+    match device.map(|d| d.to_ascii_lowercase()).as_deref() {
+        Some("t5ai") => 460800,
+        _ => 115200,
     }
 }
 
@@ -506,6 +532,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             log::info!("[cli] update check={} source={:?}", check, source);
             update::run_update(check, source)
                 .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
+        }
+        Commands::Monitor {
+            port,
+            baud,
+            device,
+            log,
+        } => {
+            let port = match port {
+                Some(p) => p,
+                None => choose_port()?,
+            };
+            let baud = baud.unwrap_or_else(|| monitor_default_baud(device.as_deref()));
+            log::info!("[cli] monitor port={} baud={} log={:?}", port, baud, log);
+            monitor::run_monitor(&port, baud, log.as_deref(), &cancel)?;
         }
         Commands::Serve { port } => {
             log::info!("[cli] serve on port {}", port);
@@ -836,6 +876,55 @@ mod tests {
         assert_eq!(default_baud("esp32s3"), 460800);
         assert_eq!(default_baud("bk7231n"), 921600);
         assert_eq!(default_baud("t5ai"), 921600);
+    }
+
+    #[test]
+    fn monitor_default_baud_per_chip() {
+        assert_eq!(monitor_default_baud(Some("t5ai")), 460800);
+        assert_eq!(monitor_default_baud(Some("T5AI")), 460800);
+        assert_eq!(monitor_default_baud(Some("bk7231n")), 115200);
+        assert_eq!(monitor_default_baud(Some("esp32")), 115200);
+        assert_eq!(monitor_default_baud(None), 115200);
+    }
+
+    #[test]
+    fn monitor_command_parses_flags() {
+        let cli = Cli::try_parse_from([
+            "tyutool", "monitor", "-p", "COM3", "-b", "115200", "-l", "dev.log",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Monitor {
+                port, baud, log, ..
+            } => {
+                assert_eq!(port.as_deref(), Some("COM3"));
+                assert_eq!(baud, Some(115200));
+                assert_eq!(log.as_deref(), Some("dev.log"));
+            }
+            _ => panic!("expected Commands::Monitor"),
+        }
+    }
+
+    #[test]
+    fn auth_is_an_alias_for_authorize() {
+        let cli = Cli::try_parse_from([
+            "tyutool",
+            "auth",
+            "-p",
+            "COM3",
+            "--uuid",
+            "u",
+            "--authkey",
+            "k",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Authorize { uuid, authkey, .. } => {
+                assert_eq!(uuid.as_deref(), Some("u"));
+                assert_eq!(authkey.as_deref(), Some("k"));
+            }
+            _ => panic!("expected Commands::Authorize via alias"),
+        }
     }
 
     #[test]

--- a/crates/tyutool-cli/src/monitor.rs
+++ b/crates/tyutool-cli/src/monitor.rs
@@ -1,0 +1,237 @@
+//! Live serial monitor — stream device output to the terminal.
+//!
+//! Modeled on TuyaOpen `tools/cli_command/cli_monitor.py`: raw device output
+//! is passed through to stdout (optionally teed to a log file with `-l`), and
+//! keystrokes are forwarded to the device so the TuyaOpen shell can be driven
+//! interactively (the device echoes typed characters, like miniterm). Reuses
+//! `SerialDebugSession` from tyutool-core for the port reader thread and
+//! disconnect detection. Quit with Ctrl+] (miniterm-compatible) or Ctrl+C.
+//!
+//! When stdin is not a terminal (pipe/CI), keys cannot be read raw; input is
+//! forwarded line-by-line as `line\r\n` instead, and Ctrl+C (SIGINT) remains
+//! the only quit path.
+
+use std::io::{IsTerminal as _, Write as _};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::Duration;
+
+use console::{Key, Term};
+use tyutool_core::{DataBits, DebugChunk, DebugConfig, Parity, SerialDebugSession, StopBits};
+
+/// Ctrl+] — miniterm's exit character (`cli_monitor.py` uses chr(0x1d)).
+const CTRL_RBRACKET: char = '\u{1d}';
+
+/// What to do with one key read from the interactive terminal.
+#[derive(Debug, PartialEq, Eq)]
+enum KeyAction {
+    /// Stop the monitor (Ctrl+] or Ctrl+C).
+    Quit,
+    /// Forward these bytes to the serial port.
+    Send(Vec<u8>),
+    /// Key has no serial mapping (arrows, function keys, …) — drop it.
+    Ignore,
+}
+
+fn key_action(key: Key) -> KeyAction {
+    match key {
+        Key::CtrlC | Key::Char(CTRL_RBRACKET) => KeyAction::Quit,
+        Key::Enter => KeyAction::Send(b"\r\n".to_vec()),
+        Key::Tab => KeyAction::Send(b"\t".to_vec()),
+        Key::Backspace => KeyAction::Send(b"\x08".to_vec()),
+        Key::Char(c) => {
+            let mut buf = [0u8; 4];
+            KeyAction::Send(c.encode_utf8(&mut buf).as_bytes().to_vec())
+        }
+        _ => KeyAction::Ignore,
+    }
+}
+
+pub fn run_monitor(
+    port: &str,
+    baud: u32,
+    log_path: Option<&str>,
+    cancel: &Arc<AtomicBool>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let log_file = match log_path {
+        Some(p) => {
+            let f = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(p)
+                .map_err(|e| format!("cannot open log file '{}': {}", p, e))?;
+            Some(Arc::new(Mutex::new(f)))
+        }
+        None => None,
+    };
+
+    let disconnect_reason: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+    let cfg = DebugConfig {
+        port: port.to_string(),
+        baud_rate: baud,
+        data_bits: DataBits::Eight,
+        parity: Parity::None,
+        stop_bits: StopBits::One,
+    };
+
+    let log_for_chunk = log_file.clone();
+    let on_chunk = Box::new(move |chunk: DebugChunk| {
+        let mut out = std::io::stdout();
+        let _ = out.write_all(&chunk.bytes);
+        let _ = out.flush();
+        if let Some(ref f) = log_for_chunk {
+            if let Ok(mut f) = f.lock() {
+                let _ = f.write_all(&chunk.bytes);
+                let _ = f.flush();
+            }
+        }
+    });
+
+    let disconnect_for_cb = Arc::clone(&disconnect_reason);
+    let on_disconnect = Box::new(move |reason: String| {
+        if let Ok(mut slot) = disconnect_for_cb.lock() {
+            slot.get_or_insert(reason);
+        }
+    });
+
+    let session = SerialDebugSession::open(cfg, on_chunk, on_disconnect)
+        .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
+
+    eprintln!(
+        "--- Monitor {} {} baud --- Quit: Ctrl+] or Ctrl+C ---",
+        port, baud
+    );
+    if let Some(p) = log_path {
+        eprintln!("--- Log file: {} ---", p);
+    }
+
+    // stdin → serial. Interactive terminal: read raw keys so Ctrl+] can be
+    // caught, forwarding each key's bytes immediately (device echoes them).
+    // Non-terminal stdin (pipe/CI): forward complete lines as `line\r\n`;
+    // on EOF the thread exits and the monitor continues read-only.
+    //
+    // The thread parks on stdin and is torn down with the process on quit.
+    // Like miniterm, a disconnect-initiated exit can leave one raw-mode key
+    // read pending; the console crate restores the terminal per read, so only
+    // that final pending read is affected.
+    let (input_tx, input_rx) = mpsc::channel::<Vec<u8>>();
+    if std::io::stdin().is_terminal() {
+        let cancel_for_stdin = Arc::clone(cancel);
+        std::thread::spawn(move || {
+            let term = Term::stdout();
+            loop {
+                if cancel_for_stdin.load(Ordering::Relaxed) {
+                    break;
+                }
+                // read_key_raw returns Key::CtrlC instead of raising SIGINT,
+                // so both quit keys funnel through KeyAction::Quit.
+                match term.read_key_raw() {
+                    Ok(key) => match key_action(key) {
+                        KeyAction::Quit => {
+                            cancel_for_stdin.store(true, Ordering::SeqCst);
+                            break;
+                        }
+                        KeyAction::Send(bytes) => {
+                            if input_tx.send(bytes).is_err() {
+                                break;
+                            }
+                        }
+                        KeyAction::Ignore => {}
+                    },
+                    Err(_) => break,
+                }
+            }
+        });
+    } else {
+        std::thread::spawn(move || {
+            let stdin = std::io::stdin();
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match stdin.read_line(&mut line) {
+                    Ok(0) | Err(_) => break, // EOF or read error
+                    Ok(_) => {
+                        let trimmed = line.trim_end_matches(['\r', '\n']);
+                        let bytes = format!("{}\r\n", trimmed).into_bytes();
+                        if input_tx.send(bytes).is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    loop {
+        if cancel.load(Ordering::Relaxed) {
+            break;
+        }
+        let reason = disconnect_reason.lock().ok().and_then(|mut s| s.take());
+        if let Some(reason) = reason {
+            // Mirror cli_monitor.py: report the disconnect and exit cleanly.
+            eprintln!();
+            eprintln!(
+                "--- Monitor stopped: serial port {} disconnected or unavailable. ---",
+                port
+            );
+            let detail = reason.trim();
+            if !detail.is_empty() {
+                eprintln!("--- Detail: {} ---", detail);
+            }
+            return Ok(());
+        }
+        while let Ok(bytes) = input_rx.try_recv() {
+            if let Err(e) = session.write(&bytes) {
+                log::warn!("[monitor] stdin forward failed: {}", e);
+            }
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    session.close();
+    eprintln!();
+    eprintln!("--- Monitor stopped ---");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ctrl_rbracket_and_ctrl_c_quit() {
+        assert_eq!(key_action(Key::Char(CTRL_RBRACKET)), KeyAction::Quit);
+        assert_eq!(key_action(Key::CtrlC), KeyAction::Quit);
+    }
+
+    #[test]
+    fn enter_sends_crlf() {
+        assert_eq!(key_action(Key::Enter), KeyAction::Send(b"\r\n".to_vec()));
+    }
+
+    #[test]
+    fn printable_chars_send_utf8_bytes() {
+        assert_eq!(key_action(Key::Char('a')), KeyAction::Send(b"a".to_vec()));
+        assert_eq!(
+            key_action(Key::Char('中')),
+            KeyAction::Send("中".as_bytes().to_vec())
+        );
+    }
+
+    #[test]
+    fn tab_and_backspace_send_control_bytes() {
+        assert_eq!(key_action(Key::Tab), KeyAction::Send(b"\t".to_vec()));
+        assert_eq!(
+            key_action(Key::Backspace),
+            KeyAction::Send(b"\x08".to_vec())
+        );
+    }
+
+    #[test]
+    fn unmapped_keys_are_ignored() {
+        assert_eq!(key_action(Key::ArrowUp), KeyAction::Ignore);
+        assert_eq!(key_action(Key::Escape), KeyAction::Ignore);
+        assert_eq!(key_action(Key::Home), KeyAction::Ignore);
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -123,10 +123,48 @@ tyutool reset [-p <PORT>] [-d <DEVICE>]
 
 ---
 
-### `authorize` — TuyaOpen device authorization
+### `monitor` — Live serial monitor
+
+```
+tyutool monitor [-p <PORT>] [-b <BAUD>] [-d <DEVICE>] [-l <FILE>]
+```
+
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--port` | `-p` | Serial port | auto-detect |
+| `--baud` | `-b` | UART baud rate | chip-specific monitor baud (see below) |
+| `--device` | `-d` | Chip name — selects the default monitor baud | none |
+| `--log` | `-l` | Append received data to this file | off |
+
+Streams raw device output to stdout. On an interactive terminal, keystrokes
+are forwarded to the device as you type (the device echoes them), so the
+TuyaOpen interactive shell (`tuya>`) can be driven from the monitor. Quit with
+`Ctrl+]` (miniterm-compatible) or `Ctrl+C`.
+
+When stdin is not a terminal (pipe/CI), input is forwarded line-by-line
+terminated with `\r\n` instead, and `Ctrl+C` is the only quit key.
+
+The default monitor baud rate is **460800** for `t5ai` (alias `t5`) and
+**115200** for every other chip or when `-d` is omitted. Note this differs from
+the flash baud defaults used by `write`/`read`/`erase`.
+
+If the device is unplugged while monitoring, the monitor reports the
+disconnect and exits cleanly (exit code `0`).
+
+**Examples:**
+```bash
+tyutool monitor                          # auto-detect port, 115200 baud
+tyutool monitor -p /dev/ttyUSB0 -d t5ai  # T5AI default baud (460800)
+tyutool monitor -p COM3 -l device.log    # tee received data to a file
+```
+
+---
+
+### `authorize` (alias: `auth`) — TuyaOpen device authorization
 
 ```
 tyutool authorize [-p <PORT>] [-d <DEVICE>] [--uuid <UUID>] [--authkey <AUTHKEY>]
+tyutool auth      [-p <PORT>] [-d <DEVICE>] [--uuid <UUID>] [--authkey <AUTHKEY>]
 ```
 
 | Flag | Description |
@@ -137,6 +175,8 @@ tyutool authorize [-p <PORT>] [-d <DEVICE>] [--uuid <UUID>] [--authkey <AUTHKEY>
 | `--authkey` | AuthKey to write (omit to read only) |
 
 To write authorization you must pass **both** `--uuid` and `--authkey`. Passing only one is rejected with an error. Passing neither performs a read-only `auth-read`.
+
+Credentials are always stored in **KV storage** — this command never burns OTP/eFuse. (OTP storage is exclusively a batch-flow feature in the GUI.)
 
 **Read current auth state:**
 ```bash
@@ -251,4 +291,4 @@ Flash OK  3.2s
 
 Exit code `0` on success, non-zero on failure or cancellation.
 
-**Cancellation:** during `write`, `read`, `erase`, or `authorize`, pressing `Ctrl+C` sets a cancellation flag so the job unwinds gracefully (closes the serial port and reports `Cancelled`) instead of the process being killed mid-transfer.
+**Cancellation:** during `write`, `read`, `erase`, or `authorize`, pressing `Ctrl+C` sets a cancellation flag so the job unwinds gracefully (closes the serial port and reports `Cancelled`) instead of the process being killed mid-transfer. For `monitor`, `Ctrl+]` or `Ctrl+C` is the normal way to quit and exits with code `0`.

--- a/docs/usage-guide/en/cli.html
+++ b/docs/usage-guide/en/cli.html
@@ -58,7 +58,7 @@
       <p><strong>Port selection</strong> (commands that take <code>-p/--port</code>): when <code>-p</code> is omitted, a <strong>single</strong> available port is used automatically. If <strong>multiple</strong> ports are present, you are prompted to choose one on an interactive terminal; in a non-interactive context (CI, pipe) the command errors and asks you to pass <code>-p</code> explicitly.</p>
 
       <h2 id="subcommands">4. Subcommands</h2>
-      <p>The 10 subcommands below are listed in logical order. Each has: a usage line (<code>&lt;pre&gt;</code>), a flag table (<code>&lt;table&gt;</code>), and an example (<code>&lt;pre&gt;</code>). Flags and defaults are identical to <code>docs/cli.md</code>.</p>
+      <p>The 11 subcommands below are listed in logical order. Each has: a usage line (<code>&lt;pre&gt;</code>), a flag table (<code>&lt;table&gt;</code>), and an example (<code>&lt;pre&gt;</code>). Flags and defaults are identical to <code>docs/cli.md</code>.</p>
 
       <h3 id="cmd-write"><code>write</code> — Flash firmware to device</h3>
       <pre>tyutool write -d &lt;DEVICE&gt; -f &lt;FILE&gt; [-p &lt;PORT&gt;] [-b &lt;BAUD&gt;] [-s &lt;START&gt;] [--end &lt;END&gt;]</pre>
@@ -139,8 +139,31 @@
 
       <hr>
 
-      <h3 id="cmd-authorize"><code>authorize</code> — TuyaOpen device authorization</h3>
-      <pre>tyutool authorize [-p &lt;PORT&gt;] [-d &lt;DEVICE&gt;] [--uuid &lt;UUID&gt;] [--authkey &lt;AUTHKEY&gt;]</pre>
+      <h3 id="cmd-monitor"><code>monitor</code> — Live serial monitor</h3>
+      <pre>tyutool monitor [-p &lt;PORT&gt;] [-b &lt;BAUD&gt;] [-d &lt;DEVICE&gt;] [-l &lt;FILE&gt;]</pre>
+      <table>
+        <thead><tr><th>Flag</th><th>Short</th><th>Description</th><th>Default</th></tr></thead>
+        <tbody>
+          <tr><td><code>--port</code></td><td><code>-p</code></td><td>Serial port</td><td>auto-detect</td></tr>
+          <tr><td><code>--baud</code></td><td><code>-b</code></td><td>UART baud rate</td><td>chip-specific monitor baud (see below)</td></tr>
+          <tr><td><code>--device</code></td><td><code>-d</code></td><td>Chip name — selects the default monitor baud</td><td>none</td></tr>
+          <tr><td><code>--log</code></td><td><code>-l</code></td><td>Append received data to this file</td><td>off</td></tr>
+        </tbody>
+      </table>
+      <p>Streams raw device output to stdout. On an interactive terminal, keystrokes are forwarded to the device as you type (the device echoes them), so the TuyaOpen interactive shell (<code>tuya&gt;</code>) can be driven from the monitor. Quit with <code>Ctrl+]</code> (miniterm-compatible) or <code>Ctrl+C</code>.</p>
+      <p>When stdin is not a terminal (pipe/CI), input is forwarded line-by-line terminated with <code>\r\n</code> instead, and <code>Ctrl+C</code> is the only quit key.</p>
+      <p>The default monitor baud rate is <strong>460800</strong> for <code>t5ai</code> (alias <code>t5</code>) and <strong>115200</strong> for every other chip or when <code>-d</code> is omitted. Note this differs from the flash baud defaults used by <code>write</code>/<code>read</code>/<code>erase</code>.</p>
+      <p>If the device is unplugged while monitoring, the monitor reports the disconnect and exits cleanly (exit code <code>0</code>).</p>
+      <p><strong>Examples:</strong></p>
+      <pre>tyutool monitor                          # auto-detect port, 115200 baud
+tyutool monitor -p /dev/ttyUSB0 -d t5ai  # T5AI default baud (460800)
+tyutool monitor -p COM3 -l device.log    # tee received data to a file</pre>
+
+      <hr>
+
+      <h3 id="cmd-authorize"><code>authorize</code> (alias: <code>auth</code>) — TuyaOpen device authorization</h3>
+      <pre>tyutool authorize [-p &lt;PORT&gt;] [-d &lt;DEVICE&gt;] [--uuid &lt;UUID&gt;] [--authkey &lt;AUTHKEY&gt;]
+tyutool auth      [-p &lt;PORT&gt;] [-d &lt;DEVICE&gt;] [--uuid &lt;UUID&gt;] [--authkey &lt;AUTHKEY&gt;]</pre>
       <table>
         <thead><tr><th>Flag</th><th>Description</th></tr></thead>
         <tbody>
@@ -151,6 +174,7 @@
         </tbody>
       </table>
       <p>To write authorization you must pass <strong>both</strong> <code>--uuid</code> and <code>--authkey</code>. Passing only one is rejected with an error. Passing neither performs a read-only <code>auth-read</code>.</p>
+      <p>Credentials are always stored in <strong>KV storage</strong> — this command never burns OTP/eFuse. (OTP storage is exclusively a batch-flow feature in the GUI.)</p>
       <p><strong>Read current auth state:</strong></p>
       <pre>tyutool authorize -p /dev/ttyUSB0
 tyutool authorize -p /dev/ttyUSB0 -d esp32</pre>
@@ -235,7 +259,7 @@ Flash OK  3.2s</pre>
       <p>Exit code <code>0</code> on success, non-zero on failure or cancellation.</p>
       <div class="callout note">
         <span class="title">Cancellation</span>
-        During <code>write</code>, <code>read</code>, <code>erase</code>, or <code>authorize</code>, pressing <code>Ctrl+C</code> sets a cancellation flag so the job <strong>unwinds gracefully</strong> (closes the serial port and reports <code>Cancelled</code>) instead of the process being killed mid-transfer.
+        During <code>write</code>, <code>read</code>, <code>erase</code>, or <code>authorize</code>, pressing <code>Ctrl+C</code> sets a cancellation flag so the job <strong>unwinds gracefully</strong> (closes the serial port and reports <code>Cancelled</code>) instead of the process being killed mid-transfer. For <code>monitor</code>, <code>Ctrl+]</code> or <code>Ctrl+C</code> is the normal way to quit and exits with code <code>0</code>.
       </div>
 
       <h2 id="developer-reference">7. Developer reference</h2>

--- a/docs/usage-guide/zh/cli.html
+++ b/docs/usage-guide/zh/cli.html
@@ -58,7 +58,7 @@
       <p><strong>端口选择</strong>（带 <code>-p/--port</code> 的命令）：省略 <code>-p</code> 时，若只有<strong>一个</strong>可用端口，会自动使用它；若存在<strong>多个</strong>端口，在交互式终端上会提示你选择一个，而在非交互环境（CI、管道）下命令会报错并要求你显式传 <code>-p</code>。</p>
 
       <h2 id="subcommands">4. 子命令</h2>
-      <p>下列 10 个子命令按字母/逻辑顺序给出。每个子命令含：用法行（<code>&lt;pre&gt;</code>）、参数表（<code>&lt;table&gt;</code>）、示例（<code>&lt;pre&gt;</code>）。参数与默认值与 <code>docs/cli.md</code> 完全一致。</p>
+      <p>下列 11 个子命令按字母/逻辑顺序给出。每个子命令含：用法行（<code>&lt;pre&gt;</code>）、参数表（<code>&lt;table&gt;</code>）、示例（<code>&lt;pre&gt;</code>）。参数与默认值与 <code>docs/cli.md</code> 完全一致。</p>
 
       <h3 id="cmd-write"><code>write</code> — 烧录固件到设备</h3>
       <pre>tyutool write -d &lt;DEVICE&gt; -f &lt;FILE&gt; [-p &lt;PORT&gt;] [-b &lt;BAUD&gt;] [-s &lt;START&gt;] [--end &lt;END&gt;]</pre>
@@ -139,8 +139,31 @@
 
       <hr>
 
-      <h3 id="cmd-authorize"><code>authorize</code> — TuyaOpen 设备授权</h3>
-      <pre>tyutool authorize [-p &lt;PORT&gt;] [-d &lt;DEVICE&gt;] [--uuid &lt;UUID&gt;] [--authkey &lt;AUTHKEY&gt;]</pre>
+      <h3 id="cmd-monitor"><code>monitor</code> — 实时串口监视</h3>
+      <pre>tyutool monitor [-p &lt;PORT&gt;] [-b &lt;BAUD&gt;] [-d &lt;DEVICE&gt;] [-l &lt;FILE&gt;]</pre>
+      <table>
+        <thead><tr><th>参数</th><th>简写</th><th>说明</th><th>默认值</th></tr></thead>
+        <tbody>
+          <tr><td><code>--port</code></td><td><code>-p</code></td><td>串口</td><td>自动检测</td></tr>
+          <tr><td><code>--baud</code></td><td><code>-b</code></td><td>UART 波特率</td><td>按芯片而定的监视波特率（见下文）</td></tr>
+          <tr><td><code>--device</code></td><td><code>-d</code></td><td>芯片名——决定默认监视波特率</td><td>无</td></tr>
+          <tr><td><code>--log</code></td><td><code>-l</code></td><td>把接收到的数据追加写入该文件</td><td>关闭</td></tr>
+        </tbody>
+      </table>
+      <p>将设备原始输出实时透传到 stdout。在交互式终端上，键入的按键会即时转发给设备（由设备回显），因此可以直接在监视器里操作 TuyaOpen 交互 shell（<code>tuya&gt;</code>）。按 <code>Ctrl+]</code>（与 miniterm 一致）或 <code>Ctrl+C</code> 退出。</p>
+      <p>当 stdin 不是终端（管道/CI）时，输入改为按行转发（行尾补 <code>\r\n</code>），此时只能用 <code>Ctrl+C</code> 退出。</p>
+      <p>默认监视波特率：<code>t5ai</code>（别名 <code>t5</code>）为 <strong>460800</strong>，其他芯片或省略 <code>-d</code> 时为 <strong>115200</strong>。注意这与 <code>write</code>/<code>read</code>/<code>erase</code> 使用的烧录波特率默认值不同。</p>
+      <p>监视过程中设备被拔出时，监视器会报告断连并正常退出（退出码 <code>0</code>）。</p>
+      <p><strong>示例：</strong></p>
+      <pre>tyutool monitor                          # 自动检测端口，115200 波特率
+tyutool monitor -p /dev/ttyUSB0 -d t5ai  # T5AI 默认波特率（460800）
+tyutool monitor -p COM3 -l device.log    # 同时把接收数据写入文件</pre>
+
+      <hr>
+
+      <h3 id="cmd-authorize"><code>authorize</code>（别名：<code>auth</code>）— TuyaOpen 设备授权</h3>
+      <pre>tyutool authorize [-p &lt;PORT&gt;] [-d &lt;DEVICE&gt;] [--uuid &lt;UUID&gt;] [--authkey &lt;AUTHKEY&gt;]
+tyutool auth      [-p &lt;PORT&gt;] [-d &lt;DEVICE&gt;] [--uuid &lt;UUID&gt;] [--authkey &lt;AUTHKEY&gt;]</pre>
       <table>
         <thead><tr><th>参数</th><th>说明</th></tr></thead>
         <tbody>
@@ -151,6 +174,7 @@
         </tbody>
       </table>
       <p>写入授权时必须<strong>同时</strong>传 <code>--uuid</code> 和 <code>--authkey</code>。只传其中一个会被拒绝并报错。两者都不传则执行只读的 <code>auth-read</code>。</p>
+      <p>凭据始终写入 <strong>KV 存储</strong>——该命令绝不会烧写 OTP/eFuse。（OTP 存储仅在 GUI 的批量流程中提供。）</p>
       <p><strong>读取当前授权状态：</strong></p>
       <pre>tyutool authorize -p /dev/ttyUSB0
 tyutool authorize -p /dev/ttyUSB0 -d esp32</pre>
@@ -235,7 +259,7 @@ Flash OK  3.2s</pre>
       <p>成功退出码为 <code>0</code>，失败或取消时为非零。</p>
       <div class="callout note">
         <span class="title">取消（Cancellation）</span>
-        在 <code>write</code>、<code>read</code>、<code>erase</code> 或 <code>authorize</code> 期间按 <code>Ctrl+C</code>，会设置一个取消标志，使任务<strong>优雅退出</strong>（关闭串口并报告 <code>Cancelled</code>），而不是在传输中途把进程杀掉。
+        在 <code>write</code>、<code>read</code>、<code>erase</code> 或 <code>authorize</code> 期间按 <code>Ctrl+C</code>，会设置一个取消标志，使任务<strong>优雅退出</strong>（关闭串口并报告 <code>Cancelled</code>），而不是在传输中途把进程杀掉。对 <code>monitor</code> 而言，<code>Ctrl+]</code> 或 <code>Ctrl+C</code> 是正常的退出方式，退出码为 <code>0</code>。
       </div>
 
       <h2 id="developer-reference">7. 开发者参考</h2>


### PR DESCRIPTION
## Summary

- **`monitor`** — new live serial monitor subcommand, modeled on TuyaOpen `tools/cli_command/cli_monitor.py`, reusing `SerialDebugSession` from tyutool-core (no direct serialport usage in the CLI):
  - Raw device output streamed to stdout; optional `-l <file>` tee (append).
  - Interactive terminal: raw key reading (`console::Term::read_key_raw`), keystrokes forwarded char-by-char (device echoes, miniterm-style); quit with **Ctrl+]** (miniterm-compatible) or **Ctrl+C**.
  - Non-TTY stdin (pipe/CI): line-based forwarding (`line\r\n`), read-only after EOF.
  - Default baud matches `cli_monitor.py`: `t5ai` → 460800, others → 115200.
  - Clean disconnect handling (report + exit 0), mirroring `_FriendlyMiniterm`.
- **`auth`** — visible alias for the existing `authorize` subcommand; help text and docs now state it is **KV storage only** (single-device authorize never burns OTP/eFuse — already enforced in core).
- Docs: `docs/cli.md`, usage-guide `en/zh cli.html`, README/README_ZH CLI examples.

## Tests

- `cargo test -p tyutool-cli`: 64 passed (new: `key_action` mapping ×5, monitor flag parsing, `auth` alias parsing, monitor default baud); clippy clean.
- Hardware-tested on a T5AI board (CH342 dual UART):
  - `auth` read-empty → write → read-back verify, credentials match (KV).
  - `monitor` on the log UART @460800 captured full boot log after reset; ANSI passthrough clean.
  - stdin line-forward (`auth-read` via pipe) and `-l` tee verified; occupied-port error path clean.
  - Interactive mode (char forwarding, Ctrl+] and Ctrl+C quit) manually verified.