### PR TITLE
fix(serial-debug): give filter-page lines unique display ids

### DIFF
--- a/src/features/serial-debug/components/SerialDebugLogView.vue
+++ b/src/features/serial-debug/components/SerialDebugLogView.vue
@@ -24,6 +24,7 @@ import { EXPORT_PAGE_SIZE } from "@/features/serial-debug/constants";
 import type {
   DebugLogLine,
   HexBytesPerRow,
+  SerialDebugLine,
 } from "@/features/serial-debug/types";
 import SerialDebugChipBar from "./SerialDebugChipBar.vue";
 
@@ -305,7 +306,7 @@ async function writeFile(
   URL.revokeObjectURL(url);
 }
 
-function formatExportLine(line: DebugLogLine): string {
+function formatExportLine(line: SerialDebugLine): string {
   const dir =
     line.direction === "tx" ? "TX " : line.direction === "rx" ? "RX " : "SYS";
   return `[${formatTs(line.tsMs)}] [${dir}] ${stripAnsi(line.text)}`;

--- a/src/features/serial-debug/types.ts
+++ b/src/features/serial-debug/types.ts
@@ -71,7 +71,29 @@ export interface SerialDebugFilterUpdatePayload {
   stats: SerialDebugFilterStats;
 }
 
+/**
+ * Mirrors `tyutool_core::serial_debug::SerialDebugLine` — one archive-backed
+ * line as returned by the paging commands. Archive lines are identified by
+ * `lineNo` (per session, starting at 1) and carry no display `id`; map them
+ * through `archiveLineToLogLine` before rendering.
+ */
+export interface SerialDebugLine {
+  lineNo: number;
+  tsMs: number;
+  direction: DebugLineDirection;
+  text: string;
+  rawBytes?: number[]; // Tauri/JSON deserializes Vec<u8> as a number[]
+}
+
 export interface SerialDebugFilterPage {
+  filterId: string;
+  totalMatches: number;
+  start: number;
+  items: SerialDebugLine[];
+}
+
+/** A filter page whose archive lines have been mapped to display lines. */
+export interface SerialDebugFilterLinePage {
   filterId: string;
   totalMatches: number;
   start: number;
@@ -81,5 +103,5 @@ export interface SerialDebugFilterPage {
 export interface SerialDebugSessionPage {
   totalLines: number;
   start: number;
-  items: DebugLogLine[];
+  items: SerialDebugLine[];
 }

--- a/src/features/serial-debug/utils.test.ts
+++ b/src/features/serial-debug/utils.test.ts
@@ -1,9 +1,35 @@
 import { describe, expect, it } from "vitest";
-import { sanitizePortName } from "./utils";
+import { archiveLineToLogLine, sanitizePortName } from "./utils";
 
 describe("sanitizePortName", () => {
   it("strips leading slash and replaces unsafe chars", () => {
     expect(sanitizePortName("/dev/ttyUSB0")).toBe("dev_ttyUSB0");
     expect(sanitizePortName("COM3")).toBe("COM3");
+  });
+});
+
+describe("archiveLineToLogLine", () => {
+  it("carries over line fields and applies the given display id", () => {
+    expect(
+      archiveLineToLogLine(
+        { lineNo: 42, tsMs: 1700, direction: "rx", text: "ERR boom" },
+        7,
+      ),
+    ).toEqual({
+      id: 7,
+      tsMs: 1700,
+      direction: "rx",
+      text: "ERR boom",
+      rawBytes: undefined,
+    });
+  });
+
+  it("converts rawBytes to a Uint8Array for the hex view", () => {
+    const line = archiveLineToLogLine(
+      { lineNo: 1, tsMs: 0, direction: "tx", text: "hi", rawBytes: [104, 105] },
+      1,
+    );
+    expect(line.rawBytes).toBeInstanceOf(Uint8Array);
+    expect(Array.from(line.rawBytes!)).toEqual([104, 105]);
   });
 });

--- a/src/features/serial-debug/utils.ts
+++ b/src/features/serial-debug/utils.ts
@@ -1,6 +1,27 @@
 /**
  * Serial-debug helpers shared across components.
  */
+import type { DebugLogLine, SerialDebugLine } from "./types";
+
+/**
+ * Maps an archive-backed line onto a display line. The caller supplies `id`
+ * because archive `lineNo`s restart at 1 on every session, while display ids
+ * must stay unique for the whole store lifetime — the log renderers cache
+ * parsed lines by id, so a reused id would render the wrong content.
+ */
+export function archiveLineToLogLine(
+  line: SerialDebugLine,
+  id: number,
+): DebugLogLine {
+  return {
+    id,
+    tsMs: line.tsMs,
+    direction: line.direction,
+    text: line.text,
+    rawBytes: line.rawBytes ? Uint8Array.from(line.rawBytes) : undefined,
+  };
+}
+
 export function sanitizePortName(port: string): string {
   const stripped = port.startsWith("/") ? port.slice(1) : port;
   return stripped.replace(/[/\\:*?"<>|.]/g, "_");

--- a/src/stores/serial-debug.test.ts
+++ b/src/stores/serial-debug.test.ts
@@ -27,6 +27,7 @@ function fakeTransport(): SerialDebugTransport & {
   emitChunkBatch: (chunks: DebugChunk[]) => void;
   emitDisconnect: (reason: string) => void;
   emitFilterUpdated: (payload: SerialDebugFilterUpdatePayload) => void;
+  setFilterPage: (filterId: string, page: SerialDebugFilterPage) => void;
   readFilterMatchesCalls: Array<{
     filterId: string;
     start?: number;
@@ -142,6 +143,10 @@ function fakeTransport(): SerialDebugTransport & {
     },
     emitFilterUpdated(payload) {
       filterListeners.forEach((l) => l(payload));
+    },
+    setFilterPage(filterId, page) {
+      const entry = filters.get(filterId);
+      if (entry) entry.page = page;
     },
   };
 }
@@ -681,6 +686,82 @@ describe("useSerialDebugStore watch chip management", () => {
     expect(s.filterPagesById).toEqual({});
     expect(s.activeFilterLoading).toBe(false);
     expect(s.activeFilterFullyLoaded).toBe(true);
+  });
+
+  it("gives every archive line in a filter page its own display id", async () => {
+    const s = useSerialDebugStore();
+    await s.addChip("ERR", false);
+    const id = s.watchChips[0].id;
+    fake.setFilterPage(id, {
+      filterId: id,
+      totalMatches: 3,
+      start: 0,
+      items: [
+        { lineNo: 3, tsMs: 1000, direction: "rx", text: "ERR alpha" },
+        { lineNo: 9, tsMs: 1001, direction: "rx", text: "ERR beta" },
+        { lineNo: 17, tsMs: 1002, direction: "rx", text: "ERR gamma" },
+      ],
+    });
+
+    await s.setActiveChip(id);
+
+    const items = s.activeDisplayLines;
+    expect(items.map((line) => line.text)).toEqual([
+      "ERR alpha",
+      "ERR beta",
+      "ERR gamma",
+    ]);
+    // Distinct ids per line: the log renderers cache parsed lines by id, so
+    // colliding ids make one line render in place of the others (issue: a
+    // single filtered line shown repeatedly).
+    expect(new Set(items.map((line) => line.id)).size).toBe(3);
+    expect(items.every((line) => Number.isInteger(line.id))).toBe(true);
+  });
+
+  it("keeps display ids stable when the same filter page is reloaded", async () => {
+    const s = useSerialDebugStore();
+    await s.addChip("ERR", false);
+    const id = s.watchChips[0].id;
+    fake.setFilterPage(id, {
+      filterId: id,
+      totalMatches: 2,
+      start: 0,
+      items: [
+        { lineNo: 3, tsMs: 1000, direction: "rx", text: "ERR alpha" },
+        { lineNo: 9, tsMs: 1001, direction: "rx", text: "ERR beta" },
+      ],
+    });
+
+    await s.setActiveChip(id);
+    const firstIds = s.activeDisplayLines.map((line) => line.id);
+    await s.setActiveChip(id);
+    expect(s.activeDisplayLines.map((line) => line.id)).toEqual(firstIds);
+  });
+
+  it("does not reuse display ids for archive line numbers of a new session", async () => {
+    const s = useSerialDebugStore();
+    await s.addChip("ERR", false);
+    const id = s.watchChips[0].id;
+    fake.setFilterPage(id, {
+      filterId: id,
+      totalMatches: 1,
+      start: 0,
+      items: [{ lineNo: 1, tsMs: 1000, direction: "rx", text: "ERR old" }],
+    });
+    await s.setActiveChip(id);
+    const oldId = s.activeDisplayLines[0].id;
+
+    await s.clear();
+    fake.setFilterPage(id, {
+      filterId: id,
+      totalMatches: 1,
+      start: 0,
+      items: [{ lineNo: 1, tsMs: 2000, direction: "rx", text: "ERR new" }],
+    });
+    await s.setActiveChip(id);
+
+    expect(s.activeDisplayLines[0].text).toBe("ERR new");
+    expect(s.activeDisplayLines[0].id).not.toBe(oldId);
   });
 
   it("throttles active filter tail reloads for repeated live updates", async () => {

--- a/src/stores/serial-debug.ts
+++ b/src/stores/serial-debug.ts
@@ -24,6 +24,7 @@ import {
 } from "@/features/firmware-flash/constants";
 import { useFlashStore } from "@/stores/flash";
 import { parseHexInput } from "@/features/serial-debug/hex-format";
+import { archiveLineToLogLine } from "@/features/serial-debug/utils";
 import { serialDebugTransport } from "@/features/serial-debug/transport";
 import { wsTransport } from "@/transport/ws-transport";
 import type {
@@ -32,7 +33,7 @@ import type {
   DebugLogLine,
   HexBytesPerRow,
   SendMode,
-  SerialDebugFilterPage,
+  SerialDebugFilterLinePage,
   SerialDebugFilterStats,
   SerialDebugFilterUpdatePayload,
   WatchChip,
@@ -177,7 +178,7 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
   const showTimestamp = ref(true);
   const showDirBadge = ref(true);
   const filterStatsById = ref<Record<string, SerialDebugFilterStats>>({});
-  const filterPagesById = ref<Record<string, SerialDebugFilterPage>>({});
+  const filterPagesById = ref<Record<string, SerialDebugFilterLinePage>>({});
   const activeFilterLoading = ref(false);
   const activeFilterFullyLoaded = ref(false);
 
@@ -195,6 +196,11 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
   const pendingAutoSaveLines: PendingAutoSaveLine[] = [];
 
   let nextLineId = 1;
+  // Display id per archive line number, so reloading a filter page keeps the
+  // ids of lines that are already on screen (the log renderers cache parsed
+  // lines by id). Reset on session clear, because archive line numbers restart.
+  let archiveLineIds = new Map<number, number>();
+  const MAX_ARCHIVE_LINE_IDS = 20000;
   const pending = {
     tx: createPendingBuffer(),
     rx: createPendingBuffer(),
@@ -445,6 +451,7 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
       ]),
     );
     filterPagesById.value = {};
+    archiveLineIds = new Map();
     activeFilterLoading.value = false;
     activeFilterFullyLoaded.value = true;
     try {
@@ -816,12 +823,31 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     }
   }
 
+  function archiveLineId(lineNo: number): number {
+    const existing = archiveLineIds.get(lineNo);
+    if (existing !== undefined) return existing;
+    // Drop the memo rather than let it grow with the session. Lines then get
+    // fresh ids (a one-off re-parse in the renderers); ids stay unique.
+    if (archiveLineIds.size >= MAX_ARCHIVE_LINE_IDS) archiveLineIds.clear();
+    const id = nextLineId++;
+    archiveLineIds.set(lineNo, id);
+    return id;
+  }
+
   async function loadFilterPage(
     filterId: string,
     start: number,
     limit: number,
-  ): Promise<SerialDebugFilterPage> {
-    return await transport.readFilterMatches(filterId, start, limit);
+  ): Promise<SerialDebugFilterLinePage> {
+    const page = await transport.readFilterMatches(filterId, start, limit);
+    return {
+      filterId: page.filterId,
+      totalMatches: page.totalMatches,
+      start: page.start,
+      items: page.items.map((line) =>
+        archiveLineToLogLine(line, archiveLineId(line.lineNo)),
+      ),
+    };
   }
 
   async function loadActiveFilterTail(): Promise<void> {


### PR DESCRIPTION
Filter tabs render archive-backed lines from serial_debug_filter_read_matches. Those arrive as tyutool_core::serial_debug::SerialDebugLine, which carries a lineNo and no display id, but the frontend typed them as DebugLogLine — so every page item had `id === undefined`. SerialDebugLogLineRenderer and SerialDebugHexViewRenderer cache parsed lines in a Map keyed by that id, so all rows collided on a single entry and every row rendered the first match's content: one filtered line shown repeatedly. The same undefined id also broke the v-for key and made Ctrl+F treat every row as the current match.

Add SerialDebugLine as the honest mirror of the Rust type, map page items through archiveLineToLogLine, and allocate display ids from the store's existing monotonic counter — memoized per line number so reloading a page keeps on-screen ids stable, reset on session clear because archive line numbers restart there, and capped so the memo cannot grow with the session.