### PR TITLE
chore(deps): bump thiserror to 2 and dirs to 6; document the vitest-env test exception

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,6 @@ refactor/v3    ← main development branch (default); feature PRs merge here
 ### Testing
 
 - Test files live next to their source, same name with `.test.ts` suffix; Rust uses inline `#[cfg(test)] mod tests`
-- **Before creating a test file:** run `ls` in the source file's directory to check whether a co-located `.test.ts` already exists. If it does, append to it — never create a parallel file with suffixes like `-extended`, `-v2`, etc.
+- **Before creating a test file:** run `ls` in the source file's directory to check whether a co-located `.test.ts` already exists. If it does, append to it — never create a parallel file with suffixes like `-extended`, `-v2`, etc. Sole exception: a second file is allowed when it needs a different `@vitest-environment` than the existing one (vitest environment directives are per-file), e.g. `settings.init.test.ts` (happy-dom) alongside `settings.test.ts` (node); name it `<stem>.<scope>.test.ts` and state the environment reason in a header comment.
 - Pure logic (utility functions, type conversions) must have unit tests; Vue components and stores as needed
 - Frontend tests run in the `node` environment — no DOM

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6091,7 +6091,7 @@ dependencies = [
  "clap_complete",
  "console",
  "ctrlc",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "fern",
  "flate2",
  "hex",
@@ -6123,12 +6123,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serialport",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "tyutool-serve"
-version = "0.1.0"
+version = "3.2.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/tyutool-cli/Cargo.toml
+++ b/crates/tyutool-cli/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 [dependencies]
 fern = "0.7"
 chrono = { version = "0.4", features = ["clock"] }
-dirs = "5"
+dirs = "6"
 log = "0.4"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"

--- a/crates/tyutool-core/Cargo.toml
+++ b/crates/tyutool-core/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-thiserror = "1"
+thiserror = "2"
 serialport = { version = "4", default-features = false, features = ["usbportinfo-interface"] }
 crc32fast = "1"
 log = "0.4"


### PR DESCRIPTION
## What

Closes the last actionable item from the 2026-08-04 code audit (`docs/audits/2026-08-04-code-audit.md`, priority #9), plus a docs clarification that closes #15.

- `tyutool-core`: `thiserror` 1 → 2
- `tyutool-cli`: `dirs` 5 → 6
- `AGENTS.md`: record the one legitimate exception to the "never create a parallel test file" rule

## Why the lockfile still shows both major versions

The bumps only move the **first-party** specs. What remains in `Cargo.lock` is out of this repo's reach:

- `thiserror 1.0.69` — pulled only by third-party transitive deps (`glib`/`gio`/`cairo-rs`, `tungstenite`, `json-patch`, `jni`, `ndk`, `redox_users`).
- `dirs 5.0.1` — pulled only by `tyutool-bridge`, which is deliberately untouched here (separate maintainer, independent `bridge-v*` release line).

## AGENTS.md change

`settings.init.test.ts` looked like a rule violation ("append to the existing test file, don't open a parallel one"), but the split is forced by tooling: vitest `@vitest-environment` directives are **per-file**, and that file needs happy-dom for `init()`'s DOM side effects while `settings.test.ts` runs in node. Merging them would mean promoting pure-logic tests to happy-dom for no benefit. Documented as a scoped exception instead, with a naming convention (`<stem>.<scope>.test.ts`) and a required header comment.

## Audit items closed by decision (no code change)

- #5 auth credentials persisted in plaintext — intentional, supports troubleshooting.
- #10 CI on `ubuntu-latest` only — intentional; cross-platform coverage lives in the release matrix.

## Verification

- `cargo test -p tyutool-core` → 228 passed
- `cargo test -p tyutool-cli` → 48 passed
- `cargo clippy -p tyutool-core -p tyutool-cli --all-targets -- -D warnings` → clean

No CLI commands changed, so `docs/cli.md` needs no update.
