### PR TITLE
ci+docs: retire stale Gitee release guidance, true-mirror code sync, CI on refactor/v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, refactor/v3]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release-auth-firmware.yml
+++ b/.github/workflows/release-auth-firmware.yml
@@ -21,7 +21,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,3 @@
-# Self-hosted runner dependencies (must be pre-installed):
-#   jq curl python3 ca-certificates
-#
 name: Release
 
 on:

--- a/.github/workflows/sync-to-gitee.yml
+++ b/.github/workflows/sync-to-gitee.yml
@@ -25,5 +25,7 @@ jobs:
 
       - name: Push to Gitee
         run: |
-          git push gitee --all --force
-          git push gitee --tags --force
+          # 真镜像：以 origin 为准同步全部分支和 tag，--prune 会删除 Gitee 上已不存在的分支/tag
+          git remote set-head origin -d || true  # 移除 origin/HEAD 符号引用，避免被当作 HEAD 分支推送
+          git push gitee "+refs/remotes/origin/*:refs/heads/*" --prune
+          git push gitee "+refs/tags/*:refs/tags/*" --prune

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square)](LICENSE.txt)
 [![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-blue?style=flat-square)](https://github.com/tuya/tyutool/releases/latest)
 
+English | [简体中文](README_ZH.md)
+
 Firmware flash tool for Tuya-class IoT devices. Available as a cross-platform desktop GUI (Tauri 2 + Vue 3) and a standalone CLI binary.
 
 ## Supported Chips

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Firmware flash tool for Tuya-class IoT devices. Available as a cross-platform de
 
 ## Download
 
-Grab the latest release from [GitHub Releases](https://github.com/tuya/tyutool/releases/latest) or the [Gitee mirror](https://gitee.com/tuya-open/tyutool/releases).
+Grab the latest release from [GitHub Releases](https://github.com/tuya/tyutool/releases/latest). In mainland China, fetch the latest [`release.json`](https://airtake-public-data-1254153901.cos.ap-shanghai.myqcloud.com/smart/embed/pruduct/tyutool/latest/release.json) from the Tuya OSS mirror and download from each entry's `url` (see [Update Manifests](#update-manifests-latestjson--releasejson)).
 
 ### GUI
 
@@ -150,8 +150,8 @@ tyutool update --check
 # Update from GitHub (default)
 tyutool update
 
-# Update from Gitee mirror
-tyutool update --source gitee
+# Update from Tuya OSS mirror (mainland China)
+tyutool update --source tuya
 ```
 
 ### Verbose logging

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -4,6 +4,8 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square)](LICENSE.txt)
 [![Platform](https://img.shields.io/badge/平台-Linux%20%7C%20macOS%20%7C%20Windows-blue?style=flat-square)](https://github.com/tuya/tyutool/releases/latest)
 
+[English](README.md) | 简体中文
+
 涂鸦 IoT 设备固件烧录工具，提供跨平台桌面 GUI（Tauri 2 + Vue 3）和独立命令行（CLI）两种使用方式。
 
 ## 支持芯片

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -16,7 +16,7 @@
 
 ## 下载
 
-从 [GitHub Releases](https://github.com/tuya/tyutool/releases/latest) 或 [Gitee 镜像](https://gitee.com/tuya-open/tyutool/releases) 获取最新版本。
+从 [GitHub Releases](https://github.com/tuya/tyutool/releases/latest) 获取最新版本。中国大陆用户可从 Tuya OSS 镜像获取最新 [`release.json`](https://airtake-public-data-1254153901.cos.ap-shanghai.myqcloud.com/smart/embed/pruduct/tyutool/latest/release.json)，再按其中条目的 `url` 下载（参见[更新清单](#更新清单latestjson--releasejson)）。
 
 ### GUI 桌面版
 
@@ -150,8 +150,8 @@ tyutool update --check
 # 从 GitHub 升级（默认）
 tyutool update
 
-# 从 Gitee 镜像升级
-tyutool update --source gitee
+# 从 Tuya OSS 镜像升级（中国大陆）
+tyutool update --source tuya
 ```
 
 ### 详细日志

--- a/scripts/publish-auth-firmware-gitee.sh
+++ b/scripts/publish-auth-firmware-gitee.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # Idempotently publish auth-firmware assets to a Gitee Release (API v5).
 #
-# Unlike scripts/sync-gitee-release.sh (which wipes all attachments and re-uploads),
-# this preserves immutable firmware:
+# Preserves immutable firmware:
 #   - <name>.bin    : skip if an attachment with the same name already exists, else upload.
 #   - auth-firmware.json : delete the old attachment (if any), then upload (overwrite).
 #


### PR DESCRIPTION
## 背景

中国大陆的更新已切换到 Tuya OSS（`release.json` 固定入口），主发布产物早已不再同步到 Gitee。本 PR 清理由此产生的过时文档与 CI 遗留，并把 Gitee 代码同步改为真镜像。

**不新增** latest.json / release.json 推送到 Gitee；auth-firmware 的 Gitee 发布保持原样（前端大陆 fallback 仍依赖它）。

## 变更

### docs
- README / README_ZH：`tyutool update --source gitee` → `--source tuya`（CLI 早已不支持 gitee 源）
- README / README_ZH：下载章节不再指向已停更的 Gitee releases 页面，大陆用户改为从 Tuya OSS 获取 `release.json` 按条目 `url` 下载
- README / README_ZH：顶部新增中英互跳链接

### ci
- `ci.yml`：push 触发分支增加 `refactor/v3`，开发主线 merge commit 获得 post-merge CI
- `sync-to-gitee.yml`：改为真镜像 —— 从 `refs/remotes/origin/*` 带 `--prune` 推送分支与 tag，GitHub 上删除的分支/tag 会真正从 Gitee 移除（原 `push --all` 每次只推检出的单个本地分支且从不清理）
- `release.yml`：删除过时的 self-hosted runner 头部注释
- `release-auth-firmware.yml`：`checkout@v4` → `v6` 与其他 workflow 对齐
- `publish-auth-firmware-gitee.sh`：删除对已删除脚本 `sync-gitee-release.sh` 的注释引用

## 注意

`--prune` 首次生效时会删除 Gitee 镜像上所有 GitHub 不存在的分支/tag（真镜像语义）。若 Gitee 仓库上有手动建的分支会被清理。