### PR TITLE
chore(release): v3.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 本项目所有重要变更记录于此 / All notable changes are documented here.
 
+## [3.2.6] - 2026-07-22
+
+### 新功能
+
+- `cli`：新增 `monitor` 命令——实时串口监视器，设备输出直达终端；交互终端下按键实时转发到设备，可直接驱动 TuyaOpen 交互 shell（`tuya>`）；支持 `-l` 将接收数据同步记录到文件；`Ctrl+]`（兼容 miniterm）或 `Ctrl+C` 退出；`t5ai` 默认波特率 460800，其余芯片 115200
+- `cli`：`authorize` 新增别名 `auth`；文档明确授权凭证始终写入 KV 存储，不会烧写 OTP/eFuse
+
+---
+
+### Features
+
+- `cli`: New `monitor` command — a live serial monitor streaming raw device output to the terminal; on interactive terminals keystrokes are forwarded to the device, so the TuyaOpen interactive shell (`tuya>`) can be driven directly; `-l` tees received data to a file; quit with `Ctrl+]` (miniterm-compatible) or `Ctrl+C`; default baud is 460800 for `t5ai` and 115200 for other chips
+- `cli`: `authorize` gains the visible alias `auth`; docs clarify that credentials are always stored in KV storage — this command never burns OTP/eFuse
+
 ## [3.2.5] - 2026-07-22
 
 ### 新功能

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5874,7 +5874,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "tyutool-cli"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5906,7 +5906,7 @@ dependencies = [
 
 [[package]]
 name = "tyutool-core"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "crc32fast",
  "espflash",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "tyutool_gui"
-version = "3.2.5"
+version = "3.2.6"
 dependencies = [
  "calamine",
  "chrono",

--- a/crates/tyutool-cli/Cargo.toml
+++ b/crates/tyutool-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tyutool-cli"
-version = "3.2.5"
+version = "3.2.6"
 edition = "2021"
 description = "tyutool CLI — shared tyutool-core flash API (no Tauri)"
 

--- a/crates/tyutool-core/Cargo.toml
+++ b/crates/tyutool-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tyutool-core"
-version = "3.2.5"
+version = "3.2.6"
 edition = "2021"
 description = "Shared flash/erase plugin registry and serial helpers for tyutool CLI and GUI"
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tyutool",
   "private": true,
-  "version": "3.2.5",
+  "version": "3.2.6",
   "type": "module",
   "scripts": {
     "clean": "node -e \"try { require('fs').rmSync('dist', { recursive: true, force: true }); } catch (e) { if (e && e.code !== 'ENOENT') throw e; }\"",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tyutool_gui"
-version = "3.2.5"
+version = "3.2.6"
 description = "tyutool — Tauri shell for tyutool-core (firmware / serial tooling)"
 authors = ["tyutool contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tyutool",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "identifier": "com.tyutool.desktop",
   "build": {
     "beforeDevCommand": "pnpm run dev",


### PR DESCRIPTION
Release bump to 3.2.6. After merge, tag v3.2.6 on refactor/v3 to trigger release CI.

## Changes since v3.2.5

- `cli`: new `monitor` command (live serial monitor) and `auth` alias for `authorize` (34ba42f)