### PR TITLE
feat(update): honor selected source for in-app updates via per-source endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-store": "^2.4.2",
-    "@tauri-apps/plugin-updater": "^2.10.0",
     "pinia": "^3.0.4",
     "vue": "^3.5.13",
     "vue-i18n": "^9.14.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       '@tauri-apps/plugin-store':
         specifier: ^2.4.2
         version: 2.4.2
-      '@tauri-apps/plugin-updater':
-        specifier: ^2.10.0
-        version: 2.10.0
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@5.6.3)(vue@3.5.31(typescript@5.6.3))
@@ -965,9 +962,6 @@ packages:
 
   '@tauri-apps/plugin-store@2.4.2':
     resolution: {integrity: sha512-0ClHS50Oq9HEvLPhNzTNFxbWVOqoAp3dRvtewQBeqfIQ0z5m3JRnOISIn2ZVPCrQC0MyGyhTS9DWhHjpigQE7A==}
-
-  '@tauri-apps/plugin-updater@2.10.0':
-    resolution: {integrity: sha512-ljN8jPlnT0aSn8ecYhuBib84alxfMx6Hc8vJSKMJyzGbTPFZAC44T2I1QNFZssgWKrAlofvJqCC6Rr472JWfkQ==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -2712,10 +2706,6 @@ snapshots:
       '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-store@2.4.2':
-    dependencies:
-      '@tauri-apps/api': 2.10.1
-
-  '@tauri-apps/plugin-updater@2.10.0':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -17,9 +17,6 @@
     "store:allow-set",
     "store:allow-save",
     "store:allow-load",
-    "updater:allow-check",
-    "updater:allow-download",
-    "updater:allow-install",
     "process:allow-exit",
     "process:allow-restart",
     "log:default"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1768,7 +1768,8 @@ async fn fetch_url(url: String, timeout_ms: u64) -> Result<String, String> {
 }
 
 /// Update-manifest endpoint per source id.
-/// Mirrors UPDATE_SOURCES in src/features/settings/update-sources.ts — keep in sync.
+/// Mirrors UPDATE_SOURCES in src/features/settings/update-sources.ts and the
+/// fallback `plugins.updater.endpoints` list in tauri.conf.json — keep in sync.
 fn update_endpoint(source: &str) -> Option<&'static str> {
     match source {
         "github" => Some("https://github.com/tuya/tyutool/releases/latest/download/latest.json"),
@@ -3551,6 +3552,23 @@ mod tests {
         )
         .unwrap();
         assert!(!cfg.authorize_enabled);
+    }
+
+    #[test]
+    fn update_endpoint_maps_known_sources_and_rejects_unknown() {
+        assert_eq!(
+            update_endpoint("github"),
+            Some("https://github.com/tuya/tyutool/releases/latest/download/latest.json")
+        );
+        // "pruduct" is the actual key spelling on the Tuya OSS bucket — do not fix.
+        assert_eq!(
+            update_endpoint("tuya"),
+            Some(
+                "https://airtake-public-data-1254153901.cos.ap-shanghai.myqcloud.com/smart/embed/pruduct/tyutool/latest/release.json"
+            )
+        );
+        assert_eq!(update_endpoint("gitee"), None);
+        assert_eq!(update_endpoint(""), None);
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,6 +58,17 @@ struct BatchAuthState {
     session: Arc<StdMutex<AllocatorSession>>,
 }
 
+/// In-app update staged by `update_check`, downloaded by `update_download`,
+/// consumed by `update_install`.
+struct UpdateState {
+    pending: StdMutex<Option<PendingUpdate>>,
+}
+
+struct PendingUpdate {
+    update: tauri_plugin_updater::Update,
+    bytes: Option<Vec<u8>>,
+}
+
 /// Excel allocator + count of slot threads using it, guarded by ONE mutex so
 /// acquire (batch_auth_start) and release (last SlotSessionGuard drop) can
 /// never interleave. Invariant: `alloc.is_some() ⇒ active > 0` — the file
@@ -1756,6 +1767,186 @@ async fn fetch_url(url: String, timeout_ms: u64) -> Result<String, String> {
     Ok(body)
 }
 
+/// Update-manifest endpoint per source id.
+/// Mirrors UPDATE_SOURCES in src/features/settings/update-sources.ts — keep in sync.
+fn update_endpoint(source: &str) -> Option<&'static str> {
+    match source {
+        "github" => Some("https://github.com/tuya/tyutool/releases/latest/download/latest.json"),
+        // "pruduct" is the actual key spelling on the Tuya OSS bucket — do not fix.
+        "tuya" => Some(
+            "https://airtake-public-data-1254153901.cos.ap-shanghai.myqcloud.com/smart/embed/pruduct/tyutool/latest/release.json",
+        ),
+        _ => None,
+    }
+}
+
+// Mirrored by UpdateCheckReply in src/features/settings/in-app-updater.ts
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateCheckReply {
+    available: bool,
+    version: String,
+    current_version: String,
+    date: Option<String>,
+    body: Option<String>,
+}
+
+// Mirrored by UpdateDownloadEvent in src/features/settings/in-app-updater.ts
+#[derive(Clone, Serialize)]
+#[serde(tag = "event", content = "data", rename_all_fields = "camelCase")]
+enum UpdateDownloadEvent {
+    Started { content_length: Option<u64> },
+    Progress { chunk_length: usize },
+    Finished,
+}
+
+/// Check for an update against the manifest endpoint of the given source
+/// ("github" or "tuya"), staging the result for `update_download`. Unlike the
+/// plugin's JS `check()`, which always walks the static endpoint list in
+/// tauri.conf.json (GitHub first), this honors the source the user picked.
+#[tauri::command]
+async fn update_check(
+    app: AppHandle,
+    state: State<'_, UpdateState>,
+    source: String,
+) -> Result<UpdateCheckReply, String> {
+    use tauri_plugin_updater::UpdaterExt;
+
+    let endpoint =
+        update_endpoint(&source).ok_or_else(|| format!("unknown update source: {}", source))?;
+    log::info!(
+        "[Update] update_check: source={}, endpoint={}",
+        source,
+        endpoint
+    );
+    let url = endpoint.parse::<tauri::Url>().map_err(|e| e.to_string())?;
+    let updater = app
+        .updater_builder()
+        .endpoints(vec![url])
+        .map_err(|e| e.to_string())?
+        .build()
+        .map_err(|e| e.to_string())?;
+    let update = updater.check().await.map_err(|e| {
+        log::warn!("[Update] update_check failed for source={}: {}", source, e);
+        e.to_string()
+    })?;
+    match update {
+        Some(update) => {
+            log::info!(
+                "[Update] update_check: available={} -> {} (source={}, download_url={})",
+                update.current_version,
+                update.version,
+                source,
+                update.download_url
+            );
+            let reply = UpdateCheckReply {
+                available: true,
+                version: update.version.clone(),
+                current_version: update.current_version.clone(),
+                date: update.date.map(|d| d.to_string()),
+                body: update.body.clone(),
+            };
+            *state.pending.lock().unwrap() = Some(PendingUpdate {
+                update,
+                bytes: None,
+            });
+            Ok(reply)
+        }
+        None => {
+            log::info!(
+                "[Update] update_check: already up to date (source={})",
+                source
+            );
+            *state.pending.lock().unwrap() = None;
+            Ok(UpdateCheckReply {
+                available: false,
+                version: String::new(),
+                current_version: app.package_info().version.to_string(),
+                date: None,
+                body: None,
+            })
+        }
+    }
+}
+
+/// Download the update staged by `update_check`, emitting
+/// `update-download-progress` events, and hold the bytes for `update_install`.
+#[tauri::command]
+async fn update_download(app: AppHandle, state: State<'_, UpdateState>) -> Result<(), String> {
+    let update = state
+        .pending
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|p| p.update.clone())
+        .ok_or("no pending update; call update_check first")?;
+
+    log::info!(
+        "[Update] update_download: starting, url={}",
+        update.download_url
+    );
+    let mut started = false;
+    let bytes = update
+        .download(
+            |chunk_length, content_length| {
+                if !started {
+                    started = true;
+                    let _ = app.emit(
+                        "update-download-progress",
+                        UpdateDownloadEvent::Started { content_length },
+                    );
+                }
+                let _ = app.emit(
+                    "update-download-progress",
+                    UpdateDownloadEvent::Progress { chunk_length },
+                );
+            },
+            || {
+                let _ = app.emit("update-download-progress", UpdateDownloadEvent::Finished);
+            },
+        )
+        .await
+        .map_err(|e| {
+            log::error!("[Update] update_download failed: {}", e);
+            e.to_string()
+        })?;
+    log::info!("[Update] update_download: downloaded {} bytes", bytes.len());
+    match state.pending.lock().unwrap().as_mut() {
+        Some(pending) => {
+            pending.bytes = Some(bytes);
+            Ok(())
+        }
+        None => Err("pending update was cleared during download".to_string()),
+    }
+}
+
+/// Install the update downloaded by `update_download`. On Windows this launches
+/// the installer and exits; the frontend relaunches via plugin-process after.
+/// The staged update is kept on failure (e.g. UAC denied) so install can be retried.
+#[tauri::command]
+async fn update_install(state: State<'_, UpdateState>) -> Result<(), String> {
+    let pending = state
+        .pending
+        .lock()
+        .unwrap()
+        .take()
+        .ok_or("no pending update; call update_check first")?;
+    let Some(bytes) = pending.bytes.as_ref() else {
+        *state.pending.lock().unwrap() = Some(pending);
+        return Err("update not downloaded; call update_download first".to_string());
+    };
+    log::info!("[Update] update_install: installing {} bytes", bytes.len());
+    match pending.update.install(bytes) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            log::error!("[Update] update_install failed: {}", e);
+            let msg = e.to_string();
+            *state.pending.lock().unwrap() = Some(pending);
+            Err(msg)
+        }
+    }
+}
+
 /// Hex-encoded SHA-256 of the given bytes (lowercase).
 fn sha256_hex(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
@@ -3053,6 +3244,9 @@ pub fn run() {
         .manage(ConfirmState {
             sender: Arc::new(StdMutex::new(None)),
         })
+        .manage(UpdateState {
+            pending: StdMutex::new(None),
+        })
         .setup(|app| {
             let version = app.package_info().version.to_string();
             let install_type = detect_install_type();
@@ -3087,6 +3281,9 @@ pub fn run() {
             check_port_available_cmd,
             check_file_exists,
             fetch_url,
+            update_check,
+            update_download,
+            update_install,
             download_auth_firmware,
             get_install_type,
             set_log_level,

--- a/src/features/settings/UpdateDialog.vue
+++ b/src/features/settings/UpdateDialog.vue
@@ -9,6 +9,7 @@ import {
   fetchLatestJson,
   isNewerVersion,
 } from "./update-sources";
+import { updateCheck, updateDownload, updateInstall } from "./in-app-updater";
 import {
   deriveUpdateSourceAction,
   deriveUpdateSummaryState,
@@ -54,10 +55,6 @@ const downloadingSource = ref("");
 const downloadingVersion = ref("");
 const installing = ref(false);
 
-let pendingUpdate: Awaited<
-  ReturnType<typeof import("@tauri-apps/plugin-updater").check>
-> = null;
-
 const manualUpdateOnly = ref(false);
 const debRpmInstall = ref(false);
 const installTypeReady = ref(false);
@@ -80,7 +77,6 @@ function resetState(): void {
   downloadingSource.value = "";
   downloadingVersion.value = "";
   installing.value = false;
-  pendingUpdate = null;
   installTypeReady.value = false;
   manualUpdateOnly.value = false;
   debRpmInstall.value = false;
@@ -269,7 +265,6 @@ function sourceActionKind(source: SourceState): UpdateSourceActionKind {
     installTypeReady: installTypeReady.value,
     manualUpdateOnly: manualUpdateOnly.value,
     inAppUpdateSupported: inAppUpdateSupported.value,
-    primaryAvailableSourceId: primaryAvailableSource.value?.id ?? null,
   });
 }
 
@@ -351,30 +346,25 @@ async function startDownload(sourceState: SourceState): Promise<void> {
     await info(
       `[Update] startDownload: source=${sourceState.id}, version=${sourceState.version}`,
     );
-    const { check } = await import("@tauri-apps/plugin-updater");
-    const update = await check();
+    const update = await updateCheck(sourceState.id);
     await info(
-      `[Update] check() returned: available=${update?.available}, version=${update?.version}, currentVersion=${update?.currentVersion}`,
+      `[Update] update_check returned: available=${update.available}, version=${update.version}, currentVersion=${update.currentVersion}`,
     );
-    if (update) {
+    if (update.available) {
       await info(
         `[Update] update details: date=${update.date}, body=${update.body?.substring(0, 200)}`,
       );
-    }
-    if (!update?.available) {
-      await info("[Update] no update available from plugin-updater");
+    } else {
+      await info("[Update] no update available from update_check");
       downloading.value = false;
       return;
     }
 
-    await update.download((event) => {
+    await updateDownload((event) => {
       if (event.event === "Started") {
-        totalBytes.value =
-          (event.data as { contentLength?: number }).contentLength ?? 0;
+        totalBytes.value = event.data.contentLength ?? 0;
       } else if (event.event === "Progress") {
-        downloadedBytes.value += (
-          event.data as { chunkLength: number }
-        ).chunkLength;
+        downloadedBytes.value += event.data.chunkLength;
         if (totalBytes.value > 0) {
           downloadPercent.value = Math.round(
             (downloadedBytes.value / totalBytes.value) * 100,
@@ -385,7 +375,6 @@ async function startDownload(sourceState: SourceState): Promise<void> {
       }
     });
 
-    pendingUpdate = update;
     downloading.value = false;
     downloadReady.value = true;
     downloadPercent.value = 100;
@@ -407,9 +396,9 @@ async function restartNow(): Promise<void> {
 
   try {
     await info("[Update] restartNow: starting install...");
-    if (pendingUpdate) {
-      await pendingUpdate.install();
-      pendingUpdate = null;
+    if (downloadReady.value) {
+      await updateInstall();
+      downloadReady.value = false;
     }
     const { relaunch } = await import("@tauri-apps/plugin-process");
     await relaunch();

--- a/src/features/settings/in-app-updater.ts
+++ b/src/features/settings/in-app-updater.ts
@@ -19,7 +19,7 @@ export type UpdateDownloadEvent =
   | { event: "Progress"; data: { chunkLength: number } }
   | { event: "Finished" };
 
-export const UPDATE_DOWNLOAD_EVENT = "update-download-progress";
+const UPDATE_DOWNLOAD_EVENT = "update-download-progress";
 
 /** Check for an update against the manifest endpoint of the given source,
  *  staging the result Rust-side for {@link updateDownload}. */

--- a/src/features/settings/in-app-updater.ts
+++ b/src/features/settings/in-app-updater.ts
@@ -1,0 +1,56 @@
+// Tauri-only IPC wrappers for the per-source in-app updater. Unlike the
+// plugin-updater JS `check()`, which always walks the static endpoint list in
+// tauri.conf.json (GitHub first), these commands honor the source the user
+// picked, so "update from Tuya OSS" really downloads via the OSS mirror.
+import type { UpdateSource } from "./update-sources";
+
+// Mirrors UpdateCheckReply in src-tauri/src/lib.rs
+export interface UpdateCheckReply {
+  available: boolean;
+  version: string;
+  currentVersion: string;
+  date: string | null;
+  body: string | null;
+}
+
+// Mirrors UpdateDownloadEvent in src-tauri/src/lib.rs
+export type UpdateDownloadEvent =
+  | { event: "Started"; data: { contentLength: number | null } }
+  | { event: "Progress"; data: { chunkLength: number } }
+  | { event: "Finished" };
+
+export const UPDATE_DOWNLOAD_EVENT = "update-download-progress";
+
+/** Check for an update against the manifest endpoint of the given source,
+ *  staging the result Rust-side for {@link updateDownload}. */
+export async function updateCheck(
+  sourceId: UpdateSource["id"],
+): Promise<UpdateCheckReply> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<UpdateCheckReply>("update_check", { source: sourceId });
+}
+
+/** Download the staged update, forwarding progress events to `onEvent`.
+ *  The bytes stay Rust-side until {@link updateInstall}. */
+export async function updateDownload(
+  onEvent: (event: UpdateDownloadEvent) => void,
+): Promise<void> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  const { listen } = await import("@tauri-apps/api/event");
+  const unlisten = await listen<UpdateDownloadEvent>(
+    UPDATE_DOWNLOAD_EVENT,
+    (event) => onEvent(event.payload),
+  );
+  try {
+    await invoke("update_download");
+  } finally {
+    unlisten();
+  }
+}
+
+/** Install the downloaded update. On Windows this launches the installer;
+ *  the caller relaunches the app afterwards. */
+export async function updateInstall(): Promise<void> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  await invoke("update_install");
+}

--- a/src/features/settings/update-dialog-state.test.ts
+++ b/src/features/settings/update-dialog-state.test.ts
@@ -127,13 +127,12 @@ describe("deriveUpdateSourceAction", () => {
       installTypeReady: true,
       manualUpdateOnly: false,
       inAppUpdateSupported: true,
-      primaryAvailableSourceId: "github",
     });
 
     expect(result).toBe("download");
   });
 
-  it("falls back to the selected source release page for non-primary sources", () => {
+  it("uses in-app download for a non-primary available source on installed builds", () => {
     const result = deriveUpdateSourceAction({
       source: makeSourceState("available", { id: "tuya" }),
       summaryKind: "available",
@@ -141,10 +140,9 @@ describe("deriveUpdateSourceAction", () => {
       installTypeReady: true,
       manualUpdateOnly: false,
       inAppUpdateSupported: true,
-      primaryAvailableSourceId: "github",
     });
 
-    expect(result).toBe("manual");
+    expect(result).toBe("download");
   });
 
   it("uses the source release page when the install type only supports manual updates", () => {
@@ -155,7 +153,6 @@ describe("deriveUpdateSourceAction", () => {
       installTypeReady: true,
       manualUpdateOnly: true,
       inAppUpdateSupported: false,
-      primaryAvailableSourceId: "github",
     });
 
     expect(result).toBe("manual");
@@ -169,7 +166,6 @@ describe("deriveUpdateSourceAction", () => {
       installTypeReady: true,
       manualUpdateOnly: false,
       inAppUpdateSupported: true,
-      primaryAvailableSourceId: "github",
     });
 
     expect(result).toBe("none");

--- a/src/features/settings/update-dialog-state.ts
+++ b/src/features/settings/update-dialog-state.ts
@@ -137,7 +137,6 @@ export function deriveUpdateSourceAction(input: {
   installTypeReady: boolean;
   manualUpdateOnly: boolean;
   inAppUpdateSupported: boolean;
-  primaryAvailableSourceId: UpdateDialogSourceState["id"] | null;
 }): UpdateSourceActionKind {
   const {
     source,
@@ -146,7 +145,6 @@ export function deriveUpdateSourceAction(input: {
     installTypeReady,
     manualUpdateOnly,
     inAppUpdateSupported,
-    primaryAvailableSourceId,
   } = input;
 
   if (
@@ -162,7 +160,9 @@ export function deriveUpdateSourceAction(input: {
     return "manual";
   }
 
-  if (inAppUpdateSupported && primaryAvailableSourceId === source.id) {
+  // Installed builds in-app update from whichever source the user picked
+  // (update_check honors the source's endpoint Rust-side).
+  if (inAppUpdateSupported) {
     return "download";
   }
 

--- a/src/utils/install-type.ts
+++ b/src/utils/install-type.ts
@@ -48,7 +48,7 @@ export function canUseInAppUpdater(
 
 /**
  * Returns flags derived from `get_install_type` (cached).
- * `manualOnly` enables the same UX as portable: no plugin-updater download/install, releases-page flow.
+ * `manualOnly` enables the same UX as portable: no in-app download/install, releases-page flow.
  */
 export async function getManualUpdateFlags(): Promise<ManualUpdateFlags> {
   const raw = await resolveInstallType();


### PR DESCRIPTION
## 背景

安装版（NSIS）用户在更新弹窗点击 **Tuya OSS 源卡片的「从此源更新」** 时，下载到的是**便携版 zip** 而不是安装器（见日志排查：GitHub 与 OSS 同时 available 时，非 primary 源落入为便携版设计的 manual 分支）。且此前即使走 download 分支，`plugin-updater` 的 JS `check()` 也只会按 `tauri.conf.json` 里的静态 endpoint 列表（GitHub 优先）下载——用户选的源实际不生效。

## 改动

**Rust（src-tauri/src/lib.rs）**
- 新增 `update_check` / `update_download` / `update_install` 三个命令：用 `UpdaterBuilder::endpoints()` 按用户所选源（`github` / `tuya`）的 manifest endpoint 构建 updater，真正实现「从 Tuya OSS 应用内更新」（大陆网络直连 COS 镜像）
- 下载进度以 `update-download-progress` 事件流回前端（Started / Progress / Finished，与原 JS 插件事件形状一致）
- 已下载的更新暂存在 `UpdateState`；安装失败（如 Windows UAC 拒绝）时保留暂存，可重试
- `update_endpoint`（源 id → endpoint 映射）带单元测试，与 `update-sources.ts` 双向注释互指

**前端**
- 新增 `features/settings/in-app-updater.ts`：三个命令的 IPC 封装，类型镜像 Rust（含注释指向）
- `UpdateDialog.vue`：`startDownload` 改走 `update_check(source)` + `update_download`；`restartNow` 走 `update_install` + relaunch
- `deriveUpdateSourceAction`：安装版下**任意** available 源都返回 `download`（原来只有 primary 源，其余误入 manual/便携包分支）；便携版/deb-rpm 的 manual 流程不变
- 移除不再使用的 `@tauri-apps/plugin-updater` JS 依赖及 capabilities 中的 `updater:allow-*` 条目（Rust 插件保留注册，`updater_builder()` 依赖其托管状态）

## 验证

- `pnpm run build`（vue-tsc + vite）、`pnpm run lint`、`pnpm run test`（57 文件 / 754 用例）全部通过
- `cargo check -p tyutool_gui`、`cargo test -p tyutool_gui --lib`（57 用例）、`cargo fmt --all --check` 通过
- 双人格 review（正确性 + 约定）：正确性审查确认互斥锁不跨 await、serde 事件形状与 TS 联合类型逐字段一致、并发入口被 UI 状态机封死、安装失败重试路径完整、dev:web 模式不可达 Tauri 调用；约定审查的 4 项发现已全部处理