### PR TITLE
fix(serial-debug): fallback level colors for RX lines without ANSI

### DIFF
--- a/src/features/serial-debug/log-line-renderer.test.ts
+++ b/src/features/serial-debug/log-line-renderer.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import type { AnsiSpan } from "./ansi-parse";
 import type { DebugLogLine } from "./types";
 
 const { parseAnsiMock, stripAnsiMock } = vi.hoisted(() => ({
-  parseAnsiMock: vi.fn((text: string) => [{ text, style: { fg: "#f00" } }]),
+  parseAnsiMock: vi.fn((text: string): AnsiSpan[] => [
+    { text, style: { fg: "#f00" } },
+  ]),
   stripAnsiMock: vi.fn((text: string) => text.replace(/\x1b\[[0-9;]*m/g, "")),
 }));
 

--- a/src/features/serial-debug/log-line-renderer.test.ts
+++ b/src/features/serial-debug/log-line-renderer.test.ts
@@ -14,10 +14,14 @@ vi.mock("./ansi-parse", () => ({
 
 import { SerialDebugLogLineRenderer } from "./log-line-renderer";
 
-function line(id: number, text: string): DebugLogLine {
+function line(
+  id: number,
+  text: string,
+  direction: DebugLogLine["direction"] = "rx",
+): DebugLogLine {
   return {
     id,
-    direction: "rx",
+    direction,
     tsMs: id,
     text,
     rawBytes: new Uint8Array(),
@@ -46,5 +50,65 @@ describe("SerialDebugLogLineRenderer", () => {
 
     renderer.render([line(2, "two")], true, "");
     expect(renderer.cacheSize()).toBe(1);
+  });
+
+  describe("level-prefix fallback colors (no ANSI fg)", () => {
+    function mockPlainSpans(): void {
+      parseAnsiMock.mockImplementationOnce((text: string) => [
+        { text, style: {} },
+      ]);
+    }
+
+    it.each([
+      ["E (1745000) Example: operation failed", "var(--ty-danger)"],
+      ["W (1745097) VoiceChatActions: idle timeout", "var(--ty-accent)"],
+      ["I (1745106) SpaxSR: wake word enabled", "var(--ty-success)"],
+      ["D (1745200) Example: debug detail", "var(--ty-primary)"],
+      ["V (1745300) Example: verbose detail", "var(--ty-text-muted)"],
+    ])("colors RX line %s with fallback fg", (text, expectedFg) => {
+      mockPlainSpans();
+      const renderer = new SerialDebugLogLineRenderer();
+      const [view] = renderer.render([line(1, text)], true, "");
+      expect(view.spans).toHaveLength(1);
+      expect(view.spans[0].style.fg).toBe(expectedFg);
+    });
+
+    it("keeps device-provided ANSI fg untouched", () => {
+      // default parseAnsi mock returns fg: '#f00'
+      const renderer = new SerialDebugLogLineRenderer();
+      const [view] = renderer.render(
+        [line(1, "I (1) Tag: already colored")],
+        true,
+        "",
+      );
+      expect(view.spans[0].style.fg).toBe("#f00");
+    });
+
+    it("does not infer colors for tx or sys lines", () => {
+      mockPlainSpans();
+      mockPlainSpans();
+      const renderer = new SerialDebugLogLineRenderer();
+      const views = renderer.render(
+        [line(1, "E (1) Tag: sent", "tx"), line(2, "E (2) Tag: note", "sys")],
+        true,
+        "",
+      );
+      expect(views[0].spans[0].style.fg).toBeUndefined();
+      expect(views[1].spans[0].style.fg).toBeUndefined();
+    });
+
+    it("leaves RX lines without a level prefix uncolored", () => {
+      mockPlainSpans();
+      const renderer = new SerialDebugLogLineRenderer();
+      const [view] = renderer.render([line(1, "plain output")], true, "");
+      expect(view.spans[0].style.fg).toBeUndefined();
+    });
+
+    it("does not apply fallback when ANSI rendering is disabled", () => {
+      mockPlainSpans();
+      const renderer = new SerialDebugLogLineRenderer();
+      const [view] = renderer.render([line(1, "E (1) Tag: failed")], false, "");
+      expect(view.spans[0].style.fg).toBeUndefined();
+    });
   });
 });

--- a/src/features/serial-debug/log-line-renderer.ts
+++ b/src/features/serial-debug/log-line-renderer.ts
@@ -37,6 +37,33 @@ type CachedLineBase = {
   lastRendered?: CachedRenderedLine;
 };
 
+// Theme-aware fallback colors for RX lines whose ESP-IDF/Tuya level prefix
+// (`E (...)`, `W (...)`, ...) carries no ANSI foreground color (issue #110).
+const LEVEL_PREFIX_RE = /^([EWIDV]) \(/;
+const LEVEL_FALLBACK_FG: Record<string, string> = {
+  E: "var(--ty-danger)",
+  W: "var(--ty-accent)",
+  I: "var(--ty-success)",
+  D: "var(--ty-primary)",
+  V: "var(--ty-text-muted)",
+};
+
+function applyLevelFallback(
+  line: DebugLogLine,
+  plainText: string,
+  spans: AnsiSpan[],
+): AnsiSpan[] {
+  if (line.direction !== "rx") return spans;
+  if (spans.some((span) => span.style.fg)) return spans;
+  const match = LEVEL_PREFIX_RE.exec(plainText);
+  if (!match) return spans;
+  const fg = LEVEL_FALLBACK_FG[match[1]];
+  return spans.map((span) => ({
+    text: span.text,
+    style: { ...span.style, fg },
+  }));
+}
+
 function splitByKeyword(
   text: string,
   searchQuery: string,
@@ -137,7 +164,7 @@ export class SerialDebugLogLineRenderer {
     existing = {
       plainText,
       lowerPlainText: plainText.toLowerCase(),
-      ansiSpans: parseAnsi(line.text),
+      ansiSpans: applyLevelFallback(line, plainText, parseAnsi(line.text)),
       plainSpans: [{ text: plainText, style: {} }],
     };
     this.baseByLineId.set(line.id, existing);


### PR DESCRIPTION
## Summary

Fixes #110.

Many ESP32 firmware builds emit plain ESP-IDF level prefixes (`E (...)`, `W (...)`, `I (...)`, `D (...)`, `V (...)`) without ANSI SGR sequences, so the serial-debug renderer — which only derives colors from ANSI — displayed every RX line in the default color.

When an RX line has **no ANSI foreground color**, the log-line renderer now infers a theme-aware fallback from the level prefix:

| Prefix | Color |
|--------|-------|
| `E (` | `var(--ty-danger)` |
| `W (` | `var(--ty-accent)` |
| `I (` | `var(--ty-success)` |
| `D (` | `var(--ty-primary)` |
| `V (` | `var(--ty-text-muted)` |

Design decisions (per issue expectations):

- Device-provided ANSI colors always win — fallback applies only when the parsed spans carry no `fg`.
- Only RX lines are inferred; TX and system lines are untouched.
- Fallback lives on the `ansiSpans` path, so turning off ANSI rendering also turns off the fallback (consistent "no coloring" behavior).
- Hex view and exported/raw log text are unchanged (they use separate code paths).
- CSS theme variables make the colors follow all app themes automatically.

## Testing

- Added unit tests in `log-line-renderer.test.ts` covering all five prefixes, ANSI-color precedence, TX/SYS exclusion, non-prefixed lines, and the ANSI-disabled case.
- `pnpm run test`: 763 passed. `pnpm run lint`: clean.