### PR TITLE
chore(release): v3.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 本项目所有重要变更记录于此 / All notable changes are documented here.
 
+## [3.2.8] - 2026-07-28
+
+### 问题修复
+
+- `serial-debug`：修复过滤标签页翻页后整页重复显示同一条匹配内容的问题——归档行没有展示 id，导致渲染缓存整页命中同一条记录；同一问题也让 Ctrl+F 把过滤页的每一行都视作当前匹配项
+
+### 工程改进
+
+- `deps`：升级开发工具链依赖（vitest、vite、tsx、undici、brace-expansion），修复 11 项 Dependabot 安全告警；仅涉及开发依赖，随包发布的运行时依赖不受影响
+- `docs`：macOS 构建已完成 Apple 签名，README 与使用指南中过时的 Gatekeeper 绕过说明已移除；中国大陆下载与更新指引改为指向涂鸦 OSS 的 `release.json`，不再使用 Gitee；`docs/cli.md` 补充发布产物清单与安装、更新源说明；使用指南补齐实机截图并修正过时内容
+- `ci`：Gitee 代码镜像改为真实镜像（同步全部分支与标签，删除也会同步），`refactor/v3` 上的推送同样触发 CI
+
+---
+
+### Bug Fixes
+
+- `serial-debug`: Fix filter tabs rendering the same matched line for every row after paging — archive-backed lines carried no display id, so the whole page collided on a single render-cache entry; the same missing id also made Ctrl+F treat every row on a filter page as the current match
+
+### Engineering
+
+- `deps`: Bump dev-toolchain dependencies (vitest, vite, tsx, undici, brace-expansion) to clear 11 Dependabot alerts; dev-only — no shipped runtime dependency is affected
+- `docs`: macOS builds are Apple-signed now, so the obsolete Gatekeeper workarounds are gone from the README and usage guide; mainland download/update guidance points at Tuya OSS `release.json` instead of Gitee; `docs/cli.md` gains the release-asset list and spells out install/update sources; the usage guide gets real screenshots and stale content fixes
+- `ci`: The Gitee code sync is a true mirror now (all branches and tags, deletions included), and pushes to `refactor/v3` also trigger CI
+
 ## [3.2.7] - 2026-07-23
 
 ### 新功能

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5874,7 +5874,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "tyutool-cli"
-version = "3.2.7"
+version = "3.2.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5906,7 +5906,7 @@ dependencies = [
 
 [[package]]
 name = "tyutool-core"
-version = "3.2.7"
+version = "3.2.8"
 dependencies = [
  "crc32fast",
  "espflash",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "tyutool_gui"
-version = "3.2.7"
+version = "3.2.8"
 dependencies = [
  "calamine",
  "chrono",

--- a/crates/tyutool-cli/Cargo.toml
+++ b/crates/tyutool-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tyutool-cli"
-version = "3.2.7"
+version = "3.2.8"
 edition = "2021"
 description = "tyutool CLI — shared tyutool-core flash API (no Tauri)"
 

--- a/crates/tyutool-core/Cargo.toml
+++ b/crates/tyutool-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tyutool-core"
-version = "3.2.7"
+version = "3.2.8"
 edition = "2021"
 description = "Shared flash/erase plugin registry and serial helpers for tyutool CLI and GUI"
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tyutool",
   "private": true,
-  "version": "3.2.7",
+  "version": "3.2.8",
   "type": "module",
   "scripts": {
     "clean": "node -e \"try { require('fs').rmSync('dist', { recursive: true, force: true }); } catch (e) { if (e && e.code !== 'ENOENT') throw e; }\"",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tyutool_gui"
-version = "3.2.7"
+version = "3.2.8"
 description = "tyutool — Tauri shell for tyutool-core (firmware / serial tooling)"
 authors = ["tyutool contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tyutool",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "identifier": "com.tyutool.desktop",
   "build": {
     "beforeDevCommand": "pnpm run dev",


### PR DESCRIPTION
Release bump to 3.2.8 — version files, `Cargo.lock`, and the CHANGELOG entry only.

## Contents of 3.2.8

**Bug Fixes**
- `serial-debug`: filter tabs rendered the same matched line for every row after paging (archive lines carried no display id, so the whole page collided on one render-cache entry); Ctrl+F was affected by the same missing id.

**Engineering**
- `deps`: dev-toolchain bumps clearing 11 Dependabot alerts (dev-only, no shipped runtime dep).
- `docs`: obsolete macOS Gatekeeper workarounds removed (builds are Apple-signed); mainland download/update guidance points at Tuya OSS `release.json`; `docs/cli.md` release-asset list; usage-guide screenshots and stale-content fixes.
- `ci`: Gitee sync is a true mirror; pushes to `refactor/v3` trigger CI.

No `新功能` / Features section — nothing user-facing was added this cycle.

## Verification
- `pnpm run test` — 768 passed (57 files)
- `pnpm run build` — clean type-check + build
- CHANGELOG draft marker removed

After merge, tag `v3.2.8` on `refactor/v3` to trigger the release CI.