### PR TITLE
串口调试：日志渲染性能、数据完整性与全会话回滚

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,40 @@ Logs exist partly so users can file good bug reports. Preserve these guarantees:
   (CLI: `SessionLogWriter` → `tyutool-<ts>-N.log`; GUI: `tauri-plugin-log` `max_file_size` +
   `RotationStrategy::KeepAll`). Across sessions, `prune_log_files` trims old files at startup
   (≤100 files / ≤100 MB total). New log sinks must stay bounded too.
+- **Bounded growth — serial-debug session archive:** the serial-debug archive
+  (`{temp_dir}/tyutool/serial-debug/serial-debug-session-<ts>-<pid>-<seq>.ndjson`
+  plus its `.idx` sidecar) is a *third* file family with its own bounds, because
+  a 921600-baud port writes ~1.74 GiB/hour into it. Per session it is size-capped
+  (default 256 MiB, user-settable 16–4096 MiB via
+  `serial_debug_set_archive_limit` / the `serial_debug_set_archive_limit` WS
+  message). The policy is **stopWriting**: on reaching the cap the archive keeps
+  what it has, appends one `Sys` line announcing the cap, and drops everything
+  after — it never renumbers or rewrites, because line numbers are the `.idx`
+  offsets (`(line_no - 1) * 16`). `dropOldest` would require a cursor-based
+  paging contract and is deliberately not implemented. That `Sys` line is a
+  **sentinel**, not prose (`serial_debug_archive_cap_sentinel`): the wording is
+  user-visible and belongs in the frontend i18n catalogue
+  (`serialDebug.log.archiveCapped`), and translating at read time makes an
+  archive re-read after a language switch show the notice in the new language.
+  Every frontend path that surfaces archive text — filter tabs, log export,
+  auto-save — goes through the single `localizeArchiveLineText` helper in
+  `src/features/serial-debug/archive-line-text.ts`; the live view, which is fed
+  by raw chunks and never reads the archive, is told separately by the
+  `serial-debug-archive-capped` Tauri event / `serial_debug_archive_capped` WS
+  message. Across sessions,
+  `prune_serial_debug_archives` runs from `SerialDebugArchive::create` and trims
+  the directory to ≤20 file pairs / ≤1 GiB, oldest mtime first. It selects on the
+  `serial-debug-session-` **stem prefix**, never on the `.idx` extension: live
+  filter match indexes (`serial-debug-filter-*.idx`) share the directory and an
+  extension-keyed sweep would delete them mid-session.
+- **Archive isolation:** the session archive is deliberately *not* in
+  `app_log_dir()` and has neither a `.log` extension nor a `tyutool-` prefix, so
+  `pick_active_log` / `collect_log_files` / `list_log_files_impl` /
+  `export_logs_zip` / `prune_log_files` all ignore it — structurally the same
+  arrangement as `batch-auth-*.trace`. It is a paging store for the UI, not a
+  diagnostic log, and it never lands in an export or archive zip. Do not move it
+  into the log dir. Archived lines carry text only (no `rawBytes`); consumers
+  that need bytes re-encode the text.
 - **Credential isolation (two-channel model):** batch-auth plaintext interaction data
   (verify comparison UUID/AuthKey values) is written to `batch-auth-<ts>.trace` via
   `BatchAuthTraceWriter`, **never** into `tyutool-*.log`. The `.trace` file uses a non-`.log`

--- a/crates/tyutool-core/src/lib.rs
+++ b/crates/tyutool-core/src/lib.rs
@@ -35,10 +35,9 @@ pub use serial_debug::{
     serial_debug_fail_backfill_if_current, serial_debug_finish_backfill_if_current,
     serial_debug_now_ms, serial_debug_scan_filter_matches, ChunkCallback, DataBits, DebugChunk,
     DebugConfig, Direction, DisconnectCallback, LogDirection, Parity, SerialDebugArchive,
-    SerialDebugArchiveMeta, SerialDebugArchiveReader, SerialDebugChunkBatchBuffer,
-    SerialDebugDropCounter, SerialDebugDropReport, SerialDebugFilterBackfillSnapshot,
-    SerialDebugFilterDefinition, SerialDebugFilterIndex, SerialDebugFilterPage,
-    SerialDebugFilterStats, SerialDebugFilterStatus, SerialDebugGeneration, SerialDebugLine,
-    SerialDebugSession, SerialDebugSessionPage, StopBits,
+    SerialDebugArchiveReader, SerialDebugChunkBatchBuffer, SerialDebugDropCounter,
+    SerialDebugDropReport, SerialDebugFilterBackfillSnapshot, SerialDebugFilterDefinition,
+    SerialDebugFilterIndex, SerialDebugFilterPage, SerialDebugFilterStats, SerialDebugFilterStatus,
+    SerialDebugGeneration, SerialDebugLine, SerialDebugSession, SerialDebugSessionPage, StopBits,
 };
 pub use usb_port_survey::{usb_port_survey, UsbPortSurveyEntry, UsbPortSurveyUsb};

--- a/crates/tyutool-core/src/lib.rs
+++ b/crates/tyutool-core/src/lib.rs
@@ -30,6 +30,7 @@ pub use serial::{
     check_port_available, device_reset_dtr_rts, list_serial_ports, PortCheckResult, SerialPortEntry,
 };
 pub use serial_debug::{
+    serial_debug_archive_cap_limit_mib, serial_debug_archive_cap_sentinel,
     serial_debug_fail_backfill_if_current, serial_debug_finish_backfill_if_current,
     serial_debug_scan_filter_matches, ChunkCallback, DataBits, DebugChunk, DebugConfig, Direction,
     DisconnectCallback, LogDirection, Parity, SerialDebugArchive, SerialDebugArchiveMeta,

--- a/crates/tyutool-core/src/lib.rs
+++ b/crates/tyutool-core/src/lib.rs
@@ -31,10 +31,12 @@ pub use serial::{
 };
 pub use serial_debug::{
     serial_debug_archive_cap_limit_mib, serial_debug_archive_cap_sentinel,
+    serial_debug_chunk_drop_bytes, serial_debug_chunk_drop_sentinel,
     serial_debug_fail_backfill_if_current, serial_debug_finish_backfill_if_current,
-    serial_debug_scan_filter_matches, ChunkCallback, DataBits, DebugChunk, DebugConfig, Direction,
-    DisconnectCallback, LogDirection, Parity, SerialDebugArchive, SerialDebugArchiveMeta,
-    SerialDebugArchiveReader, SerialDebugChunkBatchBuffer, SerialDebugFilterBackfillSnapshot,
+    serial_debug_now_ms, serial_debug_scan_filter_matches, ChunkCallback, DataBits, DebugChunk,
+    DebugConfig, Direction, DisconnectCallback, LogDirection, Parity, SerialDebugArchive,
+    SerialDebugArchiveMeta, SerialDebugArchiveReader, SerialDebugChunkBatchBuffer,
+    SerialDebugDropCounter, SerialDebugDropReport, SerialDebugFilterBackfillSnapshot,
     SerialDebugFilterDefinition, SerialDebugFilterIndex, SerialDebugFilterPage,
     SerialDebugFilterStats, SerialDebugFilterStatus, SerialDebugGeneration, SerialDebugLine,
     SerialDebugSession, SerialDebugSessionPage, StopBits,

--- a/crates/tyutool-core/src/serial_debug.rs
+++ b/crates/tyutool-core/src/serial_debug.rs
@@ -112,7 +112,10 @@ pub struct SerialDebugLine {
 /// character: it never occurs in a translated UI string, which is the only other
 /// source of `Sys` lines.
 const ARCHIVE_CAP_SENTINEL_PREFIX: &str = "\u{1}tyutool:archive-capped:";
-const ARCHIVE_CAP_SENTINEL_SUFFIX: char = '\u{1}';
+/// Opening delimiter of the dropped-chunk sentinel — same family, same
+/// collision-safety rules, different payload (bytes lost, not the MiB cap).
+const CHUNK_DROP_SENTINEL_PREFIX: &str = "\u{1}tyutool:chunks-dropped:";
+const SENTINEL_SUFFIX: char = '\u{1}';
 
 /// Text written into the archive in place of the first line that would have
 /// broken the size cap, carrying the limit in MiB.
@@ -134,23 +137,125 @@ const ARCHIVE_CAP_SENTINEL_SUFFIX: char = '\u{1}';
 /// 3. the match is on the whole string (prefix + digits + suffix), not a
 ///    substring, so a longer line that merely embeds the marker is not a match.
 pub fn serial_debug_archive_cap_sentinel(limit_mib: u64) -> String {
-    format!("{ARCHIVE_CAP_SENTINEL_PREFIX}{limit_mib}{ARCHIVE_CAP_SENTINEL_SUFFIX}")
+    format!("{ARCHIVE_CAP_SENTINEL_PREFIX}{limit_mib}{SENTINEL_SUFFIX}")
 }
 
-/// The MiB limit carried by an archive-cap sentinel line, or `None` for any
-/// other line. Mirrored in `src/features/serial-debug/archive-line-text.ts`.
-pub fn serial_debug_archive_cap_limit_mib(line: &SerialDebugLine) -> Option<u64> {
+/// Text written into the archive at a gap in the chunk stream, carrying the
+/// number of bytes lost. Same reasoning and the same three collision-safety
+/// layers as [`serial_debug_archive_cap_sentinel`].
+pub fn serial_debug_chunk_drop_sentinel(dropped_bytes: u64) -> String {
+    format!("{CHUNK_DROP_SENTINEL_PREFIX}{dropped_bytes}{SENTINEL_SUFFIX}")
+}
+
+/// The numeric payload of a `Sys` sentinel line built from `prefix`, or `None`
+/// for any other line. The `Sys`-only / whole-string / digits-only rules live
+/// here so every sentinel family gets all three.
+fn sentinel_payload(line: &SerialDebugLine, prefix: &str) -> Option<u64> {
     if line.direction != LogDirection::Sys {
         return None;
     }
     let digits = line
         .text
-        .strip_prefix(ARCHIVE_CAP_SENTINEL_PREFIX)?
-        .strip_suffix(ARCHIVE_CAP_SENTINEL_SUFFIX)?;
+        .strip_prefix(prefix)?
+        .strip_suffix(SENTINEL_SUFFIX)?;
     if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
         return None;
     }
     digits.parse().ok()
+}
+
+/// The MiB limit carried by an archive-cap sentinel line, or `None` for any
+/// other line. Mirrored in `src/features/serial-debug/archive-line-text.ts`.
+pub fn serial_debug_archive_cap_limit_mib(line: &SerialDebugLine) -> Option<u64> {
+    sentinel_payload(line, ARCHIVE_CAP_SENTINEL_PREFIX)
+}
+
+/// The byte count carried by a dropped-chunk sentinel line, or `None` for any
+/// other line. Mirrored in `src/features/serial-debug/archive-line-text.ts`.
+pub fn serial_debug_chunk_drop_bytes(line: &SerialDebugLine) -> Option<u64> {
+    sentinel_payload(line, CHUNK_DROP_SENTINEL_PREFIX)
+}
+
+fn log_direction(direction: Direction) -> LogDirection {
+    match direction {
+        Direction::Tx => LogDirection::Tx,
+        Direction::Rx => LogDirection::Rx,
+    }
+}
+
+/// One coalesced report of chunks the bridge had to drop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SerialDebugDropReport {
+    pub chunks: u64,
+    pub bytes: u64,
+}
+
+/// Quiet period after the last drop before a burst is reported. Without it a
+/// sustained overload would emit one notice per dropped chunk — thousands of
+/// them, which is noise, not information.
+pub const SERIAL_DEBUG_DROP_QUIET_MS: u64 = 250;
+/// Ceiling on how long a burst may keep absorbing drops before it is reported
+/// anyway. A device that never stops printing would otherwise never go quiet,
+/// and the user — the one person who can act on this by lowering the baud rate
+/// or muting device-side logging — would be told nothing at all.
+pub const SERIAL_DEBUG_DROP_BURST_MS: u64 = 2000;
+
+/// Accumulates dropped chunks so one burst of loss becomes one user-visible
+/// notice.
+///
+/// Written by the serial reader thread (which must never block) and read by the
+/// bridge thread. Both counters are swapped independently, so a drop recorded
+/// between the two swaps can have its chunk count and its byte count land in
+/// different reports; nothing is ever lost, and the user-visible figure (bytes)
+/// stays exact per report.
+#[derive(Debug, Default)]
+pub struct SerialDebugDropCounter {
+    chunks: AtomicU64,
+    bytes: AtomicU64,
+    first_drop_ms: AtomicU64,
+    last_drop_ms: AtomicU64,
+}
+
+impl SerialDebugDropCounter {
+    /// Record one dropped chunk. Cheap and non-blocking by construction: this
+    /// runs on the reader thread, the only thread draining the OS buffer.
+    pub fn record(&self, bytes: usize, now_ms: u64) {
+        self.chunks.fetch_add(1, Ordering::SeqCst);
+        self.bytes.fetch_add(bytes as u64, Ordering::SeqCst);
+        let _ = self
+            .first_drop_ms
+            .compare_exchange(0, now_ms, Ordering::SeqCst, Ordering::SeqCst);
+        self.last_drop_ms.store(now_ms, Ordering::SeqCst);
+    }
+
+    /// The pending burst, if it is ready to report: either the loss has stopped
+    /// ([`SERIAL_DEBUG_DROP_QUIET_MS`]) or it has been going on long enough that
+    /// waiting for it to stop would keep the user in the dark
+    /// ([`SERIAL_DEBUG_DROP_BURST_MS`]).
+    pub fn take_report(&self, now_ms: u64) -> Option<SerialDebugDropReport> {
+        if self.chunks.load(Ordering::SeqCst) == 0 && self.bytes.load(Ordering::SeqCst) == 0 {
+            return None;
+        }
+        let quiet_for = now_ms.saturating_sub(self.last_drop_ms.load(Ordering::SeqCst));
+        let burst_age = now_ms.saturating_sub(self.first_drop_ms.load(Ordering::SeqCst));
+        if quiet_for < SERIAL_DEBUG_DROP_QUIET_MS && burst_age < SERIAL_DEBUG_DROP_BURST_MS {
+            return None;
+        }
+        self.take_pending()
+    }
+
+    /// Drain whatever is pending regardless of timing — for teardown, so a burst
+    /// that was still aggregating when the session ended is still reported, and
+    /// for session clear, where the caller discards it.
+    pub fn take_pending(&self) -> Option<SerialDebugDropReport> {
+        let chunks = self.chunks.swap(0, Ordering::SeqCst);
+        let bytes = self.bytes.swap(0, Ordering::SeqCst);
+        self.first_drop_ms.store(0, Ordering::SeqCst);
+        if chunks == 0 && bytes == 0 {
+            return None;
+        }
+        Some(SerialDebugDropReport { chunks, bytes })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -517,10 +622,7 @@ impl SerialDebugArchive {
                 .map(|idx| idx + 1)
                 .unwrap_or(0);
             let text = String::from_utf8_lossy(&raw_bytes[..text_end]).into_owned();
-            let direction = match chunk.direction {
-                Direction::Tx => LogDirection::Tx,
-                Direction::Rx => LogDirection::Rx,
-            };
+            let direction = log_direction(chunk.direction);
             // `raw_bytes` is deliberately dropped here: `text` above is already
             // derived from it, and carrying it into the archive JSON costs
             // ~268 B of `number[]` per 407 B line. Consumers that need bytes
@@ -548,6 +650,59 @@ impl SerialDebugArchive {
         }
 
         Ok(completed)
+    }
+
+    /// Record a gap in the chunk stream for `direction`: whatever is buffered
+    /// there is closed off as its own line, then a dropped-chunk sentinel `Sys`
+    /// line is appended. Returns the lines written, newest last.
+    ///
+    /// Closing the buffer is the whole point. `append_chunk` only cuts a line at
+    /// `\n`, so if a chunk is dropped mid-line the bytes before the gap and the
+    /// bytes after it are concatenated into one line that looks perfectly
+    /// ordinary — a log line the device never printed. Cutting here turns the
+    /// loss into a visible line boundary with the sentinel right after it.
+    pub fn append_gap(
+        &mut self,
+        direction: Direction,
+        ts_ms: u64,
+        dropped_bytes: u64,
+    ) -> std::io::Result<Vec<SerialDebugLine>> {
+        let pending = match direction {
+            Direction::Tx => &mut self.pending_tx,
+            Direction::Rx => &mut self.pending_rx,
+        };
+        let partial = std::mem::take(pending);
+        let mut written = Vec::new();
+        if !partial.is_empty() {
+            let text_end = partial
+                .iter()
+                .rposition(|&b| b != b'\n' && b != b'\r')
+                .map(|idx| idx + 1)
+                .unwrap_or(0);
+            if let Some(line) = self.append_line(SerialDebugLine {
+                line_no: 0,
+                ts_ms,
+                direction: log_direction(direction),
+                text: String::from_utf8_lossy(&partial[..text_end]).into_owned(),
+                raw_bytes: None,
+            })? {
+                written.push(line);
+            }
+        }
+        if let Some(line) = self.append_line(SerialDebugLine {
+            line_no: 0,
+            ts_ms,
+            direction: LogDirection::Sys,
+            // A sentinel, not prose — see `serial_debug_chunk_drop_sentinel`.
+            text: serial_debug_chunk_drop_sentinel(dropped_bytes),
+            raw_bytes: None,
+        })? {
+            written.push(line);
+        }
+        if !written.is_empty() {
+            self.flush_writers()?;
+        }
+        Ok(written)
     }
 
     /// Returns `None` once the archive is capped (see [`Self::append_line`]).
@@ -1347,6 +1502,12 @@ fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+/// The clock the serial-debug engine timestamps with, for hosts that have to
+/// stamp drop reports and gap lines with the same reading.
+pub fn serial_debug_now_ms() -> u64 {
+    now_ms()
 }
 
 fn next_serial_debug_session_id(now_ms: u64, pid: u32) -> String {
@@ -2323,6 +2484,208 @@ mod tests {
                 "must not match: {text:?}"
             );
         }
+    }
+
+    #[test]
+    fn chunk_drop_sentinel_is_only_recognised_on_an_exact_sys_line() {
+        let line = |direction, text: &str| SerialDebugLine {
+            line_no: 1,
+            ts_ms: 0,
+            direction,
+            text: text.to_string(),
+            raw_bytes: None,
+        };
+
+        assert_eq!(
+            serial_debug_chunk_drop_bytes(&line(
+                LogDirection::Sys,
+                &serial_debug_chunk_drop_sentinel(8192)
+            )),
+            Some(8192)
+        );
+
+        // Device output is never a Sys line, so echoing the marker cannot forge
+        // a data-loss notice.
+        assert_eq!(
+            serial_debug_chunk_drop_bytes(&line(
+                LogDirection::Rx,
+                &serial_debug_chunk_drop_sentinel(8192)
+            )),
+            None
+        );
+
+        for text in [
+            &format!("boot: {}", serial_debug_chunk_drop_sentinel(8192)),
+            &format!("{} trailing", serial_debug_chunk_drop_sentinel(8192)),
+            "\u{1}tyutool:chunks-dropped:\u{1}",
+            "\u{1}tyutool:chunks-dropped:12x\u{1}",
+            "tyutool:chunks-dropped:8192",
+        ] {
+            assert_eq!(
+                serial_debug_chunk_drop_bytes(&line(LogDirection::Sys, text)),
+                None,
+                "must not match: {text:?}"
+            );
+        }
+
+        // The two sentinel families never answer for each other.
+        assert_eq!(
+            serial_debug_archive_cap_limit_mib(&line(
+                LogDirection::Sys,
+                &serial_debug_chunk_drop_sentinel(8192)
+            )),
+            None
+        );
+        assert_eq!(
+            serial_debug_chunk_drop_bytes(&line(
+                LogDirection::Sys,
+                &serial_debug_archive_cap_sentinel(256)
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn append_gap_closes_the_open_line_so_the_halves_never_merge() {
+        let dir = temp_serial_debug_dir("gap-line-boundary");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+
+        // A line that was still being received when the drop happened.
+        archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 1,
+                bytes: b"before-gap".to_vec(),
+            })
+            .unwrap();
+        assert_eq!(archive.total_lines(), 0, "no newline yet");
+
+        let written = archive.append_gap(Direction::Rx, 2, 4096).unwrap();
+        assert_eq!(written.len(), 2);
+        assert_eq!(written[0].direction, LogDirection::Rx);
+        assert_eq!(written[0].text, "before-gap");
+        assert_eq!(written[1].direction, LogDirection::Sys);
+        assert_eq!(serial_debug_chunk_drop_bytes(&written[1]), Some(4096));
+
+        // Bytes that arrive after the gap start a line of their own. Without the
+        // cut above they would have been appended to "before-gap", producing one
+        // plausible-looking line the device never printed.
+        let after = archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 3,
+                bytes: b"after-gap\n".to_vec(),
+            })
+            .unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].text, "after-gap");
+
+        let all = archive.read_line_range(1, 10).unwrap();
+        let texts = all.iter().map(|l| l.text.as_str()).collect::<Vec<_>>();
+        assert_eq!(
+            texts,
+            vec![
+                "before-gap",
+                serial_debug_chunk_drop_sentinel(4096).as_str(),
+                "after-gap",
+            ]
+        );
+        assert!(
+            !texts.iter().any(|t| t.contains("before-gapafter-gap")),
+            "the gap must be a line boundary, not a splice: {texts:?}"
+        );
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn append_gap_only_cuts_its_own_direction_and_needs_no_pending_bytes() {
+        let dir = temp_serial_debug_dir("gap-direction");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+
+        archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Tx,
+                ts_ms: 1,
+                bytes: b"half-sent".to_vec(),
+            })
+            .unwrap();
+
+        // Nothing buffered on Rx: the gap is just the sentinel.
+        let written = archive.append_gap(Direction::Rx, 2, 512).unwrap();
+        assert_eq!(written.len(), 1);
+        assert_eq!(written[0].direction, LogDirection::Sys);
+
+        // The untouched Tx buffer still completes normally.
+        let completed = archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Tx,
+                ts_ms: 3,
+                bytes: b"-rest\n".to_vec(),
+            })
+            .unwrap();
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0].text, "half-sent-rest");
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn drop_counter_coalesces_a_burst_into_one_report() {
+        let drops = SerialDebugDropCounter::default();
+
+        drops.record(4096, 1_000);
+        drops.record(2048, 1_010);
+        drops.record(1024, 1_020);
+
+        // Still losing bytes — reporting now would be one notice per chunk.
+        assert_eq!(drops.take_report(1_100), None);
+
+        let report = drops
+            .take_report(1_020 + SERIAL_DEBUG_DROP_QUIET_MS)
+            .unwrap();
+        assert_eq!(report.chunks, 3);
+        assert_eq!(report.bytes, 4096 + 2048 + 1024);
+
+        // One burst, one notice: the counters are empty afterwards.
+        assert_eq!(drops.take_report(9_999_999), None);
+        assert_eq!(drops.take_pending(), None);
+    }
+
+    #[test]
+    fn drop_counter_reports_a_burst_that_never_goes_quiet() {
+        let drops = SerialDebugDropCounter::default();
+
+        // A device that keeps flooding never leaves a quiet window, and the user
+        // is exactly the person who can act on this — so the burst ceiling has to
+        // force a report out.
+        let mut now = 1_000;
+        while now < 1_000 + SERIAL_DEBUG_DROP_BURST_MS {
+            drops.record(4096, now);
+            assert_eq!(drops.take_report(now), None);
+            now += 10;
+        }
+        drops.record(4096, now);
+        let report = drops.take_report(now).unwrap();
+        assert!(report.chunks > 1, "the burst must be coalesced");
+        assert_eq!(report.bytes, report.chunks * 4096);
+    }
+
+    #[test]
+    fn drop_counter_take_pending_drains_an_unfinished_burst() {
+        let drops = SerialDebugDropCounter::default();
+        assert_eq!(drops.take_pending(), None);
+
+        drops.record(64, 1_000);
+        // Teardown / session clear must not need the timing gate.
+        assert_eq!(
+            drops.take_pending(),
+            Some(SerialDebugDropReport {
+                chunks: 1,
+                bytes: 64
+            })
+        );
+        assert_eq!(drops.take_pending(), None);
     }
 
     #[test]

--- a/crates/tyutool-core/src/serial_debug.rs
+++ b/crates/tyutool-core/src/serial_debug.rs
@@ -72,6 +72,23 @@ const MAX_PENDING_SERIAL_DEBUG_LINE_BYTES: usize = 4096;
 const FILTER_BACKFILL_READ_BATCH_LINES: u64 = 512;
 static SERIAL_DEBUG_SESSION_SEQ: AtomicU64 = AtomicU64::new(0);
 
+/// Compile-time cap for one session archive. The GUI/web setting overrides this
+/// at runtime, but a device can flood the port before the setting is pushed
+/// down (~508 KiB/s at 921600 baud), so the default has to be bounded on its
+/// own. Mirrors `DEFAULT_ARCHIVE_LIMIT_MIB` in
+/// `src/features/serial-debug/constants.ts`.
+const DEFAULT_SERIAL_DEBUG_ARCHIVE_MAX_BYTES: u64 = 256 * 1024 * 1024;
+/// Bytes reserved below `max_bytes` so the "archive full" `Sys` line always
+/// fits. Its encoded form is well under 300 B.
+const ARCHIVE_CAP_NOTICE_HEADROOM_BYTES: u64 = 512;
+/// Stem prefix shared by both halves of a session archive pair
+/// (`<prefix><session-id>.ndjson` + `<prefix><session-id>.idx`).
+const SERIAL_DEBUG_SESSION_FILE_PREFIX: &str = "serial-debug-session-";
+/// Cross-session bounds for the archive directory, in the shape of
+/// `prune_log_files`: file *pairs* and total bytes, whichever binds first.
+const MAX_ARCHIVE_SESSIONS: usize = 20;
+const MAX_ARCHIVE_TOTAL_BYTES: u64 = 1024 * 1024 * 1024;
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum LogDirection {
@@ -91,6 +108,51 @@ pub struct SerialDebugLine {
     pub raw_bytes: Option<Vec<u8>>,
 }
 
+/// Opening delimiter of the archive-cap sentinel. `\u{1}` (SOH) is a C0 control
+/// character: it never occurs in a translated UI string, which is the only other
+/// source of `Sys` lines.
+const ARCHIVE_CAP_SENTINEL_PREFIX: &str = "\u{1}tyutool:archive-capped:";
+const ARCHIVE_CAP_SENTINEL_SUFFIX: char = '\u{1}';
+
+/// Text written into the archive in place of the first line that would have
+/// broken the size cap, carrying the limit in MiB.
+///
+/// Why a sentinel rather than a finished sentence:
+/// * the notice is user-visible, so its wording must come from the frontend
+///   i18n catalogue (`serialDebug.log.archiveCapped`) — a Chinese UI must not
+///   grow an English line;
+/// * translating at read time means a session archive re-read after the user
+///   switches language shows the notice in the *new* language, which a string
+///   baked in at write time could never do.
+///
+/// Collision safety — a device log line can never be mistaken for this:
+/// 1. only `Sys` lines are ever tested ([`serial_debug_archive_cap_limit_mib`]),
+///    and device bytes always arrive as `Tx`/`Rx`, so device output cannot reach
+///    the check at all;
+/// 2. the remaining `Sys` producer is the frontend's own `appendSysLine`, which
+///    passes translated catalogue strings — none of which contain U+0001;
+/// 3. the match is on the whole string (prefix + digits + suffix), not a
+///    substring, so a longer line that merely embeds the marker is not a match.
+pub fn serial_debug_archive_cap_sentinel(limit_mib: u64) -> String {
+    format!("{ARCHIVE_CAP_SENTINEL_PREFIX}{limit_mib}{ARCHIVE_CAP_SENTINEL_SUFFIX}")
+}
+
+/// The MiB limit carried by an archive-cap sentinel line, or `None` for any
+/// other line. Mirrored in `src/features/serial-debug/archive-line-text.ts`.
+pub fn serial_debug_archive_cap_limit_mib(line: &SerialDebugLine) -> Option<u64> {
+    if line.direction != LogDirection::Sys {
+        return None;
+    }
+    let digits = line
+        .text
+        .strip_prefix(ARCHIVE_CAP_SENTINEL_PREFIX)?
+        .strip_suffix(ARCHIVE_CAP_SENTINEL_SUFFIX)?;
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    digits.parse().ok()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SerialDebugArchiveMeta {
@@ -108,6 +170,12 @@ pub struct SerialDebugArchive {
     idx_writer: std::io::BufWriter<File>,
     next_offset: u64,
     next_line_no: u64,
+    /// Byte budget for `log_path`; 0 disables the cap.
+    max_bytes: u64,
+    /// Set once the budget is exhausted. Existing content is kept and new lines
+    /// are dropped (`stopWriting`) — never rewritten, so line numbers and the
+    /// `(line_no - 1) * 16` index arithmetic stay valid.
+    capped: bool,
     pending_tx: Vec<u8>,
     pending_rx: Vec<u8>,
 }
@@ -286,11 +354,86 @@ impl SerialDebugFilterIndex {
     }
 }
 
+struct ArchiveSessionFiles {
+    paths: Vec<std::path::PathBuf>,
+    bytes: u64,
+    modified: SystemTime,
+}
+
+/// Delete the oldest `serial-debug-session-*` archives until the directory is
+/// within both the pair-count and total-byte limits. Always keeps at least one.
+///
+/// Selection is keyed on the **stem prefix**, never on the extension: the same
+/// directory also holds `serial-debug-filter-<id>.idx` (and `.live.idx`) match
+/// indexes belonging to *live* filters, and an `extension == "idx"` sweep would
+/// delete those out from under a running session.
+///
+/// Both halves of a pair are removed together — an orphan `.idx` indexes
+/// nothing and an orphan `.ndjson` cannot be paged.
+///
+/// Ordering is by mtime (oldest first), not by filename as in
+/// `prune_log_files`: an archive that is still being written keeps its mtime
+/// fresh, so mtime ordering protects the live archives of this process *and* of
+/// the other `tyutool-serve` WebSocket connections that share this directory.
+fn prune_serial_debug_archives(root_dir: &std::path::Path) {
+    let mut sessions: HashMap<String, ArchiveSessionFiles> = HashMap::new();
+    let entries = match std::fs::read_dir(root_dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+    for path in entries.filter_map(|e| e.ok()).map(|e| e.path()) {
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if !stem.starts_with(SERIAL_DEBUG_SESSION_FILE_PREFIX) {
+            continue;
+        }
+        let Ok(meta) = std::fs::metadata(&path) else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let modified = meta.modified().unwrap_or(UNIX_EPOCH);
+        let entry = sessions
+            .entry(stem.to_string())
+            .or_insert_with(|| ArchiveSessionFiles {
+                paths: Vec::new(),
+                bytes: 0,
+                modified: UNIX_EPOCH,
+            });
+        entry.paths.push(path);
+        entry.bytes = entry.bytes.saturating_add(meta.len());
+        entry.modified = entry.modified.max(modified);
+    }
+
+    let mut sessions = sessions.into_values().collect::<Vec<_>>();
+    sessions.sort_by_key(|session| session.modified);
+
+    let mut count = sessions.len();
+    let mut total = sessions
+        .iter()
+        .fold(0u64, |acc, session| acc.saturating_add(session.bytes));
+    for session in &sessions {
+        if count <= 1 || (count <= MAX_ARCHIVE_SESSIONS && total <= MAX_ARCHIVE_TOTAL_BYTES) {
+            break;
+        }
+        for path in &session.paths {
+            let _ = std::fs::remove_file(path);
+        }
+        count -= 1;
+        total = total.saturating_sub(session.bytes);
+    }
+}
+
 impl SerialDebugArchive {
     pub fn create(root_dir: &std::path::Path) -> std::io::Result<Self> {
         std::fs::create_dir_all(root_dir)?;
         let (session_id, log_path, idx_path, log_writer, idx_writer) =
             Self::create_session_files(root_dir)?;
+        // Prune after the new pair exists (same order as `prune_trace_files`):
+        // the fresh files are the newest, so they can never be the ones trimmed.
+        prune_serial_debug_archives(root_dir);
         Ok(Self {
             root_dir: root_dir.to_path_buf(),
             session_id,
@@ -300,9 +443,20 @@ impl SerialDebugArchive {
             idx_writer,
             next_offset: 0,
             next_line_no: 0,
+            max_bytes: DEFAULT_SERIAL_DEBUG_ARCHIVE_MAX_BYTES,
+            capped: false,
             pending_tx: Vec::new(),
             pending_rx: Vec::new(),
         })
+    }
+
+    /// Update the per-session byte cap (0 disables it). Raising it above the
+    /// current size resumes archiving; lowering it stops at the next line.
+    pub fn set_max_bytes(&mut self, max_bytes: u64) {
+        self.max_bytes = max_bytes;
+        if !self.would_exceed_cap(0) {
+            self.capped = false;
+        }
     }
 
     pub fn meta(&self) -> SerialDebugArchiveMeta {
@@ -331,6 +485,7 @@ impl SerialDebugArchive {
         self.idx_writer = idx_writer;
         self.next_offset = 0;
         self.next_line_no = 0;
+        self.capped = false;
         self.pending_tx.clear();
         self.pending_rx.clear();
         let _ = std::fs::remove_file(old_log_path);
@@ -366,18 +521,27 @@ impl SerialDebugArchive {
                 Direction::Tx => LogDirection::Tx,
                 Direction::Rx => LogDirection::Rx,
             };
+            // `raw_bytes` is deliberately dropped here: `text` above is already
+            // derived from it, and carrying it into the archive JSON costs
+            // ~268 B of `number[]` per 407 B line. Consumers that need bytes
+            // (the hex view on a filter tab) re-encode `text`; the live view
+            // never goes through the archive at all.
             decoded.push(SerialDebugLine {
                 line_no: 0,
                 ts_ms: chunk.ts_ms,
                 direction,
                 text,
-                raw_bytes: Some(raw_bytes),
+                raw_bytes: None,
             });
         }
 
         let mut completed = Vec::with_capacity(decoded.len());
         for line in decoded {
-            completed.push(self.append_line(line)?);
+            // `None` once the archive is capped — the drain above already
+            // consumed the bytes, so the loop still converges.
+            if let Some(line) = self.append_line(line)? {
+                completed.push(line);
+            }
         }
         if !completed.is_empty() {
             self.flush_writers()?;
@@ -386,11 +550,12 @@ impl SerialDebugArchive {
         Ok(completed)
     }
 
+    /// Returns `None` once the archive is capped (see [`Self::append_line`]).
     pub fn append_sys_line(
         &mut self,
         ts_ms: u64,
         text: String,
-    ) -> std::io::Result<SerialDebugLine> {
+    ) -> std::io::Result<Option<SerialDebugLine>> {
         let line = self.append_line(SerialDebugLine {
             line_no: 0,
             ts_ms,
@@ -463,16 +628,80 @@ impl SerialDebugArchive {
         }
     }
 
-    fn append_line(&mut self, mut line: SerialDebugLine) -> std::io::Result<SerialDebugLine> {
-        self.next_line_no += 1;
-        line.line_no = self.next_line_no;
+    /// Append one line, or drop it once the archive is capped.
+    ///
+    /// Returns the archived line; `None` means nothing was written. The line
+    /// that first crosses the cap is replaced by the cap sentinel, which *is*
+    /// returned — the callers recognise it with
+    /// [`serial_debug_archive_cap_limit_mib`] and notify the live view, so the
+    /// cap surfaces there as well as in the export and the auto-save file
+    /// rather than truncating silently.
+    ///
+    /// `next_line_no` is only incremented after the bytes are handed to the
+    /// writers. Numbering a line that never reaches the `.idx` file would put a
+    /// hole in it, and `(line_no - 1) * 16` would then read the wrong entry for
+    /// every later line — silent corruption with no error anywhere.
+    fn append_line(
+        &mut self,
+        mut line: SerialDebugLine,
+    ) -> std::io::Result<Option<SerialDebugLine>> {
+        if self.capped {
+            return Ok(None);
+        }
+        line.line_no = self.next_line_no + 1;
         let encoded = serde_json::to_vec(&line)?;
-        self.log_writer.write_all(&encoded)?;
+        if self.would_exceed_cap(encoded.len() as u64) {
+            self.capped = true;
+            let ts_ms = line.ts_ms;
+            return self.write_cap_notice(ts_ms).map(Some);
+        }
+        self.write_encoded_line(line, &encoded).map(Some)
+    }
+
+    /// Whether writing `encoded_len` more payload bytes would break the budget.
+    /// Uses `next_offset` — the authoritative logical size — and never
+    /// `metadata().len()`, which lags behind by whatever the `BufWriter` still
+    /// holds (`flush_writers` only runs once per batch).
+    fn would_exceed_cap(&self, encoded_len: u64) -> bool {
+        if self.max_bytes == 0 {
+            return false;
+        }
+        let budget = self
+            .max_bytes
+            .saturating_sub(ARCHIVE_CAP_NOTICE_HEADROOM_BYTES);
+        self.next_offset.saturating_add(encoded_len + 1) > budget
+    }
+
+    fn write_cap_notice(&mut self, ts_ms: u64) -> std::io::Result<SerialDebugLine> {
+        let line = SerialDebugLine {
+            line_no: self.next_line_no + 1,
+            ts_ms,
+            direction: LogDirection::Sys,
+            // A sentinel, not prose: the wording is a user-visible string and
+            // belongs in the frontend i18n catalogue. See
+            // `serial_debug_archive_cap_sentinel`.
+            //
+            // The UI floor is 16 MiB, so rounding up only ever shows on
+            // deliberately tiny caps (tests).
+            text: serial_debug_archive_cap_sentinel(self.max_bytes.div_ceil(1024 * 1024)),
+            raw_bytes: None,
+        };
+        let encoded = serde_json::to_vec(&line)?;
+        self.write_encoded_line(line, &encoded)
+    }
+
+    fn write_encoded_line(
+        &mut self,
+        line: SerialDebugLine,
+        encoded: &[u8],
+    ) -> std::io::Result<SerialDebugLine> {
+        self.log_writer.write_all(encoded)?;
         self.log_writer.write_all(b"\n")?;
         self.idx_writer.write_all(&self.next_offset.to_le_bytes())?;
         self.idx_writer
             .write_all(&(encoded.len() as u64).to_le_bytes())?;
         self.next_offset += encoded.len() as u64 + 1;
+        self.next_line_no += 1;
         Ok(line)
     }
 
@@ -1978,6 +2207,279 @@ mod tests {
         assert_eq!(updates.len(), 1);
         assert_eq!(updates[0].filter_id, filter.id);
         assert_eq!(updates[0].total_matches, 2);
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    /// Fill the archive until it caps, then return the number of lines written.
+    fn fill_until_capped(archive: &mut SerialDebugArchive) -> u64 {
+        for i in 0..10_000u64 {
+            let before = archive.total_lines();
+            archive
+                .append_chunk(&DebugChunk {
+                    direction: Direction::Rx,
+                    ts_ms: i,
+                    bytes: format!("line {i} padding padding padding\n").into_bytes(),
+                })
+                .unwrap();
+            if archive.total_lines() == before {
+                return archive.total_lines();
+            }
+        }
+        panic!("archive never reached its cap");
+    }
+
+    #[test]
+    fn capped_archive_stops_numbering_lines_and_keeps_index_consistent() {
+        let dir = temp_serial_debug_dir("cap-stop-writing");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+        archive.set_max_bytes(4096);
+
+        let capped_at = fill_until_capped(&mut archive);
+        assert!(capped_at > 0, "some lines must land before the cap");
+
+        // The cap must not hand out line numbers for lines that never reached
+        // the .idx file — a hole there would make (line_no - 1) * 16 read the
+        // wrong entry for every later line, silently.
+        let idx_len = std::fs::metadata(&archive.idx_path).unwrap().len();
+        assert_eq!(idx_len, capped_at * ARCHIVE_INDEX_ENTRY_BYTES);
+        let log_len = std::fs::metadata(&archive.log_path).unwrap().len();
+        assert_eq!(log_len, archive.next_offset);
+        assert!(log_len <= 4096, "cap must bound the payload: {log_len}");
+
+        // Every numbered line is still readable at its indexed offset.
+        let all = archive.read_line_range(1, capped_at).unwrap();
+        assert_eq!(all.len() as u64, capped_at);
+        assert_eq!(all.last().unwrap().line_no, capped_at);
+
+        // The last archived line announces the cap rather than truncating
+        // silently — as a sentinel the frontend translates, never as prose.
+        let notice = all.last().unwrap();
+        assert_eq!(notice.direction, LogDirection::Sys);
+        // Pins the wire format mirrored in
+        // src/features/serial-debug/archive-line-text.ts.
+        assert_eq!(notice.text, "\u{1}tyutool:archive-capped:1\u{1}");
+        assert_eq!(serial_debug_archive_cap_limit_mib(notice), Some(1));
+
+        // Further appends change nothing at all.
+        let before = archive.total_lines();
+        archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 9,
+                bytes: b"still flowing\n".to_vec(),
+            })
+            .unwrap();
+        assert_eq!(archive.total_lines(), before);
+        assert_eq!(
+            std::fs::metadata(&archive.idx_path).unwrap().len(),
+            idx_len,
+            "index must not grow after the cap"
+        );
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn cap_sentinel_is_only_recognised_on_an_exact_sys_line() {
+        let sentinel = |direction, text: &str| SerialDebugLine {
+            line_no: 1,
+            ts_ms: 0,
+            direction,
+            text: text.to_string(),
+            raw_bytes: None,
+        };
+
+        assert_eq!(
+            serial_debug_archive_cap_limit_mib(&sentinel(
+                LogDirection::Sys,
+                &serial_debug_archive_cap_sentinel(256)
+            )),
+            Some(256)
+        );
+
+        // A device that echoes the marker byte-for-byte still cannot forge the
+        // notice: its output is never a Sys line.
+        assert_eq!(
+            serial_debug_archive_cap_limit_mib(&sentinel(
+                LogDirection::Rx,
+                &serial_debug_archive_cap_sentinel(256)
+            )),
+            None
+        );
+
+        // Whole-string match only — an embedding line is not a sentinel.
+        for text in [
+            &format!("boot: {}", serial_debug_archive_cap_sentinel(256)),
+            &format!("{} trailing", serial_debug_archive_cap_sentinel(256)),
+            "\u{1}tyutool:archive-capped:\u{1}",
+            "\u{1}tyutool:archive-capped:12x\u{1}",
+            "tyutool:archive-capped:256",
+            "session archive reached its 256 MiB limit",
+        ] {
+            assert_eq!(
+                serial_debug_archive_cap_limit_mib(&sentinel(LogDirection::Sys, text)),
+                None,
+                "must not match: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn capped_archive_returns_no_lines_and_freezes_filter_matches() {
+        let dir = temp_serial_debug_dir("cap-filter-freeze");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+        let mut filters = SerialDebugFilterIndex::create(&dir).unwrap();
+        let filter = filters
+            .add_filter("line".into(), false, "#f00".into(), 0)
+            .unwrap();
+        archive.set_max_bytes(4096);
+
+        loop {
+            let completed = archive
+                .append_chunk(&DebugChunk {
+                    direction: Direction::Rx,
+                    ts_ms: 1,
+                    bytes: b"line padding padding padding padding\n".to_vec(),
+                })
+                .unwrap();
+            filters.ingest_completed_lines(&completed).unwrap();
+            if completed.is_empty() {
+                break;
+            }
+        }
+        let frozen = filters.stats(&filter.id).unwrap().total_matches;
+
+        for _ in 0..5 {
+            let completed = archive
+                .append_chunk(&DebugChunk {
+                    direction: Direction::Rx,
+                    ts_ms: 2,
+                    bytes: b"line after the cap\n".to_vec(),
+                })
+                .unwrap();
+            assert!(completed.is_empty(), "capped archive yields no lines");
+            filters.ingest_completed_lines(&completed).unwrap();
+        }
+        assert_eq!(filters.stats(&filter.id).unwrap().total_matches, frozen);
+
+        // Sys lines are dropped too, and report it.
+        assert!(archive.append_sys_line(3, "note".into()).unwrap().is_none());
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn clear_resets_the_capped_state() {
+        let dir = temp_serial_debug_dir("cap-clear");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+        archive.set_max_bytes(4096);
+        fill_until_capped(&mut archive);
+
+        archive.clear().unwrap();
+        assert_eq!(archive.total_lines(), 0);
+
+        let completed = archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 1,
+                bytes: b"after clear\n".to_vec(),
+            })
+            .unwrap();
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0].line_no, 1);
+        assert_eq!(completed[0].text, "after clear");
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn raising_the_limit_resumes_archiving_a_capped_session() {
+        let dir = temp_serial_debug_dir("cap-raise");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+        archive.set_max_bytes(4096);
+        let capped_at = fill_until_capped(&mut archive);
+
+        archive.set_max_bytes(64 * 1024);
+        let completed = archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 1,
+                bytes: b"after raise\n".to_vec(),
+            })
+            .unwrap();
+        assert_eq!(completed.len(), 1);
+        assert_eq!(completed[0].line_no, capped_at + 1);
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn archive_lines_do_not_carry_raw_bytes_into_the_session_file() {
+        let dir = temp_serial_debug_dir("no-raw-bytes");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+        let completed = archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 1,
+                bytes: b"hello\n".to_vec(),
+            })
+            .unwrap();
+        assert_eq!(completed[0].text, "hello");
+        assert!(completed[0].raw_bytes.is_none());
+
+        let raw = std::fs::read_to_string(&archive.log_path).unwrap();
+        assert!(
+            !raw.contains("rawBytes"),
+            "archive JSON must stay lean: {raw}"
+        );
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn prune_removes_session_pairs_but_never_live_filter_indexes() {
+        let dir = temp_serial_debug_dir("prune-keeps-filter-idx");
+        // A live filter's match index lives in the same directory and shares the
+        // `.idx` extension — pruning by extension would delete it mid-session.
+        let filter_idx = dir.join("serial-debug-filter-filter-1.idx");
+        let filter_live_idx = dir.join("serial-debug-filter-filter-1.live.idx");
+        std::fs::write(&filter_idx, b"keep me").unwrap();
+        std::fs::write(&filter_live_idx, b"keep me too").unwrap();
+
+        let mut created = Vec::new();
+        for i in 0..(MAX_ARCHIVE_SESSIONS + 3) {
+            let ndjson = dir.join(format!(
+                "{SERIAL_DEBUG_SESSION_FILE_PREFIX}{i:04}-1-0.ndjson"
+            ));
+            let idx = dir.join(format!("{SERIAL_DEBUG_SESSION_FILE_PREFIX}{i:04}-1-0.idx"));
+            std::fs::write(&ndjson, b"{}\n").unwrap();
+            std::fs::write(&idx, [0u8; 16]).unwrap();
+            // Distinct mtimes: prune orders by mtime, oldest first.
+            std::thread::sleep(std::time::Duration::from_millis(5));
+            created.push((ndjson, idx));
+        }
+
+        prune_serial_debug_archives(&dir);
+
+        assert!(filter_idx.exists(), "live filter match index must survive");
+        assert!(
+            filter_live_idx.exists(),
+            "pending live filter match index must survive"
+        );
+
+        let surviving = created.iter().filter(|(ndjson, _)| ndjson.exists()).count();
+        assert_eq!(surviving, MAX_ARCHIVE_SESSIONS);
+        for (ndjson, idx) in &created {
+            assert_eq!(
+                ndjson.exists(),
+                idx.exists(),
+                "both halves of a pair must go together: {ndjson:?}"
+            );
+        }
+        // The newest pairs are the ones kept.
+        assert!(created.last().unwrap().0.exists());
+        assert!(!created.first().unwrap().0.exists());
 
         std::fs::remove_dir_all(dir).unwrap();
     }

--- a/crates/tyutool-core/src/serial_debug.rs
+++ b/crates/tyutool-core/src/serial_debug.rs
@@ -70,6 +70,18 @@ const ARCHIVE_INDEX_ENTRY_BYTES: u64 = 16;
 const FILTER_MATCH_INDEX_ENTRY_BYTES: u64 = 8;
 const MAX_PENDING_SERIAL_DEBUG_LINE_BYTES: usize = 4096;
 const FILTER_BACKFILL_READ_BATCH_LINES: u64 = 512;
+/// How many `.idx` entries one archive read pulls in a single `read_exact`
+/// (16 KiB). A page is 400 lines, so a normal page costs exactly one index
+/// read; the cap only bounds the buffer when a caller asks for a huge `limit`.
+const ARCHIVE_READ_INDEX_BATCH_LINES: usize = 1024;
+/// Byte budget for one bulk read out of the `.ndjson`. Consecutive archived
+/// lines occupy a contiguous byte span (see [`read_line_run`]), so a page is
+/// normally fetched with one `read_exact`; this splits the span when a caller
+/// asks for more lines than the budget covers, so peak memory stays bounded
+/// regardless of `limit`. A line is at most
+/// `MAX_PENDING_SERIAL_DEBUG_LINE_BYTES` of payload, so any single line always
+/// fits and the split always makes progress.
+const ARCHIVE_READ_SPAN_BUDGET_BYTES: u64 = 4 * 1024 * 1024;
 static SERIAL_DEBUG_SESSION_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// Compile-time cap for one session archive. The GUI/web setting overrides this
@@ -256,14 +268,6 @@ impl SerialDebugDropCounter {
         }
         Some(SerialDebugDropReport { chunks, bytes })
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct SerialDebugArchiveMeta {
-    pub session_id: String,
-    pub log_path: String,
-    pub total_lines: u64,
 }
 
 pub struct SerialDebugArchive {
@@ -564,14 +568,6 @@ impl SerialDebugArchive {
         }
     }
 
-    pub fn meta(&self) -> SerialDebugArchiveMeta {
-        SerialDebugArchiveMeta {
-            session_id: self.session_id.clone(),
-            log_path: self.log_path.display().to_string(),
-            total_lines: self.total_lines(),
-        }
-    }
-
     pub fn total_lines(&self) -> u64 {
         self.next_line_no
     }
@@ -667,27 +663,9 @@ impl SerialDebugArchive {
         ts_ms: u64,
         dropped_bytes: u64,
     ) -> std::io::Result<Vec<SerialDebugLine>> {
-        let pending = match direction {
-            Direction::Tx => &mut self.pending_tx,
-            Direction::Rx => &mut self.pending_rx,
-        };
-        let partial = std::mem::take(pending);
         let mut written = Vec::new();
-        if !partial.is_empty() {
-            let text_end = partial
-                .iter()
-                .rposition(|&b| b != b'\n' && b != b'\r')
-                .map(|idx| idx + 1)
-                .unwrap_or(0);
-            if let Some(line) = self.append_line(SerialDebugLine {
-                line_no: 0,
-                ts_ms,
-                direction: log_direction(direction),
-                text: String::from_utf8_lossy(&partial[..text_end]).into_owned(),
-                raw_bytes: None,
-            })? {
-                written.push(line);
-            }
+        if let Some(line) = self.close_pending_line(direction, ts_ms)? {
+            written.push(line);
         }
         if let Some(line) = self.append_line(SerialDebugLine {
             line_no: 0,
@@ -703,6 +681,59 @@ impl SerialDebugArchive {
             self.flush_writers()?;
         }
         Ok(written)
+    }
+
+    /// Close whatever is still buffered in *both* directions, for the end of a
+    /// session. Returns the lines written, newest last.
+    ///
+    /// `append_chunk` only cuts a line at `\n`, so output the device never
+    /// terminated — a `login: ` prompt, a progress bar, a bootloader prompt —
+    /// stays in the pending buffer. Without this the port closes on top of it
+    /// and those bytes exist nowhere: not in the live view, not in the archive,
+    /// and therefore not in the export, the auto-save file, the filter tabs or
+    /// the history window either. Empty buffers write nothing, so closing a
+    /// quiet session adds no blank line.
+    pub fn finalize_pending_lines(&mut self, ts_ms: u64) -> std::io::Result<Vec<SerialDebugLine>> {
+        let mut written = Vec::new();
+        for direction in [Direction::Tx, Direction::Rx] {
+            if let Some(line) = self.close_pending_line(direction, ts_ms)? {
+                written.push(line);
+            }
+        }
+        if !written.is_empty() {
+            self.flush_writers()?;
+        }
+        Ok(written)
+    }
+
+    /// Cut whatever is buffered for `direction` into a line of its own. `None`
+    /// when nothing is buffered (or the archive is capped). Does not flush —
+    /// callers batch that with the rest of what they write.
+    fn close_pending_line(
+        &mut self,
+        direction: Direction,
+        ts_ms: u64,
+    ) -> std::io::Result<Option<SerialDebugLine>> {
+        let pending = match direction {
+            Direction::Tx => &mut self.pending_tx,
+            Direction::Rx => &mut self.pending_rx,
+        };
+        let partial = std::mem::take(pending);
+        if partial.is_empty() {
+            return Ok(None);
+        }
+        let text_end = partial
+            .iter()
+            .rposition(|&b| b != b'\n' && b != b'\r')
+            .map(|idx| idx + 1)
+            .unwrap_or(0);
+        self.append_line(SerialDebugLine {
+            line_no: 0,
+            ts_ms,
+            direction: log_direction(direction),
+            text: String::from_utf8_lossy(&partial[..text_end]).into_owned(),
+            raw_bytes: None,
+        })
     }
 
     /// Returns `None` once the archive is capped (see [`Self::append_line`]).
@@ -735,15 +766,16 @@ impl SerialDebugArchive {
     }
 
     pub fn read_lines(&self, line_nos: &[u64]) -> std::io::Result<Vec<SerialDebugLine>> {
-        let mut idx_file = File::open(&self.idx_path)?;
-        let mut log_file = File::open(&self.log_path)?;
-        let mut items = Vec::with_capacity(line_nos.len());
-        for &line_no in line_nos {
-            if let Some(line) = self.read_line_with_files(line_no, &mut idx_file, &mut log_file)? {
-                items.push(line);
-            }
-        }
-        Ok(items)
+        // `total_lines()` is read once, before any I/O. The archive is
+        // append-only, so a run bounded by that snapshot is fully written and
+        // flushed for the whole read — nothing a later append does can move
+        // bytes the run already covers.
+        read_archive_lines(
+            &self.log_path,
+            &self.idx_path,
+            line_nos,
+            Some(self.total_lines()),
+        )
     }
 
     pub fn read_page(&self, start: u64, limit: u64) -> std::io::Result<SerialDebugSessionPage> {
@@ -871,22 +903,6 @@ impl SerialDebugArchive {
         self.read_index_entry_with_file(line_no, &mut idx_file)
     }
 
-    fn read_line_with_files(
-        &self,
-        line_no: u64,
-        idx_file: &mut File,
-        log_file: &mut File,
-    ) -> std::io::Result<Option<SerialDebugLine>> {
-        if line_no == 0 || line_no > self.total_lines() {
-            return Ok(None);
-        }
-        let (offset, len) = self.read_index_entry_with_file(line_no, idx_file)?;
-        log_file.seek(SeekFrom::Start(offset))?;
-        let mut buf = vec![0u8; len as usize];
-        log_file.read_exact(&mut buf)?;
-        Ok(Some(serde_json::from_slice::<SerialDebugLine>(&buf)?))
-    }
-
     fn read_index_entry_with_file(
         &self,
         line_no: u64,
@@ -926,26 +942,11 @@ impl SerialDebugArchive {
 
 impl SerialDebugArchiveReader {
     pub fn read_lines(&self, line_nos: &[u64]) -> std::io::Result<Vec<SerialDebugLine>> {
-        let mut idx_file = File::open(&self.idx_path)?;
-        let mut log_file = File::open(&self.log_path)?;
-        let mut items = Vec::with_capacity(line_nos.len());
-        for &line_no in line_nos {
-            if line_no == 0 {
-                continue;
-            }
-            idx_file.seek(SeekFrom::Start((line_no - 1) * ARCHIVE_INDEX_ENTRY_BYTES))?;
-            let mut offset_buf = [0u8; 8];
-            let mut len_buf = [0u8; 8];
-            idx_file.read_exact(&mut offset_buf)?;
-            idx_file.read_exact(&mut len_buf)?;
-            let offset = u64::from_le_bytes(offset_buf);
-            let len = u64::from_le_bytes(len_buf);
-            log_file.seek(SeekFrom::Start(offset))?;
-            let mut buf = vec![0u8; len as usize];
-            log_file.read_exact(&mut buf)?;
-            items.push(serde_json::from_slice::<SerialDebugLine>(&buf)?);
-        }
-        Ok(items)
+        // No `total_lines` bound here: the reader is a path snapshot with no
+        // view of the writer's counter, so a line number past the end still
+        // fails the `.idx` read as it always has. Callers bound the range with
+        // the total they snapshotted alongside the reader.
+        read_archive_lines(&self.log_path, &self.idx_path, line_nos, None)
     }
 
     pub fn read_line_range(
@@ -959,6 +960,119 @@ impl SerialDebugArchiveReader {
         let line_nos = (start_line_no..start_line_no.saturating_add(limit)).collect::<Vec<_>>();
         self.read_lines(&line_nos)
     }
+}
+
+/// Read the archived lines named by `line_nos`, in that order, skipping line 0
+/// and — when `max_line_no` is set — anything past the end of the archive.
+///
+/// Line numbers that ascend by exactly one are grouped into a *run* and fetched
+/// by [`read_line_run`] with a handful of syscalls instead of four per line;
+/// that is the whole point, since paging (`read_page` / `read_line_range`) asks
+/// for nothing but one long run. Sparse input — a filter's match list — simply
+/// degenerates to runs of length one, which cost what the per-line path always
+/// cost.
+fn read_archive_lines(
+    log_path: &std::path::Path,
+    idx_path: &std::path::Path,
+    line_nos: &[u64],
+    max_line_no: Option<u64>,
+) -> std::io::Result<Vec<SerialDebugLine>> {
+    let mut idx_file = File::open(idx_path)?;
+    let mut log_file = File::open(log_path)?;
+    let mut items = Vec::with_capacity(line_nos.len());
+    let in_range = |line_no: u64| line_no != 0 && max_line_no.is_none_or(|max| line_no <= max);
+
+    let mut i = 0;
+    while i < line_nos.len() {
+        let first = line_nos[i];
+        if !in_range(first) {
+            i += 1;
+            continue;
+        }
+        let mut run = 1;
+        while i + run < line_nos.len() {
+            let next = first.saturating_add(run as u64);
+            if line_nos[i + run] != next || !in_range(next) {
+                break;
+            }
+            run += 1;
+        }
+        read_line_run(&mut idx_file, &mut log_file, first, run, &mut items)?;
+        i += run;
+    }
+    Ok(items)
+}
+
+/// Append `count` consecutive archived lines starting at `first_line_no`
+/// (1-based) to `out`.
+///
+/// The `.idx` entries of consecutive lines are themselves consecutive
+/// (`(line_no - 1) * 16`), and the `.ndjson` is append-only — every line is
+/// written at `next_offset` and advances it by `len + 1` — so the payloads of
+/// consecutive lines form one contiguous byte span with a single `\n` between
+/// them. That holds for every append path (`append_chunk`, `append_gap`,
+/// `append_sys_line`, the cap notice), because they all funnel through
+/// `write_encoded_line`, and the `stopWriting` cap never rewrites or renumbers.
+/// So one seek+read fetches the whole index slice and one more fetches the whole
+/// payload span: 4 syscalls per batch instead of 4 per line.
+fn read_line_run(
+    idx_file: &mut File,
+    log_file: &mut File,
+    first_line_no: u64,
+    count: usize,
+    out: &mut Vec<SerialDebugLine>,
+) -> std::io::Result<()> {
+    let mut done = 0;
+    while done < count {
+        let batch = (count - done).min(ARCHIVE_READ_INDEX_BATCH_LINES);
+        let batch_first = first_line_no + done as u64;
+        idx_file.seek(SeekFrom::Start(
+            (batch_first - 1) * ARCHIVE_INDEX_ENTRY_BYTES,
+        ))?;
+        let mut idx_buf = vec![0u8; batch * ARCHIVE_INDEX_ENTRY_BYTES as usize];
+        idx_file.read_exact(&mut idx_buf)?;
+
+        let entries = idx_buf
+            .chunks_exact(ARCHIVE_INDEX_ENTRY_BYTES as usize)
+            .map(|entry| {
+                let mut offset = [0u8; 8];
+                let mut len = [0u8; 8];
+                offset.copy_from_slice(&entry[..8]);
+                len.copy_from_slice(&entry[8..]);
+                (u64::from_le_bytes(offset), u64::from_le_bytes(len))
+            })
+            .collect::<Vec<_>>();
+
+        let mut i = 0;
+        while i < entries.len() {
+            // Grow the span while it stays inside the byte budget; `last` never
+            // stays below `i`, so a single oversized line still makes progress.
+            let (span_start, first_len) = entries[i];
+            let mut last = i;
+            let mut span_end = span_start + first_len;
+            while last + 1 < entries.len() {
+                let (next_offset, next_len) = entries[last + 1];
+                let next_end = next_offset + next_len;
+                if next_end - span_start > ARCHIVE_READ_SPAN_BUDGET_BYTES {
+                    break;
+                }
+                last += 1;
+                span_end = next_end;
+            }
+            let mut span = vec![0u8; (span_end - span_start) as usize];
+            log_file.seek(SeekFrom::Start(span_start))?;
+            log_file.read_exact(&mut span)?;
+            for &(offset, len) in &entries[i..=last] {
+                let from = (offset - span_start) as usize;
+                out.push(serde_json::from_slice::<SerialDebugLine>(
+                    &span[from..from + len as usize],
+                )?);
+            }
+            i = last + 1;
+        }
+        done += batch;
+    }
+    Ok(())
 }
 
 impl SerialDebugFilterIndex {
@@ -2630,6 +2744,71 @@ mod tests {
         std::fs::remove_dir_all(dir).unwrap();
     }
 
+    /// Closing a port must not swallow what the device printed last. A prompt
+    /// (`login: `), a progress bar or a bootloader banner carries no trailing
+    /// newline, so nothing else in the archive ever cuts it.
+    #[test]
+    fn finalize_pending_lines_archives_the_unterminated_tail_of_both_directions() {
+        let dir = temp_serial_debug_dir("finalize-tail");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+
+        archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Tx,
+                ts_ms: 1,
+                bytes: b"who".to_vec(),
+            })
+            .unwrap();
+        archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 2,
+                bytes: b"login: ".to_vec(),
+            })
+            .unwrap();
+        assert_eq!(archive.total_lines(), 0, "neither side ended in a newline");
+
+        let written = archive.finalize_pending_lines(3).unwrap();
+
+        assert_eq!(written.len(), 2);
+        assert_eq!(written[0].direction, LogDirection::Tx);
+        assert_eq!(written[0].text, "who");
+        assert_eq!(written[1].direction, LogDirection::Rx);
+        assert_eq!(written[1].text, "login: ");
+        // Readable from the archive file, not just returned: that is what the
+        // export, the auto-save backfill and the history window read.
+        let all = archive.read_line_range(1, 10).unwrap();
+        assert_eq!(
+            all.iter().map(|l| l.text.as_str()).collect::<Vec<_>>(),
+            vec!["who", "login: "]
+        );
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn finalize_pending_lines_writes_nothing_when_nothing_is_buffered() {
+        let dir = temp_serial_debug_dir("finalize-empty");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+
+        archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 1,
+                bytes: b"done\n".to_vec(),
+            })
+            .unwrap();
+
+        // Every byte already ended in a line; closing must not add a blank one.
+        assert!(archive.finalize_pending_lines(2).unwrap().is_empty());
+        assert_eq!(archive.total_lines(), 1);
+        // Idempotent: a second close still has nothing to cut.
+        assert!(archive.finalize_pending_lines(3).unwrap().is_empty());
+        assert_eq!(archive.total_lines(), 1);
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
     #[test]
     fn drop_counter_coalesces_a_burst_into_one_report() {
         let drops = SerialDebugDropCounter::default();
@@ -2873,6 +3052,234 @@ mod tests {
             .unwrap();
         assert_eq!(completed_tail.len(), 1);
         assert_eq!(completed_tail[0].text.len(), 8);
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    /// The pre-batching reader: seek+read the index entry, then seek+read the
+    /// payload, once per line. Kept here as the reference that the batched
+    /// `read_archive_lines` has to reproduce exactly.
+    fn read_lines_one_at_a_time(
+        log_path: &std::path::Path,
+        idx_path: &std::path::Path,
+        line_nos: &[u64],
+        max_line_no: Option<u64>,
+    ) -> Vec<SerialDebugLine> {
+        let mut idx_file = File::open(idx_path).unwrap();
+        let mut log_file = File::open(log_path).unwrap();
+        let mut items = Vec::new();
+        for &line_no in line_nos {
+            if line_no == 0 || max_line_no.is_some_and(|max| line_no > max) {
+                continue;
+            }
+            idx_file
+                .seek(SeekFrom::Start((line_no - 1) * ARCHIVE_INDEX_ENTRY_BYTES))
+                .unwrap();
+            let mut offset_buf = [0u8; 8];
+            let mut len_buf = [0u8; 8];
+            idx_file.read_exact(&mut offset_buf).unwrap();
+            idx_file.read_exact(&mut len_buf).unwrap();
+            let offset = u64::from_le_bytes(offset_buf);
+            let len = u64::from_le_bytes(len_buf);
+            log_file.seek(SeekFrom::Start(offset)).unwrap();
+            let mut buf = vec![0u8; len as usize];
+            log_file.read_exact(&mut buf).unwrap();
+            items.push(serde_json::from_slice::<SerialDebugLine>(&buf).unwrap());
+        }
+        items
+    }
+
+    /// `read_page(start, limit)` must return exactly what the one-line-at-a-time
+    /// reader returns for the same window, and must keep clamping `start`
+    /// silently — the frontend reads `items[0].lineNo`, but `page.start` is part
+    /// of the contract all the same.
+    fn assert_read_page_matches_reference(archive: &SerialDebugArchive, start: u64, limit: u64) {
+        let total = archive.total_lines();
+        let clamped_start = start.min(total);
+        let end = clamped_start.saturating_add(limit).min(total);
+        let expected = read_lines_one_at_a_time(
+            &archive.log_path,
+            &archive.idx_path,
+            &(clamped_start + 1..=end).collect::<Vec<_>>(),
+            Some(total),
+        );
+
+        let page = archive.read_page(start, limit).unwrap();
+        assert_eq!(page.total_lines, total, "start={start} limit={limit}");
+        assert_eq!(page.start, clamped_start, "start={start} limit={limit}");
+        assert_eq!(page.items, expected, "start={start} limit={limit}");
+    }
+
+    fn append_numbered_lines(archive: &mut SerialDebugArchive, count: u64) {
+        let mut bytes = Vec::new();
+        for i in 1..=count {
+            bytes.extend_from_slice(format!("line {i} payload\n").as_bytes());
+        }
+        archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 7,
+                bytes,
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn archive_read_page_matches_line_by_line_reads() {
+        let dir = temp_serial_debug_dir("read-page-equivalence");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+
+        // Empty archive: every window is empty and `start` clamps to 0.
+        assert_read_page_matches_reference(&archive, 0, 400);
+        assert_read_page_matches_reference(&archive, 9, 400);
+
+        // Single line.
+        append_numbered_lines(&mut archive, 1);
+        assert_read_page_matches_reference(&archive, 0, 400);
+        assert_read_page_matches_reference(&archive, 1, 400);
+        assert_read_page_matches_reference(&archive, 5, 400);
+
+        // 907 lines over a 400-line page size: two full pages, a short last
+        // page, and both page boundaries.
+        append_numbered_lines(&mut archive, 906);
+        assert_eq!(archive.total_lines(), 907);
+        for start in [0, 1, 399, 400, 401, 799, 800, 906, 907] {
+            assert_read_page_matches_reference(&archive, start, 400);
+        }
+        // `start` past the end is clamped silently, not rejected.
+        for start in [908, 5_000, u64::MAX] {
+            assert_read_page_matches_reference(&archive, start, 400);
+        }
+        assert!(archive.read_page(908, 400).unwrap().items.is_empty());
+        assert_eq!(archive.read_page(908, 400).unwrap().start, 907);
+        // Degenerate limits.
+        assert_read_page_matches_reference(&archive, 10, 0);
+        assert_read_page_matches_reference(&archive, 10, 1);
+        assert_read_page_matches_reference(&archive, 0, u64::MAX);
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn archive_read_page_matches_line_by_line_reads_with_gap_and_cap_lines() {
+        let dir = temp_serial_debug_dir("read-page-equivalence-sentinels");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+
+        // A gap closes off the buffered partial line and appends a sentinel, so
+        // the archive holds an ordinary line, a partial line and a `Sys` line
+        // back to back — the contiguous-span assumption has to hold across all
+        // three.
+        append_numbered_lines(&mut archive, 3);
+        archive
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 8,
+                bytes: b"truncated".to_vec(),
+            })
+            .unwrap();
+        archive.append_gap(Direction::Rx, 9, 128).unwrap();
+        append_numbered_lines(&mut archive, 3);
+        archive.append_sys_line(10, "note".into()).unwrap();
+        assert_eq!(archive.total_lines(), 9);
+        for start in 0..=10 {
+            assert_read_page_matches_reference(&archive, start, 4);
+        }
+
+        // Then fill to the cap: the last archived line is the cap sentinel and
+        // nothing is written after it, so the index stays hole-free.
+        archive.set_max_bytes(8192);
+        let capped_at = fill_until_capped(&mut archive);
+        assert!(capped_at > 9);
+        assert!(
+            serial_debug_archive_cap_limit_mib(
+                archive
+                    .read_page(capped_at - 1, 1)
+                    .unwrap()
+                    .items
+                    .first()
+                    .unwrap()
+            )
+            .is_some(),
+            "the last line must be the cap sentinel"
+        );
+        for start in [0, capped_at / 2, capped_at - 1, capped_at, capped_at + 5] {
+            assert_read_page_matches_reference(&archive, start, 400);
+        }
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn archive_read_page_matches_line_by_line_reads_across_read_batches() {
+        let dir = temp_serial_debug_dir("read-page-equivalence-batches");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+        // 1200 near-maximal lines: more than ARCHIVE_READ_INDEX_BATCH_LINES
+        // (1024) and over 4 MiB of payload, so a single-window read has to split
+        // both its index reads and its payload spans.
+        let filler = "x".repeat(4000);
+        for batch in 0..12 {
+            let mut bytes = Vec::new();
+            for i in 0..100 {
+                bytes.extend_from_slice(format!("{}-{i} {filler}\n", batch).as_bytes());
+            }
+            archive
+                .append_chunk(&DebugChunk {
+                    direction: Direction::Rx,
+                    ts_ms: batch,
+                    bytes,
+                })
+                .unwrap();
+        }
+        assert_eq!(archive.total_lines(), 1200);
+        assert_read_page_matches_reference(&archive, 0, 1200);
+        assert_read_page_matches_reference(&archive, 1000, 400);
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn archive_read_lines_matches_line_by_line_reads_for_arbitrary_line_numbers() {
+        let dir = temp_serial_debug_dir("read-lines-equivalence");
+        let mut archive = SerialDebugArchive::create(&dir).unwrap();
+        append_numbered_lines(&mut archive, 20);
+
+        // Sparse (a filter match list), descending, duplicated, line 0 and past
+        // the end all have to behave as before: skip what is out of range, keep
+        // the caller's order everywhere else.
+        for line_nos in [
+            vec![],
+            vec![0],
+            vec![0, 1, 0, 2],
+            vec![3, 7, 8, 9, 15],
+            vec![20, 19, 18],
+            vec![5, 5, 5, 6],
+            vec![18, 19, 20, 21, 22],
+            (1..=20).collect::<Vec<_>>(),
+        ] {
+            let expected = read_lines_one_at_a_time(
+                &archive.log_path,
+                &archive.idx_path,
+                &line_nos,
+                Some(archive.total_lines()),
+            );
+            assert_eq!(
+                archive.read_lines(&line_nos).unwrap(),
+                expected,
+                "{line_nos:?}"
+            );
+
+            // The snapshot reader has no total to clamp against; within the
+            // archive it must agree line for line.
+            if line_nos.iter().all(|&n| n <= 20) {
+                let reader_expected =
+                    read_lines_one_at_a_time(&archive.log_path, &archive.idx_path, &line_nos, None);
+                assert_eq!(
+                    archive.snapshot_reader().read_lines(&line_nos).unwrap(),
+                    reader_expected,
+                    "{line_nos:?}"
+                );
+            }
+        }
 
         std::fs::remove_dir_all(dir).unwrap();
     }

--- a/crates/tyutool-serve/src/lib.rs
+++ b/crates/tyutool-serve/src/lib.rs
@@ -96,6 +96,11 @@ pub enum ClientMessage {
         #[serde(default)]
         request_id: Option<String>,
     },
+    /// Per-session archive byte cap. Without this the `dev:web` archive would
+    /// stay unbounded and the setting would silently do nothing in web mode.
+    SerialDebugSetArchiveLimit {
+        max_bytes: u64,
+    },
     /// Frontend response to `flash_progress` `auth_conflict` milestone.
     AuthorizeConfirm {
         confirmed: bool,
@@ -159,6 +164,11 @@ pub enum ServerMessage {
         page: SerialDebugSessionPage,
         #[serde(skip_serializing_if = "Option::is_none")]
         request_id: Option<String>,
+    },
+    /// The session archive stopped recording. The frontend renders the wording
+    /// from `serialDebug.log.archiveCapped`, so only the number crosses.
+    SerialDebugArchiveCapped {
+        limit_mib: u64,
     },
 }
 
@@ -674,7 +684,13 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
                         }
                     }
                 };
-                ingest_serial_debug_lines_ws(&sink_tx, &debug_filters, &[line]);
+                // `None` once the session archive hit its size cap.
+                if let Some(line) = line {
+                    ingest_serial_debug_lines_ws(&sink_tx, &debug_filters, &[line]);
+                }
+            }
+            ClientMessage::SerialDebugSetArchiveLimit { max_bytes } => {
+                debug_archive.lock().unwrap().set_max_bytes(max_bytes);
             }
             ClientMessage::SerialDebugFilterAdd {
                 keyword,
@@ -974,6 +990,24 @@ fn spawn_serial_debug_chunk_bridge_ws(
     handle
 }
 
+/// Every line the archive accepts passes through `ingest_serial_debug_lines_ws`,
+/// which makes it the one place that can spot the archive-cap sentinel. The live
+/// view never sees archived lines — it re-splits the raw `serial_debug_chunk*`
+/// payloads itself — so without this message the cap notice would only ever
+/// exist in the archive file and the user would watch the log keep scrolling
+/// with no hint that recording had stopped.
+fn emit_archive_cap_notice_ws(
+    sink_tx: &tokio::sync::mpsc::UnboundedSender<ServerMessage>,
+    lines: &[SerialDebugLine],
+) {
+    if let Some(limit_mib) = lines
+        .iter()
+        .find_map(tyutool_core::serial_debug_archive_cap_limit_mib)
+    {
+        let _ = sink_tx.send(ServerMessage::SerialDebugArchiveCapped { limit_mib });
+    }
+}
+
 fn ingest_serial_debug_lines_ws(
     sink_tx: &tokio::sync::mpsc::UnboundedSender<ServerMessage>,
     filters: &Arc<Mutex<SerialDebugFilterIndex>>,
@@ -982,6 +1016,7 @@ fn ingest_serial_debug_lines_ws(
     if lines.is_empty() {
         return;
     }
+    emit_archive_cap_notice_ws(sink_tx, lines);
     let updates = {
         let mut guard = match filters.lock() {
             Ok(guard) => guard,
@@ -1288,6 +1323,20 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_serial_debug_set_archive_limit() {
+        let msg: ClientMessage = serde_json::from_str(
+            r#"{"type":"serial_debug_set_archive_limit","max_bytes":268435456}"#,
+        )
+        .unwrap();
+        match msg {
+            ClientMessage::SerialDebugSetArchiveLimit { max_bytes } => {
+                assert_eq!(max_bytes, 268_435_456)
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
     fn deserialize_serial_debug_device_reset() {
         let msg: ClientMessage =
             serde_json::from_str(r#"{"type":"serial_debug_device_reset","chip_id":"T5AI"}"#)
@@ -1478,6 +1527,41 @@ mod tests {
         .unwrap();
         assert!(disc.contains(r#""type":"serial_debug_disconnected""#));
         assert!(disc.contains(r#""reason":"device removed""#));
+    }
+
+    #[test]
+    fn archive_cap_sentinel_becomes_an_archive_capped_message() {
+        let line = |direction, text: String| SerialDebugLine {
+            line_no: 7,
+            ts_ms: 1,
+            direction,
+            text,
+            raw_bytes: None,
+        };
+        let (sink_tx, mut sink_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        emit_archive_cap_notice_ws(
+            &sink_tx,
+            &[line(
+                tyutool_core::LogDirection::Sys,
+                tyutool_core::serial_debug_archive_cap_sentinel(64),
+            )],
+        );
+        let json = serde_json::to_string(&sink_rx.try_recv().unwrap()).unwrap();
+        assert!(json.contains(r#""type":"serial_debug_archive_capped""#));
+        // snake_case like every other ServerMessage field (cf. `request_id`);
+        // `ws-transport.ts` maps it to `limitMib` at the boundary.
+        assert!(json.contains(r#""limit_mib":64"#), "{json}");
+
+        // Ordinary device output never triggers it, even byte-for-byte.
+        emit_archive_cap_notice_ws(
+            &sink_tx,
+            &[line(
+                tyutool_core::LogDirection::Rx,
+                tyutool_core::serial_debug_archive_cap_sentinel(64),
+            )],
+        );
+        assert!(sink_rx.try_recv().is_err());
     }
 
     #[test]

--- a/crates/tyutool-serve/src/lib.rs
+++ b/crates/tyutool-serve/src/lib.rs
@@ -135,10 +135,10 @@ pub enum ServerMessage {
         request_id: Option<String>,
     },
     SerialDebugChunk {
-        chunk: DebugChunk,
+        chunk: ArchivedChunk,
     },
     SerialDebugChunkBatch {
-        chunks: Vec<DebugChunk>,
+        chunks: Vec<ArchivedChunk>,
     },
     SerialDebugOpened,
     SerialDebugClosed,
@@ -170,13 +170,36 @@ pub enum ServerMessage {
     /// from `serialDebug.log.archiveCapped`, so only the number crosses.
     SerialDebugArchiveCapped {
         limit_mib: u64,
+        /// `archived_before` of the cap sentinel itself — see [`ArchivedChunk`].
+        archived_before: u64,
     },
     /// Device output was dropped because the bridge queue was full. One message
     /// per coalesced burst; the wording comes from
     /// `serialDebug.log.chunksDropped`.
     SerialDebugChunksDropped {
         dropped_bytes: u64,
+        /// `archived_before` of the gap lines this notice belongs to — see
+        /// [`ArchivedChunk`].
+        archived_before: u64,
     },
+}
+
+/// One chunk on its way to the browser, plus the number of lines the session
+/// archive held *before* this chunk was appended to it. Twin of `ArchivedChunk`
+/// in `src-tauri/src/serial_debug.rs`, which carries the full rationale: it is
+/// what lets the frontend enable auto-save mid-session without duplicating or
+/// losing a line, and it is exact because `append_chunk` archives a whole chunk
+/// under one lock, so no snapshot can land inside a chunk.
+///
+/// Flattened into the `chunk` object, which already serialises camelCase
+/// (`tsMs`), so the field reaches the frontend as `archivedBefore` with no
+/// mapping in `ws-transport.ts`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchivedChunk {
+    #[serde(flatten)]
+    pub chunk: DebugChunk,
+    pub archived_before: u64,
 }
 
 enum SerialDebugChunkBridgeMessage {
@@ -595,6 +618,10 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
                 if let Some(bridge) = debug_chunk_bridge.lock().unwrap().take() {
                     let _ = bridge.shutdown();
                 }
+                // After the bridge's shutdown ack, so everything it was still
+                // holding is archived and the tail is cut behind all of it.
+                let lines = finalize_serial_debug_pending_ws(&debug_archive);
+                ingest_serial_debug_lines_ws(&sink_tx, &debug_filters, &lines);
                 let _ = sink_tx.send(ServerMessage::SerialDebugClosed);
             }
             ClientMessage::SerialDebugDeviceReset { chip_id } => {
@@ -637,12 +664,24 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
                         ts_ms,
                         bytes,
                     };
-                    let completed = {
+                    // Tx chunks bypass the bounded bridge queue and are archived
+                    // right here, so this is where `archived_before` has to be
+                    // read (same lock guard).
+                    let (completed, archived_before) = {
                         let mut archive = debug_archive.lock().unwrap();
-                        archive.append_chunk(&chunk).unwrap_or_default()
+                        let archived_before = archive.total_lines();
+                        (
+                            archive.append_chunk(&chunk).unwrap_or_default(),
+                            archived_before,
+                        )
                     };
                     ingest_serial_debug_lines_ws(&sink_tx, &debug_filters, &completed);
-                    let _ = sink_tx.send(ServerMessage::SerialDebugChunk { chunk });
+                    let _ = sink_tx.send(ServerMessage::SerialDebugChunk {
+                        chunk: ArchivedChunk {
+                            chunk,
+                            archived_before,
+                        },
+                    });
                 } else {
                     let _ = sink_tx.send(ServerMessage::Error {
                         message: "serial debug not open".into(),
@@ -931,19 +970,27 @@ fn flush_serial_debug_chunk_ws(
     if chunks.is_empty() {
         return;
     }
-    let completed = {
-        let mut archive = match archive.lock() {
+    let (completed, archived) = {
+        let mut guard = match archive.lock() {
             Ok(guard) => guard,
             Err(_) => return,
         };
         let mut completed = Vec::new();
-        for chunk in &chunks {
-            completed.extend(archive.append_chunk(chunk).unwrap_or_default());
+        let mut archived = Vec::with_capacity(chunks.len());
+        // One `archived_before` per chunk, not one per batch — see the twin in
+        // `src-tauri/src/serial_debug.rs`.
+        for chunk in chunks {
+            let archived_before = guard.total_lines();
+            completed.extend(guard.append_chunk(&chunk).unwrap_or_default());
+            archived.push(ArchivedChunk {
+                chunk,
+                archived_before,
+            });
         }
-        completed
+        (completed, archived)
     };
     ingest_serial_debug_lines_ws(sink_tx, filters, &completed);
-    let _ = sink_tx.send(ServerMessage::SerialDebugChunkBatch { chunks });
+    let _ = sink_tx.send(ServerMessage::SerialDebugChunkBatch { chunks: archived });
 }
 
 /// Surface one coalesced burst of dropped chunks — `log::warn!` for the
@@ -968,19 +1015,45 @@ fn report_serial_debug_drops_ws(
     );
     // Only the reader thread's Rx chunks travel the bounded queue: the Tx path
     // (`SerialDebugSend`) writes straight to the archive.
-    let lines = {
+    let (lines, archived_before) = {
         let mut guard = match archive.lock() {
             Ok(guard) => guard,
             Err(_) => return,
         };
-        guard
-            .append_gap(Direction::Rx, serial_debug_now_ms(), report.bytes)
-            .unwrap_or_default()
+        // `append_gap` writes the cut-off partial line and the sentinel under one
+        // lock, so one number covers both frontend lines.
+        let archived_before = guard.total_lines();
+        (
+            guard
+                .append_gap(Direction::Rx, serial_debug_now_ms(), report.bytes)
+                .unwrap_or_default(),
+            archived_before,
+        )
     };
     ingest_serial_debug_lines_ws(sink_tx, filters, &lines);
     let _ = sink_tx.send(ServerMessage::SerialDebugChunksDropped {
         dropped_bytes: report.bytes,
+        archived_before,
     });
+}
+
+/// Cut the tail the device never terminated into the archive, at the end of a
+/// session. Twin of `finalize_serial_debug_pending` in `src-tauri`.
+///
+/// Nothing else closes that buffer: `append_chunk` only cuts on a newline and
+/// `append_gap` only runs when a chunk is dropped, so a prompt or a progress bar
+/// — output the device deliberately leaves unterminated — would go down with the
+/// port and appear in neither the live view nor the archive.
+fn finalize_serial_debug_pending_ws(
+    archive: &Arc<Mutex<SerialDebugArchive>>,
+) -> Vec<SerialDebugLine> {
+    let mut guard = match archive.lock() {
+        Ok(guard) => guard,
+        Err(_) => return Vec::new(),
+    };
+    guard
+        .finalize_pending_lines(serial_debug_now_ms())
+        .unwrap_or_default()
 }
 
 fn spawn_serial_debug_chunk_bridge_ws(
@@ -1082,11 +1155,15 @@ fn emit_archive_cap_notice_ws(
     sink_tx: &tokio::sync::mpsc::UnboundedSender<ServerMessage>,
     lines: &[SerialDebugLine],
 ) {
-    if let Some(limit_mib) = lines
-        .iter()
-        .find_map(tyutool_core::serial_debug_archive_cap_limit_mib)
-    {
-        let _ = sink_tx.send(ServerMessage::SerialDebugArchiveCapped { limit_mib });
+    if let Some((limit_mib, line_no)) = lines.iter().find_map(|line| {
+        tyutool_core::serial_debug_archive_cap_limit_mib(line).map(|mib| (mib, line.line_no))
+    }) {
+        let _ = sink_tx.send(ServerMessage::SerialDebugArchiveCapped {
+            limit_mib,
+            // The sentinel is an archive line like any other, so its own
+            // position is exactly `line_no - 1`.
+            archived_before: line_no.saturating_sub(1),
+        });
     }
 }
 
@@ -1634,6 +1711,9 @@ mod tests {
         // snake_case like every other ServerMessage field (cf. `request_id`);
         // `ws-transport.ts` maps it to `limitMib` at the boundary.
         assert!(json.contains(r#""limit_mib":64"#), "{json}");
+        // The sentinel sits at line 7, so it is inside a backfill snapshot iff
+        // that snapshot is >= 7, i.e. iff `archived_before` (6) < snapshot.
+        assert!(json.contains(r#""archived_before":6"#), "{json}");
 
         // Ordinary device output never triggers it, even byte-for-byte.
         emit_archive_cap_notice_ws(
@@ -1644,6 +1724,52 @@ mod tests {
             )],
         );
         assert!(sink_rx.try_recv().is_err());
+    }
+
+    /// The web host must save the tail exactly like the Tauri host: closing the
+    /// port is the last moment output the device left unterminated — a `login: `
+    /// prompt, a progress bar — can reach the archive at all.
+    #[test]
+    fn finalize_serial_debug_pending_ws_archives_the_unterminated_tail() {
+        let dir = std::env::temp_dir().join(format!(
+            "tyutool-serve-close-tail-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let archive = Arc::new(Mutex::new(SerialDebugArchive::create(&dir).unwrap()));
+        archive
+            .lock()
+            .unwrap()
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 1,
+                bytes: b"login: ".to_vec(),
+            })
+            .unwrap();
+        assert_eq!(archive.lock().unwrap().total_lines(), 0, "no newline yet");
+
+        let lines = finalize_serial_debug_pending_ws(&archive);
+
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].text, "login: ");
+        assert_eq!(
+            archive
+                .lock()
+                .unwrap()
+                .read_line_range(1, 10)
+                .unwrap()
+                .iter()
+                .map(|l| l.text.clone())
+                .collect::<Vec<_>>(),
+            vec!["login: ".to_string()]
+        );
+        // Closing again has nothing left to cut: no empty line.
+        assert!(finalize_serial_debug_pending_ws(&archive).is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The web host must report dropped device output exactly like the Tauri
@@ -1693,6 +1819,10 @@ mod tests {
         );
         // snake_case on the wire; `ws-transport.ts` maps it to `droppedBytes`.
         assert!(json.contains(r#""dropped_bytes":12288"#), "{json}");
+        // Nothing was archived before the gap ("before-gap" has no newline yet,
+        // so it is still buffered), and `append_gap` writes both of its lines
+        // under one lock — one number covers the cut line and the notice.
+        assert!(json.contains(r#""archived_before":0"#), "{json}");
 
         // Bytes arriving after the gap must start their own line.
         let after = archive
@@ -1765,33 +1895,91 @@ mod tests {
         assert!(err.contains(r#""message":"boom""#));
 
         let chunk = serde_json::to_string(&ServerMessage::SerialDebugChunk {
-            chunk: DebugChunk {
-                direction: tyutool_core::Direction::Tx,
-                ts_ms: 42,
-                bytes: vec![7, 8],
+            chunk: ArchivedChunk {
+                chunk: DebugChunk {
+                    direction: tyutool_core::Direction::Tx,
+                    ts_ms: 42,
+                    bytes: vec![7, 8],
+                },
+                archived_before: 9,
             },
         })
         .unwrap();
         assert!(chunk.contains(r#""type":"serial_debug_chunk""#));
         assert!(chunk.contains(r#""direction":"tx""#));
+        // Flattened into the chunk object and camelCase like `tsMs`, so
+        // `ws-transport.ts` needs no mapping for it.
+        assert!(chunk.contains(r#""archivedBefore":9"#), "{chunk}");
 
         let batch = serde_json::to_string(&ServerMessage::SerialDebugChunkBatch {
             chunks: vec![
-                DebugChunk {
-                    direction: tyutool_core::Direction::Rx,
-                    ts_ms: 1,
-                    bytes: vec![1],
+                ArchivedChunk {
+                    chunk: DebugChunk {
+                        direction: tyutool_core::Direction::Rx,
+                        ts_ms: 1,
+                        bytes: vec![1],
+                    },
+                    archived_before: 0,
                 },
-                DebugChunk {
-                    direction: tyutool_core::Direction::Rx,
-                    ts_ms: 2,
-                    bytes: vec![2, 3],
+                ArchivedChunk {
+                    chunk: DebugChunk {
+                        direction: tyutool_core::Direction::Rx,
+                        ts_ms: 2,
+                        bytes: vec![2, 3],
+                    },
+                    archived_before: 1,
                 },
             ],
         })
         .unwrap();
         assert!(batch.contains(r#""type":"serial_debug_chunk_batch""#));
         assert!(batch.contains(r#""tsMs":2"#));
+        assert!(batch.contains(r#""archivedBefore":1"#), "{batch}");
+    }
+
+    /// The frontend's mid-session auto-save handoff is exact only if every chunk
+    /// reports the archive line count that existed *before* it was appended —
+    /// per chunk, so a batch of several chunks carries several numbers.
+    #[test]
+    fn chunk_batch_reports_the_archive_position_of_each_chunk() {
+        let dir = std::env::temp_dir().join(format!(
+            "tyutool-serve-chunk-positions-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let archive = Arc::new(Mutex::new(SerialDebugArchive::create(&dir).unwrap()));
+        let filters = Arc::new(Mutex::new(SerialDebugFilterIndex::create(&dir).unwrap()));
+        let (sink_tx, mut sink_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let chunk = |bytes: &[u8]| DebugChunk {
+            direction: Direction::Rx,
+            ts_ms: 1,
+            bytes: bytes.to_vec(),
+        };
+        flush_serial_debug_chunk_ws(
+            &sink_tx,
+            &archive,
+            &filters,
+            vec![
+                chunk(b"one\n"),       // archives line 1
+                chunk(b"partial"),     // archives nothing (no newline yet)
+                chunk(b"-end\ntwo\n"), // archives lines 2 and 3
+            ],
+        );
+
+        let positions = match sink_rx.try_recv().unwrap() {
+            ServerMessage::SerialDebugChunkBatch { chunks } => {
+                chunks.iter().map(|c| c.archived_before).collect::<Vec<_>>()
+            }
+            other => panic!("expected a chunk batch, got {other:?}"),
+        };
+        assert_eq!(positions, vec![0, 1, 1]);
+        assert_eq!(archive.lock().unwrap().total_lines(), 3);
+
+        std::fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]

--- a/crates/tyutool-serve/src/lib.rs
+++ b/crates/tyutool-serve/src/lib.rs
@@ -6,7 +6,7 @@
 
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, RecvTimeoutError, SyncSender};
+use std::sync::mpsc::{self, RecvTimeoutError, SyncSender, TrySendError};
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -27,11 +27,12 @@ use tokio_tungstenite::{
 };
 use tyutool_core::{
     device_reset_dtr_rts, list_serial_ports, run_job, serial_debug_fail_backfill_if_current,
-    serial_debug_finish_backfill_if_current, serial_debug_scan_filter_matches, DebugChunk,
-    DebugConfig, FlashJob, SerialDebugArchive, SerialDebugArchiveReader,
-    SerialDebugChunkBatchBuffer, SerialDebugFilterBackfillSnapshot, SerialDebugFilterDefinition,
-    SerialDebugFilterIndex, SerialDebugFilterPage, SerialDebugFilterStats, SerialDebugGeneration,
-    SerialDebugLine, SerialDebugSession, SerialDebugSessionPage, SerialPortEntry,
+    serial_debug_finish_backfill_if_current, serial_debug_now_ms, serial_debug_scan_filter_matches,
+    DebugChunk, DebugConfig, Direction, FlashJob, SerialDebugArchive, SerialDebugArchiveReader,
+    SerialDebugChunkBatchBuffer, SerialDebugDropCounter, SerialDebugDropReport,
+    SerialDebugFilterBackfillSnapshot, SerialDebugFilterDefinition, SerialDebugFilterIndex,
+    SerialDebugFilterPage, SerialDebugFilterStats, SerialDebugGeneration, SerialDebugLine,
+    SerialDebugSession, SerialDebugSessionPage, SerialPortEntry,
 };
 
 const SERIAL_DEBUG_CHUNK_FLUSH_MS: u64 = 12;
@@ -170,6 +171,12 @@ pub enum ServerMessage {
     SerialDebugArchiveCapped {
         limit_mib: u64,
     },
+    /// Device output was dropped because the bridge queue was full. One message
+    /// per coalesced burst; the wording comes from
+    /// `serialDebug.log.chunksDropped`.
+    SerialDebugChunksDropped {
+        dropped_bytes: u64,
+    },
 }
 
 enum SerialDebugChunkBridgeMessage {
@@ -191,18 +198,27 @@ struct SerialDebugChunkBridgeHandle {
     generation: Arc<SerialDebugGeneration>,
     send_lock: Arc<Mutex<()>>,
     tx: SyncSender<SerialDebugChunkBridgeMessage>,
+    drops: Arc<SerialDebugDropCounter>,
 }
 
 impl SerialDebugChunkBridgeHandle {
-    fn send_chunk(
-        &self,
-        chunk: DebugChunk,
-    ) -> Result<(), std::sync::mpsc::SendError<SerialDebugChunkBridgeMessage>> {
+    /// Hand one chunk to the bridge, or account for it as lost. `try_send`, never
+    /// `send`, for the reason spelled out on the Tauri twin in
+    /// `src-tauri/src/serial_debug.rs`: blocking the serial reader thread stops
+    /// the OS receive buffer being drained, and the driver then discards bytes
+    /// silently. Dropping here keeps the loss countable and reportable.
+    fn send_chunk(&self, chunk: DebugChunk) {
         let _guard = self.send_lock.lock().unwrap();
-        self.tx.send(SerialDebugChunkBridgeMessage::Chunk {
+        let bytes = chunk.bytes.len();
+        match self.tx.try_send(SerialDebugChunkBridgeMessage::Chunk {
             generation: self.generation.current(),
             chunk,
-        })
+        }) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => self.drops.record(bytes, serial_debug_now_ms()),
+            // The bridge thread is gone; the session is being torn down.
+            Err(TrySendError::Disconnected(_)) => {}
+        }
     }
 
     fn reset(&self) -> Result<u64, String> {
@@ -550,7 +566,7 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
                 let result = SerialDebugSession::open(
                     cfg,
                     Box::new(move |chunk| {
-                        let _ = chunk_bridge_for_session.send_chunk(chunk);
+                        chunk_bridge_for_session.send_chunk(chunk);
                     }),
                     Box::new(move |reason| {
                         let _ =
@@ -930,6 +946,43 @@ fn flush_serial_debug_chunk_ws(
     let _ = sink_tx.send(ServerMessage::SerialDebugChunkBatch { chunks });
 }
 
+/// Surface one coalesced burst of dropped chunks — `log::warn!` for the
+/// developer, a gap in the archive and a `Sys` notice for the user. Twin of
+/// `report_serial_debug_drops` in `src-tauri/src/serial_debug.rs`; the two hosts
+/// must behave identically (`src/CLAUDE.md`: web and Tauri parity).
+fn report_serial_debug_drops_ws(
+    sink_tx: &tokio::sync::mpsc::UnboundedSender<ServerMessage>,
+    archive: &Arc<Mutex<SerialDebugArchive>>,
+    filters: &Arc<Mutex<SerialDebugFilterIndex>>,
+    pending: &mut SerialDebugChunkBatchBuffer,
+    report: SerialDebugDropReport,
+) {
+    // Everything buffered arrived before the gap.
+    flush_serial_debug_chunk_ws(sink_tx, archive, filters, pending.take());
+    log::warn!(
+        "[serial-debug] chunk bridge queue full (capacity {}): dropped {} chunk(s) / {} byte(s) \
+         of device output",
+        SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY,
+        report.chunks,
+        report.bytes
+    );
+    // Only the reader thread's Rx chunks travel the bounded queue: the Tx path
+    // (`SerialDebugSend`) writes straight to the archive.
+    let lines = {
+        let mut guard = match archive.lock() {
+            Ok(guard) => guard,
+            Err(_) => return,
+        };
+        guard
+            .append_gap(Direction::Rx, serial_debug_now_ms(), report.bytes)
+            .unwrap_or_default()
+    };
+    ingest_serial_debug_lines_ws(sink_tx, filters, &lines);
+    let _ = sink_tx.send(ServerMessage::SerialDebugChunksDropped {
+        dropped_bytes: report.bytes,
+    });
+}
+
 fn spawn_serial_debug_chunk_bridge_ws(
     sink_tx: tokio::sync::mpsc::UnboundedSender<ServerMessage>,
     archive: Arc<Mutex<SerialDebugArchive>>,
@@ -940,15 +993,22 @@ fn spawn_serial_debug_chunk_bridge_ws(
     // when archive/filter/UI consumption temporarily lags behind the serial reader.
     let (tx, rx) =
         mpsc::sync_channel::<SerialDebugChunkBridgeMessage>(SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY);
+    let drops = Arc::new(SerialDebugDropCounter::default());
     let handle = SerialDebugChunkBridgeHandle {
         generation: Arc::clone(&generation),
         send_lock: Arc::new(Mutex::new(())),
         tx: tx.clone(),
+        drops: Arc::clone(&drops),
     };
     std::thread::spawn(move || {
         let mut pending = SerialDebugChunkBatchBuffer::new();
         let mut active_generation = generation.current();
         loop {
+            // Before every receive, so `recv_timeout`'s own tick is the poll
+            // clock and no `continue` below can skip the check.
+            if let Some(report) = drops.take_report(serial_debug_now_ms()) {
+                report_serial_debug_drops_ws(&sink_tx, &archive, &filters, &mut pending, report);
+            }
             match rx.recv_timeout(Duration::from_millis(SERIAL_DEBUG_CHUNK_FLUSH_MS)) {
                 Ok(SerialDebugChunkBridgeMessage::Chunk { generation, chunk }) => {
                     if generation != active_generation {
@@ -965,11 +1025,23 @@ fn spawn_serial_debug_chunk_bridge_ws(
                 }
                 Ok(SerialDebugChunkBridgeMessage::Reset { generation, ack }) => {
                     let _ = pending.take();
+                    // Drops from the cleared session belong to the log the user
+                    // just discarded.
+                    let _ = drops.take_pending();
                     active_generation = generation;
                     let _ = ack.send(());
                 }
                 Ok(SerialDebugChunkBridgeMessage::Shutdown { ack }) => {
                     flush_serial_debug_chunk_ws(&sink_tx, &archive, &filters, pending.take());
+                    if let Some(report) = drops.take_pending() {
+                        report_serial_debug_drops_ws(
+                            &sink_tx,
+                            &archive,
+                            &filters,
+                            &mut pending,
+                            report,
+                        );
+                    }
                     let _ = ack.send(());
                     return;
                 }
@@ -982,6 +1054,16 @@ fn spawn_serial_debug_chunk_bridge_ws(
                 }
                 Err(RecvTimeoutError::Disconnected) => {
                     flush_serial_debug_chunk_ws(&sink_tx, &archive, &filters, pending.take());
+                    // A burst still aggregating at teardown is reported anyway.
+                    if let Some(report) = drops.take_pending() {
+                        report_serial_debug_drops_ws(
+                            &sink_tx,
+                            &archive,
+                            &filters,
+                            &mut pending,
+                            report,
+                        );
+                    }
                     return;
                 }
             }
@@ -1564,6 +1646,81 @@ mod tests {
         assert!(sink_rx.try_recv().is_err());
     }
 
+    /// The web host must report dropped device output exactly like the Tauri
+    /// host: cut the open line in the archive so the bytes either side of the gap
+    /// cannot be spliced into one fake line, then announce the gap on the wire.
+    #[test]
+    fn report_serial_debug_drops_ws_cuts_the_line_and_announces_the_gap() {
+        let dir = std::env::temp_dir().join(format!(
+            "tyutool-serve-drop-report-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let archive = Arc::new(Mutex::new(SerialDebugArchive::create(&dir).unwrap()));
+        let filters = Arc::new(Mutex::new(SerialDebugFilterIndex::create(&dir).unwrap()));
+        let (sink_tx, mut sink_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut pending = SerialDebugChunkBatchBuffer::new();
+
+        // A line still being received when the queue overflowed.
+        archive
+            .lock()
+            .unwrap()
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 1,
+                bytes: b"before-gap".to_vec(),
+            })
+            .unwrap();
+
+        report_serial_debug_drops_ws(
+            &sink_tx,
+            &archive,
+            &filters,
+            &mut pending,
+            SerialDebugDropReport {
+                chunks: 3,
+                bytes: 12_288,
+            },
+        );
+
+        let json = serde_json::to_string(&sink_rx.try_recv().unwrap()).unwrap();
+        assert!(
+            json.contains(r#""type":"serial_debug_chunks_dropped""#),
+            "{json}"
+        );
+        // snake_case on the wire; `ws-transport.ts` maps it to `droppedBytes`.
+        assert!(json.contains(r#""dropped_bytes":12288"#), "{json}");
+
+        // Bytes arriving after the gap must start their own line.
+        let after = archive
+            .lock()
+            .unwrap()
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 2,
+                bytes: b"after-gap\n".to_vec(),
+            })
+            .unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].text, "after-gap");
+
+        let lines = archive.lock().unwrap().read_line_range(1, 10).unwrap();
+        let texts = lines.iter().map(|l| l.text.as_str()).collect::<Vec<_>>();
+        assert_eq!(
+            texts,
+            vec![
+                "before-gap",
+                tyutool_core::serial_debug_chunk_drop_sentinel(12_288).as_str(),
+                "after-gap",
+            ]
+        );
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
     #[test]
     fn serialize_serial_debug_state_info_omits_cfg_when_closed() {
         let closed = serde_json::to_string(&ServerMessage::SerialDebugStateInfo {
@@ -1660,23 +1817,19 @@ mod tests {
             Arc::new(SerialDebugGeneration::default()),
         );
 
-        bridge
-            .send_chunk(DebugChunk {
-                direction: tyutool_core::Direction::Rx,
-                ts_ms: 1,
-                bytes: b"pre".to_vec(),
-            })
-            .unwrap();
+        bridge.send_chunk(DebugChunk {
+            direction: tyutool_core::Direction::Rx,
+            ts_ms: 1,
+            bytes: b"pre".to_vec(),
+        });
         bridge.reset().unwrap();
         archive.lock().unwrap().clear().unwrap();
 
-        bridge
-            .send_chunk(DebugChunk {
-                direction: tyutool_core::Direction::Rx,
-                ts_ms: 2,
-                bytes: b"post\nnew\n".to_vec(),
-            })
-            .unwrap();
+        bridge.send_chunk(DebugChunk {
+            direction: tyutool_core::Direction::Rx,
+            ts_ms: 2,
+            bytes: b"post\nnew\n".to_vec(),
+        });
         bridge.shutdown().unwrap();
 
         let page = archive.lock().unwrap().read_page(0, 10).unwrap();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -716,6 +716,7 @@ pub fn run() {
             serial_debug::serial_debug_filter_remove,
             serial_debug::serial_debug_filter_read_matches,
             serial_debug::serial_debug_session_read_page,
+            serial_debug::serial_debug_set_archive_limit,
             logs::write_text_file,
             logs::append_text_file,
             logs::register_dialog_path,

--- a/src-tauri/src/serial_debug.rs
+++ b/src-tauri/src/serial_debug.rs
@@ -42,6 +42,8 @@ struct DisconnectPayload {
 #[serde(rename_all = "camelCase")]
 struct ArchiveCappedPayload {
     limit_mib: u64,
+    /// `archived_before` of the cap sentinel itself — see [`ArchivedChunk`].
+    archived_before: u64,
 }
 
 /// Payload of `serial-debug-chunks-dropped`. Only the byte count crosses — the
@@ -50,6 +52,38 @@ struct ArchiveCappedPayload {
 #[serde(rename_all = "camelCase")]
 struct ChunksDroppedPayload {
     dropped_bytes: u64,
+    /// `archived_before` of the gap lines this notice belongs to — see
+    /// [`ArchivedChunk`].
+    archived_before: u64,
+}
+
+/// One chunk on its way to the webview, plus the number of lines the session
+/// archive held *before* this chunk was appended to it.
+///
+/// That number is what lets the frontend switch auto-save on mid-session without
+/// either duplicating or losing a line. Auto-save enables in two halves — the
+/// archive is paged into the file up to a snapshot `N`, the live queue continues
+/// after it — and the frontend cannot otherwise tell which half a live line
+/// belongs to: its own line counter and the archive's `line_no` diverge (the
+/// archive freezes its numbering once capped, and never holds an unterminated
+/// trailing line).
+///
+/// `archived_before` closes that gap exactly, because `append_chunk` archives a
+/// whole chunk under one lock: no snapshot can land *inside* a chunk, so every
+/// line the chunk produced is either wholly inside `N` or wholly after it.
+/// A live line is therefore already in the backfilled half iff
+/// `archived_before < N` — see `dropBackfilledAutoSaveLines` in
+/// `src/stores/serial-debug.ts`.
+///
+/// Read under the same lock guard as the `append_chunk` it precedes; reading it
+/// outside the guard would let another writer slip in between and make the
+/// number a lie.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ArchivedChunk {
+    #[serde(flatten)]
+    chunk: DebugChunk,
+    archived_before: u64,
 }
 
 #[derive(Clone, Serialize)]
@@ -147,13 +181,17 @@ fn emit_filter_update(
 /// would only ever exist in the archive file and the user would watch the log
 /// keep scrolling with no hint that recording had stopped.
 fn emit_archive_cap_notice(app: &AppHandle, lines: &[SerialDebugLine]) {
-    if let Some(limit_mib) = lines
-        .iter()
-        .find_map(tyutool_core::serial_debug_archive_cap_limit_mib)
-    {
+    if let Some((limit_mib, line_no)) = lines.iter().find_map(|line| {
+        tyutool_core::serial_debug_archive_cap_limit_mib(line).map(|mib| (mib, line.line_no))
+    }) {
         let _ = app.emit(
             "serial-debug-archive-capped",
-            &ArchiveCappedPayload { limit_mib },
+            &ArchiveCappedPayload {
+                limit_mib,
+                // The sentinel is an archive line like any other, so its own
+                // position is exactly `line_no - 1`.
+                archived_before: line_no.saturating_sub(1),
+            },
         );
     }
 }
@@ -199,19 +237,29 @@ fn flush_serial_debug_chunk(
     if chunks.is_empty() {
         return;
     }
-    let completed = {
-        let mut archive = match archive.lock() {
+    let (completed, archived) = {
+        let mut guard = match archive.lock() {
             Ok(guard) => guard,
             Err(_) => return,
         };
         let mut completed = Vec::new();
-        for chunk in &chunks {
-            completed.extend(archive.append_chunk(chunk).unwrap_or_default());
+        let mut archived = Vec::with_capacity(chunks.len());
+        // One `archived_before` per chunk, not one per batch: per-chunk only
+        // needs `append_chunk` to be atomic, which the archive guarantees on its
+        // own, whereas a per-batch number would additionally rely on this loop
+        // holding the lock for the whole batch.
+        for chunk in chunks {
+            let archived_before = guard.total_lines();
+            completed.extend(guard.append_chunk(&chunk).unwrap_or_default());
+            archived.push(ArchivedChunk {
+                chunk,
+                archived_before,
+            });
         }
-        completed
+        (completed, archived)
     };
     ingest_serial_debug_lines(app, archive, filters, &completed);
-    let _ = app.emit("serial-debug-chunk-batch", &chunks);
+    let _ = app.emit("serial-debug-chunk-batch", &archived);
 }
 
 enum SerialDebugChunkBridgeMessage {
@@ -297,22 +345,49 @@ fn report_serial_debug_drops(
     );
     // Only the reader thread's Rx chunks travel the bounded queue: the Tx path
     // (`serial_debug_send`) writes straight to the archive.
-    let lines = {
+    let (lines, archived_before) = {
         let mut guard = match archive.lock() {
             Ok(guard) => guard,
             Err(_) => return,
         };
-        guard
-            .append_gap(Direction::Rx, serial_debug_now_ms(), report.bytes)
-            .unwrap_or_default()
+        // `append_gap` writes the cut-off partial line and the sentinel under one
+        // lock, so one number covers both frontend lines — see [`ArchivedChunk`].
+        let archived_before = guard.total_lines();
+        (
+            guard
+                .append_gap(Direction::Rx, serial_debug_now_ms(), report.bytes)
+                .unwrap_or_default(),
+            archived_before,
+        )
     };
     ingest_serial_debug_lines(app, archive, filters, &lines);
     let _ = app.emit(
         "serial-debug-chunks-dropped",
         &ChunksDroppedPayload {
             dropped_bytes: report.bytes,
+            archived_before,
         },
     );
+}
+
+/// Cut the tail the device never terminated into the archive, at the end of a
+/// session. Returns the lines written (empty when nothing was buffered) so the
+/// caller can ingest them like any other archive line.
+///
+/// Nothing else closes that buffer: `append_chunk` only cuts on a newline and
+/// `append_gap` only runs when a chunk is dropped, so a prompt or a progress bar
+/// — output the device deliberately leaves unterminated — would go down with the
+/// port and appear in neither the live view nor the archive.
+fn finalize_serial_debug_pending(
+    archive: &Arc<StdMutex<SerialDebugArchive>>,
+) -> Vec<SerialDebugLine> {
+    let mut guard = match archive.lock() {
+        Ok(guard) => guard,
+        Err(_) => return Vec::new(),
+    };
+    guard
+        .finalize_pending_lines(serial_debug_now_ms())
+        .unwrap_or_default()
 }
 
 fn spawn_serial_debug_chunk_bridge(
@@ -456,7 +531,10 @@ pub(crate) async fn serial_debug_open(
 }
 
 #[tauri::command]
-pub(crate) async fn serial_debug_close(state: State<'_, DebugState>) -> Result<(), String> {
+pub(crate) async fn serial_debug_close(
+    app: AppHandle,
+    state: State<'_, DebugState>,
+) -> Result<(), String> {
     let session = {
         let mut guard = state
             .session
@@ -476,6 +554,12 @@ pub(crate) async fn serial_debug_close(state: State<'_, DebugState>) -> Result<(
         .lock()
         .map_err(|_| "debug state poisoned".to_string())?
         .take();
+    // Cut after the bridge handle is dropped, which is what releases the bridge
+    // thread's final flush, so the chunks it was still holding land in the
+    // archive ahead of the tail. (`tyutool-serve`'s bridge acks its shutdown and
+    // is therefore exact about that ordering; this one has no ack.)
+    let lines = finalize_serial_debug_pending(&state.archive);
+    ingest_serial_debug_lines(&app, &state.archive, &state.filters, &lines);
     Ok(())
 }
 
@@ -506,17 +590,29 @@ pub(crate) fn serial_debug_send(
         ts_ms,
         bytes: bytes.clone(),
     };
-    let completed = {
+    // Tx chunks bypass the bounded bridge queue and are archived right here, so
+    // this is where their `archived_before` has to be read (same lock guard).
+    let (completed, archived_before) = {
         let mut archive = state
             .archive
             .lock()
             .map_err(|_| "debug archive poisoned".to_string())?;
-        archive
-            .append_chunk(&chunk)
-            .map_err(|e| format!("append serial debug tx chunk failed: {e}"))?
+        let archived_before = archive.total_lines();
+        (
+            archive
+                .append_chunk(&chunk)
+                .map_err(|e| format!("append serial debug tx chunk failed: {e}"))?,
+            archived_before,
+        )
     };
     ingest_serial_debug_lines(&app, &state.archive, &state.filters, &completed);
-    let _ = app.emit("serial-debug-chunk", &chunk);
+    let _ = app.emit(
+        "serial-debug-chunk",
+        &ArchivedChunk {
+            chunk,
+            archived_before,
+        },
+    );
     Ok(())
 }
 
@@ -573,13 +669,19 @@ pub(crate) fn serial_debug_session_clear(
     Ok(())
 }
 
+/// Returns the archive `line_no` the line was written as, or `None` when nothing
+/// was written (the archive is capped). The frontend needs the number for the
+/// same reason chunks carry `archived_before` (see [`ArchivedChunk`]): a sys line
+/// is pushed to the live view before it is archived, so its position in the
+/// archive is only known once this command answers. `None` means "not in the
+/// archive at all", which is what keeps such a line out of the discard pass.
 #[tauri::command]
 pub(crate) fn serial_debug_append_sys_line(
     app: AppHandle,
     state: State<'_, DebugState>,
     ts_ms: u64,
     text: String,
-) -> Result<(), String> {
+) -> Result<Option<u64>, String> {
     let line = {
         let mut archive = state
             .archive
@@ -590,10 +692,11 @@ pub(crate) fn serial_debug_append_sys_line(
             .map_err(|e| format!("append sys line failed: {e}"))?
     };
     // `None` once the session archive hit its size cap.
+    let line_no = line.as_ref().map(|line| line.line_no);
     if let Some(line) = line {
         ingest_serial_debug_lines(&app, &state.archive, &state.filters, &[line]);
     }
-    Ok(())
+    Ok(line_no)
 }
 
 /// Push the user's archive-size limit (MiB in the UI, bytes on the wire) down to
@@ -838,6 +941,49 @@ mod tests {
     fn serial_debug_device_reset_session_requires_open_session() {
         let err = serial_debug_device_reset_session(None, "T5AI").unwrap_err();
         assert_eq!(err, "serial debug not open");
+    }
+
+    /// Closing the port is the last moment the bytes the device printed without
+    /// a trailing newline can be saved — a `login: ` prompt, a progress bar.
+    /// Nothing else in the archive ever cuts them.
+    #[test]
+    fn closing_a_session_archives_the_unterminated_tail() {
+        let dir = std::env::temp_dir().join(format!(
+            "tyutool-gui-serial-debug-close-{}-{}",
+            std::process::id(),
+            serial_debug_now_ms()
+        ));
+        let archive = Arc::new(StdMutex::new(SerialDebugArchive::create(&dir).unwrap()));
+        archive
+            .lock()
+            .unwrap()
+            .append_chunk(&DebugChunk {
+                direction: Direction::Rx,
+                ts_ms: 1,
+                bytes: b"login: ".to_vec(),
+            })
+            .unwrap();
+        assert_eq!(archive.lock().unwrap().total_lines(), 0, "no newline yet");
+
+        let lines = finalize_serial_debug_pending(&archive);
+
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].text, "login: ");
+        assert_eq!(
+            archive
+                .lock()
+                .unwrap()
+                .read_line_range(1, 10)
+                .unwrap()
+                .iter()
+                .map(|l| l.text.clone())
+                .collect::<Vec<_>>(),
+            vec!["login: ".to_string()]
+        );
+        // Closing again has nothing left to cut: no empty line.
+        assert!(finalize_serial_debug_pending(&archive).is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A full queue must cost us the chunk, not the reader thread.

--- a/src-tauri/src/serial_debug.rs
+++ b/src-tauri/src/serial_debug.rs
@@ -35,6 +35,14 @@ struct DisconnectPayload {
     reason: String,
 }
 
+/// Payload of `serial-debug-archive-capped`. The frontend renders the notice
+/// itself from `serialDebug.log.archiveCapped`, so only the number crosses.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ArchiveCappedPayload {
+    limit_mib: u64,
+}
+
 #[derive(Clone, Serialize)]
 pub(crate) struct SerialDebugFilterUpdatePayload {
     def: SerialDebugFilterDefinition,
@@ -123,6 +131,24 @@ fn emit_filter_update(
     );
 }
 
+/// Every line the archive accepts passes through `ingest_serial_debug_lines`,
+/// which makes it the one place that can spot the archive-cap sentinel. The
+/// live view never sees archived lines — it re-splits the raw
+/// `serial-debug-chunk*` payloads itself — so without this event the cap notice
+/// would only ever exist in the archive file and the user would watch the log
+/// keep scrolling with no hint that recording had stopped.
+fn emit_archive_cap_notice(app: &AppHandle, lines: &[SerialDebugLine]) {
+    if let Some(limit_mib) = lines
+        .iter()
+        .find_map(tyutool_core::serial_debug_archive_cap_limit_mib)
+    {
+        let _ = app.emit(
+            "serial-debug-archive-capped",
+            &ArchiveCappedPayload { limit_mib },
+        );
+    }
+}
+
 fn ingest_serial_debug_lines(
     app: &AppHandle,
     archive: &Arc<StdMutex<SerialDebugArchive>>,
@@ -132,6 +158,7 @@ fn ingest_serial_debug_lines(
     if lines.is_empty() {
         return;
     }
+    emit_archive_cap_notice(app, lines);
     let updates = {
         let mut guard = match filters.lock() {
             Ok(guard) => guard,
@@ -480,7 +507,26 @@ pub(crate) fn serial_debug_append_sys_line(
             .append_sys_line(ts_ms, text)
             .map_err(|e| format!("append sys line failed: {e}"))?
     };
-    ingest_serial_debug_lines(&app, &state.archive, &state.filters, &[line]);
+    // `None` once the session archive hit its size cap.
+    if let Some(line) = line {
+        ingest_serial_debug_lines(&app, &state.archive, &state.filters, &[line]);
+    }
+    Ok(())
+}
+
+/// Push the user's archive-size limit (MiB in the UI, bytes on the wire) down to
+/// the archive. Mirrors the `set_log_level` shape: a setting the frontend owns
+/// and re-applies on load and on change.
+#[tauri::command]
+pub(crate) fn serial_debug_set_archive_limit(
+    state: State<'_, DebugState>,
+    max_bytes: u64,
+) -> Result<(), String> {
+    state
+        .archive
+        .lock()
+        .map_err(|_| "debug archive poisoned".to_string())?
+        .set_max_bytes(max_bytes);
     Ok(())
 }
 

--- a/src-tauri/src/serial_debug.rs
+++ b/src-tauri/src/serial_debug.rs
@@ -6,7 +6,7 @@
 //! (`SERIAL_DEBUG_CHUNK_FLUSH_*`) so a chatty device cannot flood the IPC
 //! channel.
 
-use std::sync::mpsc::{self, RecvTimeoutError, SyncSender};
+use std::sync::mpsc::{self, RecvTimeoutError, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
@@ -15,8 +15,9 @@ use tauri::{AppHandle, Emitter, State};
 
 use tyutool_core::{
     serial_debug_fail_backfill_if_current, serial_debug_finish_backfill_if_current,
-    serial_debug_scan_filter_matches, DebugChunk, DebugConfig, SerialDebugArchive,
-    SerialDebugArchiveReader, SerialDebugChunkBatchBuffer, SerialDebugFilterBackfillSnapshot,
+    serial_debug_now_ms, serial_debug_scan_filter_matches, DebugChunk, DebugConfig, Direction,
+    SerialDebugArchive, SerialDebugArchiveReader, SerialDebugChunkBatchBuffer,
+    SerialDebugDropCounter, SerialDebugDropReport, SerialDebugFilterBackfillSnapshot,
     SerialDebugFilterDefinition, SerialDebugFilterIndex, SerialDebugFilterPage,
     SerialDebugFilterStats, SerialDebugGeneration, SerialDebugLine, SerialDebugSession,
     SerialDebugSessionPage,
@@ -41,6 +42,14 @@ struct DisconnectPayload {
 #[serde(rename_all = "camelCase")]
 struct ArchiveCappedPayload {
     limit_mib: u64,
+}
+
+/// Payload of `serial-debug-chunks-dropped`. Only the byte count crosses — the
+/// wording comes from `serialDebug.log.chunksDropped`.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ChunksDroppedPayload {
+    dropped_bytes: u64,
 }
 
 #[derive(Clone, Serialize)]
@@ -221,18 +230,33 @@ pub(crate) struct SerialDebugChunkBridgeHandle {
     generation: Arc<SerialDebugGeneration>,
     send_lock: Arc<StdMutex<()>>,
     tx: SyncSender<SerialDebugChunkBridgeMessage>,
+    drops: Arc<SerialDebugDropCounter>,
 }
 
 impl SerialDebugChunkBridgeHandle {
-    fn send_chunk(
-        &self,
-        chunk: DebugChunk,
-    ) -> Result<(), std::sync::mpsc::SendError<SerialDebugChunkBridgeMessage>> {
+    /// Hand one chunk to the bridge, or account for it as lost.
+    ///
+    /// `try_send`, never `send`: this runs on the serial reader thread, which is
+    /// the only thread draining the OS/driver receive buffer, and the port runs
+    /// without flow control. Blocking here therefore applies no backpressure to
+    /// the *device* — it just stops the buffer being drained until the driver
+    /// overflows and discards bytes we never saw, with no count, no error and
+    /// nothing to show the user. Dropping the chunk here instead keeps the reader
+    /// draining and moves the loss to a boundary we own: we know how many bytes
+    /// went, we can close the archive line so the halves cannot be spliced, and
+    /// we can tell the user (who can lower the baud rate or quieten the device).
+    fn send_chunk(&self, chunk: DebugChunk) {
         let _guard = self.send_lock.lock().unwrap();
-        self.tx.send(SerialDebugChunkBridgeMessage::Chunk {
+        let bytes = chunk.bytes.len();
+        match self.tx.try_send(SerialDebugChunkBridgeMessage::Chunk {
             generation: self.generation.current(),
             chunk,
-        })
+        }) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => self.drops.record(bytes, serial_debug_now_ms()),
+            // The bridge thread is gone; the session is being torn down.
+            Err(TrySendError::Disconnected(_)) => {}
+        }
     }
 
     fn reset(&self) -> Result<u64, String> {
@@ -250,6 +274,47 @@ impl SerialDebugChunkBridgeHandle {
     }
 }
 
+/// Surface one coalesced burst of dropped chunks: a `log::warn!` for the
+/// developer, a gap in the archive and a `Sys` notice for the user.
+///
+/// Whatever is buffered is flushed first — those chunks arrived before the gap,
+/// and emitting them afterwards would put the notice in the wrong place in the
+/// live view.
+fn report_serial_debug_drops(
+    app: &AppHandle,
+    archive: &Arc<StdMutex<SerialDebugArchive>>,
+    filters: &Arc<StdMutex<SerialDebugFilterIndex>>,
+    pending: &mut SerialDebugChunkBatchBuffer,
+    report: SerialDebugDropReport,
+) {
+    flush_serial_debug_chunk(app, archive, filters, pending.take());
+    log::warn!(
+        "[serial-debug] chunk bridge queue full (capacity {}): dropped {} chunk(s) / {} byte(s) \
+         of device output",
+        SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY,
+        report.chunks,
+        report.bytes
+    );
+    // Only the reader thread's Rx chunks travel the bounded queue: the Tx path
+    // (`serial_debug_send`) writes straight to the archive.
+    let lines = {
+        let mut guard = match archive.lock() {
+            Ok(guard) => guard,
+            Err(_) => return,
+        };
+        guard
+            .append_gap(Direction::Rx, serial_debug_now_ms(), report.bytes)
+            .unwrap_or_default()
+    };
+    ingest_serial_debug_lines(app, archive, filters, &lines);
+    let _ = app.emit(
+        "serial-debug-chunks-dropped",
+        &ChunksDroppedPayload {
+            dropped_bytes: report.bytes,
+        },
+    );
+}
+
 fn spawn_serial_debug_chunk_bridge(
     app: AppHandle,
     archive: Arc<StdMutex<SerialDebugArchive>>,
@@ -260,15 +325,22 @@ fn spawn_serial_debug_chunk_bridge(
     // when archive/filter/UI consumption temporarily lags behind the serial reader.
     let (tx, rx) =
         mpsc::sync_channel::<SerialDebugChunkBridgeMessage>(SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY);
+    let drops = Arc::new(SerialDebugDropCounter::default());
     let handle = SerialDebugChunkBridgeHandle {
         generation: Arc::clone(&generation),
         send_lock: Arc::new(StdMutex::new(())),
         tx: tx.clone(),
+        drops: Arc::clone(&drops),
     };
     std::thread::spawn(move || {
         let mut pending = SerialDebugChunkBatchBuffer::new();
         let mut active_generation = generation.current();
         loop {
+            // Before every receive, so `recv_timeout`'s own tick is the poll
+            // clock and no `continue` below can skip the check.
+            if let Some(report) = drops.take_report(serial_debug_now_ms()) {
+                report_serial_debug_drops(&app, &archive, &filters, &mut pending, report);
+            }
             match rx.recv_timeout(Duration::from_millis(SERIAL_DEBUG_CHUNK_FLUSH_MS)) {
                 Ok(SerialDebugChunkBridgeMessage::Chunk { generation, chunk }) => {
                     if generation != active_generation {
@@ -285,6 +357,10 @@ fn spawn_serial_debug_chunk_bridge(
                 }
                 Ok(SerialDebugChunkBridgeMessage::Reset { generation, ack }) => {
                     let _ = pending.take();
+                    // Drops from the cleared session belong to the log the user
+                    // just discarded; reporting them into the new one would be a
+                    // notice about a gap that is no longer there.
+                    let _ = drops.take_pending();
                     active_generation = generation;
                     let _ = ack.send(());
                 }
@@ -297,6 +373,12 @@ fn spawn_serial_debug_chunk_bridge(
                 }
                 Err(RecvTimeoutError::Disconnected) => {
                     flush_serial_debug_chunk(&app, &archive, &filters, pending.take());
+                    // A burst still aggregating at teardown is reported anyway —
+                    // it is the last thing the user needs to know about the log
+                    // they are about to read.
+                    if let Some(report) = drops.take_pending() {
+                        report_serial_debug_drops(&app, &archive, &filters, &mut pending, report);
+                    }
                     return;
                 }
             }
@@ -342,7 +424,7 @@ pub(crate) async fn serial_debug_open(
         SerialDebugSession::open(
             cfg,
             Box::new(move |chunk: DebugChunk| {
-                let _ = chunk_tx_for_session.send_chunk(chunk);
+                chunk_tx_for_session.send_chunk(chunk);
             }),
             Box::new(move |reason: String| {
                 let _ =
@@ -756,5 +838,42 @@ mod tests {
     fn serial_debug_device_reset_session_requires_open_session() {
         let err = serial_debug_device_reset_session(None, "T5AI").unwrap_err();
         assert_eq!(err, "serial debug not open");
+    }
+
+    /// A full queue must cost us the chunk, not the reader thread.
+    ///
+    /// This test would hang rather than fail if `send_chunk` went back to a
+    /// blocking `send`: nothing drains `rx`, so the third call would park
+    /// forever — which is exactly what stalls the serial reader in production
+    /// and lets the OS receive buffer overflow behind our back.
+    #[test]
+    fn full_bridge_queue_drops_chunks_instead_of_blocking_the_reader() {
+        let (tx, rx) = mpsc::sync_channel::<SerialDebugChunkBridgeMessage>(1);
+        let handle = SerialDebugChunkBridgeHandle {
+            generation: Arc::new(SerialDebugGeneration::default()),
+            send_lock: Arc::new(StdMutex::new(())),
+            tx,
+            drops: Arc::new(SerialDebugDropCounter::default()),
+        };
+        let chunk = |bytes: usize| DebugChunk {
+            direction: Direction::Rx,
+            ts_ms: 1,
+            bytes: vec![b'x'; bytes],
+        };
+
+        handle.send_chunk(chunk(4)); // fits the capacity-1 queue
+        handle.send_chunk(chunk(8)); // dropped
+        handle.send_chunk(chunk(16)); // dropped
+
+        // One report for the whole burst, carrying the total loss.
+        let report = handle.drops.take_pending().unwrap();
+        assert_eq!(report.chunks, 2);
+        assert_eq!(report.bytes, 24);
+        assert!(handle.drops.take_pending().is_none());
+
+        drop(rx);
+        // A disconnected queue is a closing session, not a data loss.
+        handle.send_chunk(chunk(32));
+        assert!(handle.drops.take_pending().is_none());
     }
 }

--- a/src/features/serial-debug/SerialDebugPage.vue
+++ b/src/features/serial-debug/SerialDebugPage.vue
@@ -15,7 +15,6 @@ useSerialAutoSave(s);
   <div class="flex min-h-0 min-w-0 w-full flex-1 flex-col gap-2">
     <SerialDebugConnectionBar />
     <SerialDebugLogView
-      :lines="s.lines"
       :hexView="s.hexView"
       :hexBytesPerRow="s.hexBytesPerRow"
       :ansiEnabled="s.ansiEnabled"

--- a/src/features/serial-debug/archive-line-text.test.ts
+++ b/src/features/serial-debug/archive-line-text.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+// happy-dom: @/i18n reads localStorage at import time.
+import { afterEach, describe, expect, it } from "vitest";
+import { i18n } from "@/i18n";
+import {
+  archiveCapNoticeText,
+  formatExportLine,
+  localizeArchiveLineText,
+} from "./archive-line-text";
+import type { DebugLineDirection, SerialDebugLine } from "./types";
+
+// Pins the wire format produced by `serial_debug_archive_cap_sentinel` in
+// crates/tyutool-core/src/serial_debug.rs. Spelled with fromCharCode so this
+// file stays printable ASCII.
+const SOH = String.fromCharCode(1);
+const sentinel = (mib: number): string =>
+  `${SOH}tyutool:archive-capped:${mib}${SOH}`;
+
+const originalLocale = i18n.global.locale.value;
+
+afterEach(() => {
+  i18n.global.locale.value = originalLocale;
+});
+
+function line(direction: DebugLineDirection, text: string): SerialDebugLine {
+  return { lineNo: 1, tsMs: 0, direction, text };
+}
+
+describe("localizeArchiveLineText", () => {
+  it("translates the cap sentinel and never leaks it verbatim", () => {
+    i18n.global.locale.value = "en";
+    const out = localizeArchiveLineText("sys", sentinel(256));
+
+    expect(out).not.toContain(SOH);
+    expect(out).not.toContain("archive-capped");
+    expect(out).toContain("256 MiB");
+    expect(out).toBe(archiveCapNoticeText(256));
+  });
+
+  it("renders in the active locale, so an archive re-read follows the UI language", () => {
+    i18n.global.locale.value = "zh-CN";
+    const zh = localizeArchiveLineText("sys", sentinel(64));
+    i18n.global.locale.value = "en";
+    const en = localizeArchiveLineText("sys", sentinel(64));
+
+    expect(zh).toContain("64 MiB");
+    expect(zh).toContain("会话归档");
+    expect(en).toContain("64 MiB");
+    expect(en).not.toBe(zh);
+  });
+
+  it("cannot be forged by device output or by a line that merely embeds it", () => {
+    // Device bytes always arrive as tx/rx, so an echoed marker stays literal.
+    expect(localizeArchiveLineText("rx", sentinel(256))).toBe(sentinel(256));
+    expect(localizeArchiveLineText("tx", sentinel(256))).toBe(sentinel(256));
+
+    for (const text of [
+      `boot: ${sentinel(256)}`,
+      `${sentinel(256)} trailing`,
+      `${SOH}tyutool:archive-capped:${SOH}`,
+      `${SOH}tyutool:archive-capped:12x${SOH}`,
+      "tyutool:archive-capped:256",
+    ]) {
+      expect(localizeArchiveLineText("sys", text)).toBe(text);
+    }
+  });
+
+  it("passes ordinary sys lines through untouched", () => {
+    expect(localizeArchiveLineText("sys", "Port lost")).toBe("Port lost");
+  });
+});
+
+describe("formatExportLine", () => {
+  it("writes the translated notice into the export, not the sentinel", () => {
+    i18n.global.locale.value = "zh-CN";
+    const out = formatExportLine(line("sys", sentinel(128)));
+
+    expect(out).not.toContain(SOH);
+    expect(out).not.toContain("archive-capped");
+    expect(out).toContain("[SYS]");
+    expect(out).toContain("128 MiB");
+  });
+
+  it("keeps the direction tag and strips ANSI from device lines", () => {
+    const esc = String.fromCharCode(27);
+    expect(formatExportLine(line("rx", `${esc}[31mboom${esc}[0m`))).toContain(
+      "[RX ] boom",
+    );
+    expect(formatExportLine(line("tx", "ping"))).toContain("[TX ] ping");
+  });
+});

--- a/src/features/serial-debug/archive-line-text.test.ts
+++ b/src/features/serial-debug/archive-line-text.test.ts
@@ -4,17 +4,20 @@ import { afterEach, describe, expect, it } from "vitest";
 import { i18n } from "@/i18n";
 import {
   archiveCapNoticeText,
+  chunksDroppedNoticeText,
   formatExportLine,
   localizeArchiveLineText,
 } from "./archive-line-text";
 import type { DebugLineDirection, SerialDebugLine } from "./types";
 
-// Pins the wire format produced by `serial_debug_archive_cap_sentinel` in
-// crates/tyutool-core/src/serial_debug.rs. Spelled with fromCharCode so this
-// file stays printable ASCII.
+// Pins the wire format produced by `serial_debug_archive_cap_sentinel` /
+// `serial_debug_chunk_drop_sentinel` in crates/tyutool-core/src/serial_debug.rs.
+// Spelled with fromCharCode so this file stays printable ASCII.
 const SOH = String.fromCharCode(1);
 const sentinel = (mib: number): string =>
   `${SOH}tyutool:archive-capped:${mib}${SOH}`;
+const dropSentinel = (bytes: number): string =>
+  `${SOH}tyutool:chunks-dropped:${bytes}${SOH}`;
 
 const originalLocale = i18n.global.locale.value;
 
@@ -68,6 +71,58 @@ describe("localizeArchiveLineText", () => {
   it("passes ordinary sys lines through untouched", () => {
     expect(localizeArchiveLineText("sys", "Port lost")).toBe("Port lost");
   });
+
+  it("translates the dropped-chunk sentinel and never leaks it verbatim", () => {
+    i18n.global.locale.value = "en";
+    const out = localizeArchiveLineText("sys", dropSentinel(12288));
+
+    expect(out).not.toContain(SOH);
+    expect(out).not.toContain("chunks-dropped");
+    expect(out).toContain("12288");
+    expect(out).toBe(chunksDroppedNoticeText(12288));
+  });
+
+  it("renders the dropped-chunk notice in the active locale", () => {
+    i18n.global.locale.value = "zh-CN";
+    const zh = localizeArchiveLineText("sys", dropSentinel(4096));
+    i18n.global.locale.value = "en";
+    const en = localizeArchiveLineText("sys", dropSentinel(4096));
+
+    expect(zh).toContain("4096");
+    expect(zh).toContain("设备输出");
+    expect(en).toContain("4096");
+    expect(en).not.toBe(zh);
+  });
+
+  it("cannot have a dropped-chunk notice forged by device output", () => {
+    expect(localizeArchiveLineText("rx", dropSentinel(4096))).toBe(
+      dropSentinel(4096),
+    );
+    expect(localizeArchiveLineText("tx", dropSentinel(4096))).toBe(
+      dropSentinel(4096),
+    );
+
+    for (const text of [
+      `boot: ${dropSentinel(4096)}`,
+      `${dropSentinel(4096)} trailing`,
+      `${SOH}tyutool:chunks-dropped:${SOH}`,
+      `${SOH}tyutool:chunks-dropped:12x${SOH}`,
+      "tyutool:chunks-dropped:4096",
+    ]) {
+      expect(localizeArchiveLineText("sys", text)).toBe(text);
+    }
+  });
+
+  it("keeps the two sentinel families apart", () => {
+    i18n.global.locale.value = "en";
+    expect(localizeArchiveLineText("sys", dropSentinel(256))).toBe(
+      chunksDroppedNoticeText(256),
+    );
+    expect(localizeArchiveLineText("sys", sentinel(256))).toBe(
+      archiveCapNoticeText(256),
+    );
+    expect(chunksDroppedNoticeText(256)).not.toBe(archiveCapNoticeText(256));
+  });
 });
 
 describe("formatExportLine", () => {
@@ -79,6 +134,16 @@ describe("formatExportLine", () => {
     expect(out).not.toContain("archive-capped");
     expect(out).toContain("[SYS]");
     expect(out).toContain("128 MiB");
+  });
+
+  it("writes the translated data-loss notice into the export", () => {
+    i18n.global.locale.value = "en";
+    const out = formatExportLine(line("sys", dropSentinel(65536)));
+
+    expect(out).not.toContain(SOH);
+    expect(out).not.toContain("chunks-dropped");
+    expect(out).toContain("[SYS]");
+    expect(out).toContain("65536");
   });
 
   it("keeps the direction tag and strips ANSI from device lines", () => {

--- a/src/features/serial-debug/archive-line-text.ts
+++ b/src/features/serial-debug/archive-line-text.ts
@@ -1,0 +1,72 @@
+/**
+ * Turning archive-backed lines into the text a user reads or saves.
+ *
+ * The Rust session archive stores the "archive size cap reached" notice as a
+ * machine-readable sentinel (`serial_debug_archive_cap_sentinel` in
+ * `crates/tyutool-core/src/serial_debug.rs`), never as a finished sentence:
+ * the wording is user-visible and must come from the i18n catalogue, and
+ * translating it at read time means an archive re-read after a language switch
+ * shows the notice in the *new* language.
+ *
+ * Every path that surfaces archive text therefore has to translate it, and they
+ * all go through `localizeArchiveLineText` here — one helper, so a path added
+ * later cannot quietly leak the raw sentinel to the user.
+ */
+import { i18n } from "@/i18n";
+import { stripAnsi } from "./ansi-parse";
+import { formatTs } from "./utils";
+import type { DebugLineDirection, SerialDebugLine } from "./types";
+
+// Mirrors `serial_debug_archive_cap_sentinel` in
+// `crates/tyutool-core/src/serial_debug.rs`. U+0001 (SOH) is a C0 control
+// character that never occurs in a translated UI string.
+// `String.fromCharCode(1)` rather than an escape so this source file stays
+// printable ASCII end to end.
+const SOH = String.fromCharCode(1);
+const SENTINEL_PREFIX = `${SOH}tyutool:archive-capped:`;
+const SENTINEL_SUFFIX = SOH;
+
+/**
+ * The MiB limit carried by an archive-cap sentinel, or `null` for anything
+ * else. Mirrors `serial_debug_archive_cap_limit_mib`, including its
+ * collision-safety rules: whole-string match (not a substring), and `sys` lines
+ * only — device output always arrives as `tx`/`rx`, so a device echoing the
+ * marker byte-for-byte still cannot forge the notice.
+ */
+function archiveCapSentinelLimitMib(
+  direction: DebugLineDirection,
+  text: string,
+): number | null {
+  if (direction !== "sys") return null;
+  if (!text.startsWith(SENTINEL_PREFIX) || !text.endsWith(SENTINEL_SUFFIX)) {
+    return null;
+  }
+  const digits = text.slice(
+    SENTINEL_PREFIX.length,
+    text.length - SENTINEL_SUFFIX.length,
+  );
+  if (!/^[0-9]+$/.test(digits)) return null;
+  return Number(digits);
+}
+
+/** The translated "archive stopped recording" notice. */
+export function archiveCapNoticeText(limitMib: number): string {
+  return i18n.global.t("serialDebug.log.archiveCapped", { mib: limitMib });
+}
+
+/** Replace the archive-cap sentinel with its translation; pass anything else through. */
+export function localizeArchiveLineText(
+  direction: DebugLineDirection,
+  text: string,
+): string {
+  const limitMib = archiveCapSentinelLimitMib(direction, text);
+  return limitMib === null ? text : archiveCapNoticeText(limitMib);
+}
+
+/** One line of an exported / saved log file. */
+export function formatExportLine(line: SerialDebugLine): string {
+  const dir =
+    line.direction === "tx" ? "TX " : line.direction === "rx" ? "RX " : "SYS";
+  const text = localizeArchiveLineText(line.direction, line.text);
+  return `[${formatTs(line.tsMs)}] [${dir}] ${stripAnsi(text)}`;
+}

--- a/src/features/serial-debug/archive-line-text.ts
+++ b/src/features/serial-debug/archive-line-text.ts
@@ -1,12 +1,13 @@
 /**
  * Turning archive-backed lines into the text a user reads or saves.
  *
- * The Rust session archive stores the "archive size cap reached" notice as a
- * machine-readable sentinel (`serial_debug_archive_cap_sentinel` in
- * `crates/tyutool-core/src/serial_debug.rs`), never as a finished sentence:
- * the wording is user-visible and must come from the i18n catalogue, and
- * translating it at read time means an archive re-read after a language switch
- * shows the notice in the *new* language.
+ * The Rust session archive stores its own notices — "archive size cap reached"
+ * (`serial_debug_archive_cap_sentinel`) and "device output was dropped here"
+ * (`serial_debug_chunk_drop_sentinel`, both in
+ * `crates/tyutool-core/src/serial_debug.rs`) — as machine-readable sentinels,
+ * never as finished sentences: the wording is user-visible and must come from the
+ * i18n catalogue, and translating it at read time means an archive re-read after
+ * a language switch shows the notice in the *new* language.
  *
  * Every path that surfaces archive text therefore has to translate it, and they
  * all go through `localizeArchiveLineText` here — one helper, so a path added
@@ -17,32 +18,35 @@ import { stripAnsi } from "./ansi-parse";
 import { formatTs } from "./utils";
 import type { DebugLineDirection, SerialDebugLine } from "./types";
 
-// Mirrors `serial_debug_archive_cap_sentinel` in
+// Mirrors `serial_debug_archive_cap_sentinel` /
+// `serial_debug_chunk_drop_sentinel` in
 // `crates/tyutool-core/src/serial_debug.rs`. U+0001 (SOH) is a C0 control
 // character that never occurs in a translated UI string.
 // `String.fromCharCode(1)` rather than an escape so this source file stays
 // printable ASCII end to end.
 const SOH = String.fromCharCode(1);
-const SENTINEL_PREFIX = `${SOH}tyutool:archive-capped:`;
+const ARCHIVE_CAPPED_PREFIX = `${SOH}tyutool:archive-capped:`;
+const CHUNKS_DROPPED_PREFIX = `${SOH}tyutool:chunks-dropped:`;
 const SENTINEL_SUFFIX = SOH;
 
 /**
- * The MiB limit carried by an archive-cap sentinel, or `null` for anything
- * else. Mirrors `serial_debug_archive_cap_limit_mib`, including its
- * collision-safety rules: whole-string match (not a substring), and `sys` lines
- * only — device output always arrives as `tx`/`rx`, so a device echoing the
- * marker byte-for-byte still cannot forge the notice.
+ * The numeric payload of the sentinel built from `prefix`, or `null` for
+ * anything else. Mirrors `sentinel_payload` in Rust, including its
+ * collision-safety rules: whole-string match (not a substring), digits-only
+ * payload, and `sys` lines only — device output always arrives as `tx`/`rx`, so
+ * a device echoing the marker byte-for-byte still cannot forge the notice.
  */
-function archiveCapSentinelLimitMib(
+function sentinelPayload(
   direction: DebugLineDirection,
   text: string,
+  prefix: string,
 ): number | null {
   if (direction !== "sys") return null;
-  if (!text.startsWith(SENTINEL_PREFIX) || !text.endsWith(SENTINEL_SUFFIX)) {
+  if (!text.startsWith(prefix) || !text.endsWith(SENTINEL_SUFFIX)) {
     return null;
   }
   const digits = text.slice(
-    SENTINEL_PREFIX.length,
+    prefix.length,
     text.length - SENTINEL_SUFFIX.length,
   );
   if (!/^[0-9]+$/.test(digits)) return null;
@@ -54,13 +58,23 @@ export function archiveCapNoticeText(limitMib: number): string {
   return i18n.global.t("serialDebug.log.archiveCapped", { mib: limitMib });
 }
 
-/** Replace the archive-cap sentinel with its translation; pass anything else through. */
+/** The translated "device output was lost here" notice. */
+export function chunksDroppedNoticeText(droppedBytes: number): string {
+  return i18n.global.t("serialDebug.log.chunksDropped", {
+    bytes: droppedBytes,
+  });
+}
+
+/** Replace a sentinel with its translation; pass anything else through. */
 export function localizeArchiveLineText(
   direction: DebugLineDirection,
   text: string,
 ): string {
-  const limitMib = archiveCapSentinelLimitMib(direction, text);
-  return limitMib === null ? text : archiveCapNoticeText(limitMib);
+  const limitMib = sentinelPayload(direction, text, ARCHIVE_CAPPED_PREFIX);
+  if (limitMib !== null) return archiveCapNoticeText(limitMib);
+  const droppedBytes = sentinelPayload(direction, text, CHUNKS_DROPPED_PREFIX);
+  if (droppedBytes !== null) return chunksDroppedNoticeText(droppedBytes);
+  return text;
 }
 
 /** One line of an exported / saved log file. */

--- a/src/features/serial-debug/components/SerialDebugLogView.test.ts
+++ b/src/features/serial-debug/components/SerialDebugLogView.test.ts
@@ -7,6 +7,7 @@ import {
   createApp,
   defineComponent,
   h,
+  KeepAlive,
   nextTick,
   ref,
   type ComponentPublicInstance,
@@ -122,6 +123,8 @@ describe("SerialDebugLogView auto-scroll", () => {
   // Refs, not mount arguments: the hex tests change these after mounting.
   const hexBytesPerRow = ref<HexBytesPerRow>(16);
   const hexViewProp = ref(false);
+  // Drives the KeepAlive wrapper below: false = "the user navigated away".
+  const keptAliveShown = ref(true);
 
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -130,6 +133,7 @@ describe("SerialDebugLogView auto-scroll", () => {
     filterMatchTotal = 0;
     hexBytesPerRow.value = 16;
     hexViewProp.value = false;
+    keptAliveShown.value = true;
     host = document.createElement("div");
     document.body.appendChild(host);
   });
@@ -150,7 +154,6 @@ describe("SerialDebugLogView auto-scroll", () => {
         setup() {
           return () =>
             h(SerialDebugLogView, {
-              lines: [],
               hexView: hexViewProp.value,
               hexBytesPerRow: hexBytesPerRow.value,
               ansiEnabled: false,
@@ -167,6 +170,42 @@ describe("SerialDebugLogView auto-scroll", () => {
       }),
     );
     return app.mount(host!);
+  }
+
+  /**
+   * Same component behind a `<KeepAlive>`, which is how the router mounts it.
+   * `onActivated` / `onDeactivated` — where the leave/return scroll restore
+   * lives — only run for a cached instance. Toggling `keptAliveShown`
+   * deactivates and reactivates the *same* instance, so the DOM node (and the
+   * geometry stub installed on it) survives the round trip.
+   */
+  function mountKeptAlive(): void {
+    keptAliveShown.value = true;
+    app = createApp(
+      defineComponent({
+        setup() {
+          return () =>
+            h(KeepAlive, () =>
+              keptAliveShown.value
+                ? h(SerialDebugLogView, {
+                    hexView: hexViewProp.value,
+                    hexBytesPerRow: hexBytesPerRow.value,
+                    ansiEnabled: false,
+                  })
+                : null,
+            );
+        },
+      }),
+    );
+    app.component(
+      "FontAwesomeIcon",
+      defineComponent({
+        setup() {
+          return () => h("i");
+        },
+      }),
+    );
+    app.mount(host!);
   }
 
   /**
@@ -191,7 +230,9 @@ describe("SerialDebugLogView auto-scroll", () => {
     Object.defineProperty(el, "scrollTop", {
       get: () => scrollTop,
       set: (v: number) => {
-        scrollTop = Math.min(v, scrollHeight() - VIEWPORT_HEIGHT);
+        // Clamp both ends like a real scroll box: the component asks for a
+        // position and reads back what the DOM actually accepted.
+        scrollTop = Math.max(0, Math.min(v, scrollHeight() - VIEWPORT_HEIGHT));
         writes.push(scrollTop);
       },
       configurable: true,
@@ -451,6 +492,63 @@ describe("SerialDebugLogView auto-scroll", () => {
 
     expect(s.lines.length).toBe(50);
     expect(renderer.cacheSize()).toBe(50);
+  });
+
+  // The scroll restore in `onActivated` replays the offset captured on leave.
+  // It used to hand that offset straight to the model while the DOM clamped it
+  // to the (now shorter) content, so the two disagreed. The clamp inside
+  // `visibleRange` hides the disagreement for as long as the buffer stays
+  // short — but once live data grows the content back past the stale offset,
+  // the mounted window jumps there while the scrollbar stays put.
+  it("keeps the mounted window on the real scroll position when the buffer shrank while the page was away", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 2000;
+    for (let i = 0; i < 600; i++) appendLine(s, i);
+    mountKeptAlive();
+    await flush();
+    const el = pane();
+    stubGeometry(el);
+    await scrollTo(el, Number.MAX_SAFE_INTEGER);
+
+    const rowHeight = spacerHeight() / 600;
+    expect(rowHeight).toBeGreaterThan(0);
+    // Park well above the tail: auto-scroll locks, so the return path below
+    // takes the "restore the saved offset" branch, not the follow-tail one.
+    await scrollTo(el, 300 * rowHeight);
+    expect(host!.querySelector(".paused-badge")).not.toBeNull();
+
+    // Leave the page. onDeactivated captures scrollTop.
+    keptAliveShown.value = false;
+    await flush();
+
+    // While away, the user lowers the visible-window cap. The store trims the
+    // buffer to a tenth of its length, so the saved offset now sits far past
+    // the end of the content it will be restored into.
+    s.logWindowLines = 60;
+    await flush();
+
+    // Come back: the DOM takes the offset it can, not the one it was given.
+    keptAliveShown.value = true;
+    await flush();
+    expect(pane()).toBe(el);
+    expect(el.scrollTop).toBe(60 * rowHeight - VIEWPORT_HEIGHT);
+
+    // Data keeps arriving and the content grows back past the stale offset,
+    // so `visibleRange` no longer clamps it away.
+    s.logWindowLines = 2000;
+    for (let i = 600; i < 1200; i++) appendLine(s, i);
+    await flush();
+
+    // Still locked, so the scrollbar has not moved …
+    expect(s.lines.length).toBe(660);
+    expect(el.scrollTop).toBe(60 * rowHeight - VIEWPORT_HEIGHT);
+    // … and the rows mounted are the rows that scrollbar is on.
+    const topRow = Math.floor(el.scrollTop / rowHeight);
+    const ids = renderedIds();
+    expect(ids).toContain(s.lines[topRow].id);
+    expect(s.lines.findIndex((line) => line.id === ids[0])).toBe(
+      topRow - OVERSCAN_ROWS,
+    );
   });
 
   // ── hex view virtualization ───────────────────────────────────────────

--- a/src/features/serial-debug/components/SerialDebugLogView.test.ts
+++ b/src/features/serial-debug/components/SerialDebugLogView.test.ts
@@ -1,0 +1,357 @@
+// @vitest-environment happy-dom
+// Auto-scroll ("follow tail") behaviour and viewport virtualization of the log
+// pane. happy-dom has no layout engine, so the scroll geometry of the pane
+// element is stubbed and every write to scrollTop is recorded.
+import { createPinia, setActivePinia } from "pinia";
+import {
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  type ComponentPublicInstance,
+} from "vue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { t } = vi.hoisted(() => ({
+  t: (key: string): string => key,
+}));
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t }),
+  createI18n: () => ({
+    global: { t, te: () => true, locale: { value: "en" } },
+  }),
+}));
+
+vi.mock("@/runtime", () => ({
+  isTauriRuntime: () => false,
+  getRuntime: () => "web",
+}));
+
+import { __setSerialDebugTransportForTest } from "@/features/serial-debug/transport";
+import type { SerialDebugTransport } from "@/features/serial-debug/transport";
+import { useSerialDebugStore } from "@/stores/serial-debug";
+import { SerialDebugLogLineRenderer } from "@/features/serial-debug/log-line-renderer";
+import SerialDebugLogView from "./SerialDebugLogView.vue";
+
+const VIEWPORT_HEIGHT = 200;
+
+function fakeTransport(): SerialDebugTransport {
+  const noopUnsub = (): void => {};
+  return {
+    open: async () => {},
+    close: async () => {},
+    send: async () => {},
+    clearSession: async () => {},
+    appendSysLine: async () => {},
+    addFilter: async () => {
+      throw new Error("not used");
+    },
+    removeFilter: async () => {},
+    readFilterMatches: async () => ({
+      filterId: "",
+      start: 0,
+      items: [],
+      totalMatches: 0,
+    }),
+    readSessionPage: async () => ({ start: 0, items: [], totalLines: 0 }),
+    onChunk: () => noopUnsub,
+    onChunkBatch: () => noopUnsub,
+    onDisconnect: () => noopUnsub,
+    onFilterUpdated: () => noopUnsub,
+  } as unknown as SerialDebugTransport;
+}
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}
+
+describe("SerialDebugLogView auto-scroll", () => {
+  let app: ReturnType<typeof createApp> | null = null;
+  let host: HTMLDivElement | null = null;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    __setSerialDebugTransportForTest(fakeTransport());
+    host = document.createElement("div");
+    document.body.appendChild(host);
+  });
+
+  afterEach(() => {
+    app?.unmount();
+    host?.remove();
+    app = null;
+    host = null;
+    __setSerialDebugTransportForTest(null);
+    vi.restoreAllMocks();
+  });
+
+  function mountComponent(hexView = false): ComponentPublicInstance {
+    app = createApp(
+      defineComponent({
+        setup() {
+          return () =>
+            h(SerialDebugLogView, {
+              lines: [],
+              hexView,
+              hexBytesPerRow: 16,
+              ansiEnabled: false,
+            });
+        },
+      }),
+    );
+    app.component(
+      "FontAwesomeIcon",
+      defineComponent({
+        setup() {
+          return () => h("i");
+        },
+      }),
+    );
+    return app.mount(host!);
+  }
+
+  /**
+   * Give the pane a fake layout: scrollHeight comes from the virtual spacer
+   * (which carries the height of the whole buffer, not of the mounted slice),
+   * and every scrollTop write is recorded so we can tell "the component tried
+   * to follow the tail" from "the component did nothing".
+   */
+  function stubGeometry(el: HTMLElement): { writes: number[] } {
+    const writes: number[] = [];
+    let scrollTop = 0;
+    const scrollHeight = (): number =>
+      Math.max(VIEWPORT_HEIGHT, spacerHeight());
+    Object.defineProperty(el, "clientHeight", {
+      get: () => VIEWPORT_HEIGHT,
+      configurable: true,
+    });
+    Object.defineProperty(el, "scrollHeight", {
+      get: scrollHeight,
+      configurable: true,
+    });
+    Object.defineProperty(el, "scrollTop", {
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = Math.min(v, scrollHeight() - VIEWPORT_HEIGHT);
+        writes.push(scrollTop);
+      },
+      configurable: true,
+    });
+    return { writes };
+  }
+
+  // Feed through the store's real write path. `lines` is a shallowRef, so a
+  // direct `s.lines.push(...)` would mutate the array without notifying any
+  // watcher — only the store publishes its own writes.
+  function appendLine(
+    s: ReturnType<typeof useSerialDebugStore>,
+    id: number,
+  ): void {
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 1_700_000_000_000 + id,
+      bytes: [...Buffer.from(`L${id}\n`)],
+    });
+  }
+
+  function pane(): HTMLElement {
+    const el = host!.querySelector(".pane");
+    if (!el) throw new Error("log pane not rendered");
+    return el as HTMLElement;
+  }
+
+  /** Full virtual height of the buffer, as published by the component. */
+  function spacerHeight(): number {
+    const el = host!.querySelector<HTMLElement>(".virt-spacer");
+    return el ? parseFloat(el.style.height) || 0 : 0;
+  }
+
+  /** The rows actually mounted (the probe row is not one of them). */
+  function renderedRows(): HTMLElement[] {
+    return [...host!.querySelectorAll<HTMLElement>(".line:not(.line-probe)")];
+  }
+
+  function renderedIds(): number[] {
+    return renderedRows().map((el) => Number(el.dataset.lineId));
+  }
+
+  /** Open the Ctrl+F bar and type a query. */
+  async function searchFor(query: string): Promise<void> {
+    const container = host!.querySelector<HTMLElement>('[tabindex="0"]')!;
+    container.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "f", ctrlKey: true }),
+    );
+    await flush();
+    const input = host!.querySelector<HTMLInputElement>(".search-input")!;
+    input.value = query;
+    input.dispatchEvent(new Event("input"));
+    await flush();
+  }
+
+  /**
+   * Hand the component its viewport geometry. happy-dom never fires a scroll
+   * event on its own, and the component reads clientHeight from the scroll
+   * handler / ResizeObserver, so one synthetic scroll bootstraps the model.
+   * Scrolling to the very bottom keeps auto-scroll unlocked.
+   */
+  async function scrollTo(el: HTMLElement, top: number): Promise<void> {
+    el.scrollTop = top;
+    el.dispatchEvent(new Event("scroll"));
+    await flush();
+  }
+
+  it("follows new lines while the visible buffer is still growing", async () => {
+    const s = useSerialDebugStore();
+    mountComponent();
+    await flush();
+    const { writes } = stubGeometry(pane());
+
+    for (let i = 0; i < 30; i++) appendLine(s, i);
+    await flush();
+
+    expect(writes.length).toBeGreaterThan(0);
+    expect(pane().scrollTop).toBe(pane().scrollHeight - VIEWPORT_HEIGHT);
+  });
+
+  it("keeps following once the visible buffer is saturated and the line count stops changing", async () => {
+    const s = useSerialDebugStore();
+    // Saturated window: the store drops one line off the head for every line it
+    // appends (logWindowLines cap in stores/serial-debug.ts), so the
+    // array length no longer changes even though the content does.
+    s.logWindowLines = 30;
+    for (let i = 0; i < 30; i++) appendLine(s, i);
+    mountComponent();
+    await flush();
+    const { writes } = stubGeometry(pane());
+    writes.length = 0;
+
+    for (let i = 30; i < 40; i++) appendLine(s, i);
+    await flush();
+
+    expect(s.lines.length).toBe(30);
+    expect(writes.length).toBeGreaterThan(0);
+    expect(host!.textContent).toContain("L39");
+  });
+
+  it("does not scroll while the user has scrolled up (auto-scroll locked)", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 30;
+    for (let i = 0; i < 30; i++) appendLine(s, i);
+    mountComponent();
+    await flush();
+    const el = pane();
+    const { writes } = stubGeometry(el);
+
+    // User scrolls up: the scroll handler locks auto-scroll.
+    el.scrollTop = 0;
+    el.dispatchEvent(new Event("scroll"));
+    await flush();
+    writes.length = 0;
+
+    for (let i = 30; i < 40; i++) appendLine(s, i);
+    await flush();
+
+    expect(s.lines.length).toBe(30);
+    expect(writes).toEqual([]);
+  });
+
+  it("mounts a bounded slice no matter how large the buffer gets", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 20000;
+    for (let i = 0; i < 500; i++) appendLine(s, i);
+    mountComponent();
+    await flush();
+    const el = pane();
+    stubGeometry(el);
+    await scrollTo(el, Number.MAX_SAFE_INTEGER);
+
+    const rowsAt500 = renderedRows().length;
+    expect(rowsAt500).toBeGreaterThan(0);
+    expect(rowsAt500).toBeLessThan(80);
+
+    for (let i = 500; i < 5000; i++) appendLine(s, i);
+    await flush();
+
+    expect(s.lines.length).toBe(5000);
+    // 10x the buffer, same amount of DOM.
+    expect(renderedRows().length).toBe(rowsAt500);
+    expect(host!.textContent).toContain("L4999");
+  });
+
+  it("mounts the rows around the current scroll offset", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 2000;
+    for (let i = 0; i < 600; i++) appendLine(s, i);
+    mountComponent();
+    await flush();
+    const el = pane();
+    stubGeometry(el);
+    await scrollTo(el, Number.MAX_SAFE_INTEGER);
+
+    const rowHeight = spacerHeight() / 600;
+    expect(rowHeight).toBeGreaterThan(0);
+    await scrollTo(el, 300 * rowHeight);
+
+    const ids = renderedIds();
+    expect(ids).toContain(s.lines[300].id);
+    expect(ids).not.toContain(s.lines[0].id);
+    expect(ids).not.toContain(s.lines[599].id);
+  });
+
+  it("scrolls a search hit outside the mounted window into view", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 2000;
+    for (let i = 0; i < 600; i++) appendLine(s, i);
+    mountComponent();
+    await flush();
+    const el = pane();
+    stubGeometry(el);
+    await scrollTo(el, Number.MAX_SAFE_INTEGER);
+    const rowHeight = spacerHeight() / 600;
+
+    // "L123" is far above the mounted window: finding it at all proves the
+    // match scan covers the whole buffer, not just the rendered rows.
+    await searchFor("L123");
+
+    expect(el.scrollTop).toBe(123 * rowHeight);
+    const current = host!.querySelectorAll(".line-search-current");
+    expect(current).toHaveLength(1);
+    expect((current[0] as HTMLElement).dataset.lineId).toBe(
+      String(s.lines[123].id),
+    );
+  });
+
+  // The whole-buffer match scan fills the renderer's per-line cache, and it
+  // runs in both views (the search bar sits above the pane). The hex view never
+  // mounts a single `.line`, so cache eviction must not hang off the ASCII
+  // branch's render path — otherwise this combination leaks every line that
+  // scrolls out of the buffer.
+  it("keeps the line cache bounded in hex view while a search is active", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 50;
+    const scan = vi.spyOn(
+      SerialDebugLogLineRenderer.prototype,
+      "matchingLineIds",
+    );
+    for (let i = 0; i < 50; i++) appendLine(s, i);
+    mountComponent(true);
+    await flush();
+    await searchFor("L");
+
+    const renderer = scan.mock.contexts[0] as SerialDebugLogLineRenderer;
+    expect(renderer).toBeInstanceOf(SerialDebugLogLineRenderer);
+    expect(host!.querySelectorAll(".line")).toHaveLength(0);
+    expect(renderer.cacheSize()).toBe(50);
+
+    // Roll the buffer over five times: the window still holds 50 lines.
+    for (let batch = 1; batch <= 5; batch++) {
+      for (let i = batch * 50; i < batch * 50 + 50; i++) appendLine(s, i);
+      await flush();
+    }
+
+    expect(s.lines.length).toBe(50);
+    expect(renderer.cacheSize()).toBe(50);
+  });
+});

--- a/src/features/serial-debug/components/SerialDebugLogView.test.ts
+++ b/src/features/serial-debug/components/SerialDebugLogView.test.ts
@@ -34,6 +34,11 @@ import type { SerialDebugTransport } from "@/features/serial-debug/transport";
 import { useSerialDebugStore } from "@/stores/serial-debug";
 import { SerialDebugLogLineRenderer } from "@/features/serial-debug/log-line-renderer";
 import { formatHexDumpFromChunks } from "@/features/serial-debug/hex-format";
+import {
+  FILTER_PAGE_SIZE,
+  HISTORY_ENTRY_PAGES,
+  HISTORY_PAGE_SIZE,
+} from "@/features/serial-debug/constants";
 import type {
   DebugLogLine,
   HexBytesPerRow,
@@ -45,6 +50,34 @@ const VIEWPORT_HEIGHT = 200;
 // vertical inset of the hex dump inside its pane.
 const OVERSCAN_ROWS = 10;
 const HEX_DUMP_INSET_Y = 12;
+
+// Synthetic Rust session archive / filter index for the paging tests. Both
+// default to 0, which reproduces the "nothing archived" transport the rest of
+// the suite was written against.
+let sessionArchiveTotal = 0;
+let filterMatchTotal = 0;
+
+/** Dense 1-based archive lines, like `SerialDebugArchive::read_page` returns. */
+function archivePage(
+  start: number,
+  limit: number,
+  total: number,
+  textPrefix: string,
+) {
+  // Mirrors Rust: an out-of-range `start` is silently clamped to `total`, and
+  // the clamped value — not the requested one — comes back in `page.start`.
+  const from = Math.min(Math.max(start, 0), total);
+  const to = Math.min(from + limit, total);
+  return {
+    start: from,
+    items: Array.from({ length: Math.max(0, to - from) }, (_, i) => ({
+      lineNo: from + i + 1,
+      tsMs: 1_700_000_000_000 + from + i,
+      direction: "rx" as const,
+      text: `${textPrefix}${from + i + 1}`,
+    })),
+  };
+}
 
 function fakeTransport(): SerialDebugTransport {
   const noopUnsub = (): void => {};
@@ -58,13 +91,19 @@ function fakeTransport(): SerialDebugTransport {
       throw new Error("not used");
     },
     removeFilter: async () => {},
-    readFilterMatches: async () => ({
-      filterId: "",
-      start: 0,
-      items: [],
-      totalMatches: 0,
+    readFilterMatches: async (
+      filterId: string,
+      start: number,
+      limit: number,
+    ) => ({
+      filterId,
+      totalMatches: filterMatchTotal,
+      ...archivePage(start, limit, filterMatchTotal, "m-"),
     }),
-    readSessionPage: async () => ({ start: 0, items: [], totalLines: 0 }),
+    readSessionPage: async (start: number, limit: number) => ({
+      totalLines: sessionArchiveTotal,
+      ...archivePage(start, limit, sessionArchiveTotal, "arch-"),
+    }),
     onChunk: () => noopUnsub,
     onChunkBatch: () => noopUnsub,
     onDisconnect: () => noopUnsub,
@@ -87,6 +126,8 @@ describe("SerialDebugLogView auto-scroll", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     __setSerialDebugTransportForTest(fakeTransport());
+    sessionArchiveTotal = 0;
+    filterMatchTotal = 0;
     hexBytesPerRow.value = 16;
     hexViewProp.value = false;
     host = document.createElement("div");
@@ -624,5 +665,204 @@ describe("SerialDebugLogView auto-scroll", () => {
     const rows = fullDumpRows(s.lines);
     expect(mountedDump().endsWith(rows[rows.length - 1])).toBe(true);
     expect(mountedDump().split("\n").length).toBeLessThan(80);
+  });
+
+  // ── full-session scrollback ("All" tab) ───────────────────────────────
+  // Scrolling past the top of the live ring buffer hands the pane a bounded
+  // window on the Rust session archive instead. The two buffers are never
+  // concatenated, so what is asserted below is (a) the switch happens and shows
+  // archive lines, (b) prepending older lines keeps the viewport on the line the
+  // user was reading, and (c) the switch does not wake the follow-tail watcher.
+
+  const ENTRY_LINES = HISTORY_PAGE_SIZE * HISTORY_ENTRY_PAGES;
+
+  /** Live buffer of `count` lines, an archive of `archived`, mounted and at the tail. */
+  async function mountWithArchive(
+    count: number,
+    archived: number,
+    hexView = false,
+  ): Promise<{
+    s: ReturnType<typeof useSerialDebugStore>;
+    el: HTMLElement;
+    writes: number[];
+  }> {
+    const s = useSerialDebugStore();
+    // Roomy on purpose: `logWindowLines` is also the history window's budget, so
+    // a tight value here would cap the window below one entry load.
+    s.logWindowLines = 20000;
+    for (let i = 0; i < count; i++) appendLine(s, i);
+    sessionArchiveTotal = archived;
+    mountComponent(hexView);
+    await flush();
+    const el = pane();
+    const { writes } = stubGeometry(el);
+    await scrollTo(el, Number.MAX_SAFE_INTEGER);
+    return { s, el, writes };
+  }
+
+  it("switches the All tab to the session archive when scrolled past the top of the live buffer", async () => {
+    const { s, el } = await mountWithArchive(200, 5000);
+
+    await scrollTo(el, 0);
+    await flush();
+
+    expect(s.historyMode).toBe(true);
+    expect(s.historyLines.length).toBe(ENTRY_LINES);
+    expect(s.historyStartLineNo).toBe(5000 - ENTRY_LINES + 1);
+    expect(s.historyEndLineNo).toBe(5000);
+    // Positioned to skip the window's last `s.lines.length` lines, i.e. roughly
+    // where the live buffer began.
+    const rowHeight = spacerHeight() / ENTRY_LINES;
+    const entryRow = ENTRY_LINES - 200;
+    expect(el.scrollTop).toBe(entryRow * rowHeight);
+    expect(host!.textContent).toContain(
+      `arch-${s.historyStartLineNo + entryRow}`,
+    );
+    // The live buffer is untouched and still filling.
+    expect(s.lines.length).toBe(200);
+    expect(host!.textContent).not.toContain("L199");
+  });
+
+  it("keeps the viewport on the same line when older history is prepended", async () => {
+    const { s, el, writes } = await mountWithArchive(200, 5000);
+    await scrollTo(el, 0);
+    await flush();
+    writes.length = 0;
+
+    // Back to the top of the window: loads the next page older.
+    await scrollTo(el, 0);
+    await flush();
+
+    expect(s.historyLines.length).toBe(ENTRY_LINES + HISTORY_PAGE_SIZE);
+    expect(s.historyStartLineNo).toBe(
+      5000 - ENTRY_LINES - HISTORY_PAGE_SIZE + 1,
+    );
+    const rowHeight = spacerHeight() / s.historyLines.length;
+    // Two writes only: the user's own scroll to 0, then the compensation that
+    // puts the previously-first line back where it was. No follow-tail write.
+    expect(writes).toEqual([0, HISTORY_PAGE_SIZE * rowHeight]);
+    expect(el.scrollTop).toBe(HISTORY_PAGE_SIZE * rowHeight);
+  });
+
+  it("locks auto-scroll on entering history mode so live output cannot pull the viewport away", async () => {
+    const { s, el, writes } = await mountWithArchive(200, 5000);
+    await scrollTo(el, 0);
+    await flush();
+
+    expect(host!.querySelector(".paused-badge")).not.toBeNull();
+    const parked = el.scrollTop;
+    writes.length = 0;
+
+    // Live lines keep arriving: they change the id of the last line in the live
+    // buffer, but the displayed buffer is the history window, and the lock is
+    // set regardless.
+    for (let i = 200; i < 240; i++) appendLine(s, i);
+    await flush();
+
+    expect(s.lines.length).toBe(240);
+    expect(writes).toEqual([]);
+    expect(el.scrollTop).toBe(parked);
+  });
+
+  it("returns to the live tail from the scroll-to-bottom badge", async () => {
+    const { s, el } = await mountWithArchive(200, 5000);
+    await scrollTo(el, 0);
+    await flush();
+    expect(s.historyMode).toBe(true);
+
+    host!.querySelector<HTMLElement>(".paused-badge")!.click();
+    await flush();
+
+    expect(s.historyMode).toBe(false);
+    expect(s.historyLines).toEqual([]);
+    expect(el.scrollTop).toBe(el.scrollHeight - VIEWPORT_HEIGHT);
+    expect(renderedIds()).toContain(s.lines[199].id);
+    expect(host!.textContent).toContain("L199");
+  });
+
+  it("leaves history mode again when scrolled back to the end of the archive", async () => {
+    const { s, el } = await mountWithArchive(200, 5000);
+    await scrollTo(el, 0);
+    await flush();
+    expect(s.historyMode).toBe(true);
+    expect(s.historyAtArchiveEnd).toBe(true);
+
+    await scrollTo(el, Number.MAX_SAFE_INTEGER);
+    await flush();
+
+    expect(s.historyMode).toBe(false);
+    expect(host!.textContent).toContain("L199");
+  });
+
+  it("renders the history window as one continuous hex dump", async () => {
+    const { s, el } = await mountWithArchive(200, 2000, true);
+
+    await scrollTo(el, 0);
+    await flush();
+
+    expect(s.historyMode).toBe(true);
+    // Archive lines carry no rawBytes, so the byte index re-encodes their text —
+    // the same path a filter tab already uses.
+    expect(s.historyLines.every((l) => l.rawBytes === undefined)).toBe(true);
+    const rows = fullDumpRows(s.historyLines);
+    expect(rows.length).toBeGreaterThan(200);
+    expect(mountedDump().split("\n").length).toBeLessThan(80);
+    // A verbatim, correctly positioned slice of the dump of the whole window.
+    const startRow = mountedWindowStartRow(rows);
+    expect(startRow).toBeGreaterThan(0);
+    expect(mountedDump()).not.toContain(rows[0]);
+    expect(mountedDump()).not.toContain(rows[rows.length - 1]);
+  });
+
+  it("stays on the live buffer when there is nothing archived", async () => {
+    const { s, el, writes } = await mountWithArchive(200, 0);
+    writes.length = 0;
+
+    await scrollTo(el, 0);
+    await flush();
+
+    expect(s.historyMode).toBe(false);
+    expect(writes).toEqual([0]);
+    expect(host!.querySelector(".history-bar")).toBeNull();
+  });
+
+  // Same scroll-anchor mechanism as history mode, on the pre-existing filter
+  // pagination: before virtualization the browser's own scroll anchoring
+  // absorbed the prepend, but the component owns scrollTop now.
+  it("keeps the viewport in place when older filter matches are prepended", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 2000;
+    filterMatchTotal = 5000;
+    mountComponent();
+    await flush();
+    s.watchChips = [{ id: "f1", keyword: "m", useRegex: false, color: "#000" }];
+    s.filterStatsById = {
+      f1: {
+        filterId: "f1",
+        status: "complete",
+        scannedUntilLineNo: 0,
+        totalLinesSnapshot: 0,
+        totalMatches: filterMatchTotal,
+        error: null,
+      },
+    };
+    await s.setActiveChip("f1");
+    await flush();
+    const el = pane();
+    stubGeometry(el);
+    await scrollTo(el, Number.MAX_SAFE_INTEGER);
+    await scrollTo(el, 0);
+
+    const button = [...host!.querySelectorAll("button")].find((b) =>
+      b.textContent?.includes("serialDebug.log.loadOlderMatches"),
+    );
+    expect(button).toBeDefined();
+    button!.click();
+    await flush();
+
+    expect(s.filterPagesById.f1.items.length).toBe(2 * FILTER_PAGE_SIZE);
+    const rowHeight = spacerHeight() / (2 * FILTER_PAGE_SIZE);
+    expect(el.scrollTop).toBe(FILTER_PAGE_SIZE * rowHeight);
+    expect(renderedRows().length).toBeLessThan(80);
   });
 });

--- a/src/features/serial-debug/components/SerialDebugLogView.test.ts
+++ b/src/features/serial-debug/components/SerialDebugLogView.test.ts
@@ -8,6 +8,7 @@ import {
   defineComponent,
   h,
   nextTick,
+  ref,
   type ComponentPublicInstance,
 } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -32,9 +33,18 @@ import { __setSerialDebugTransportForTest } from "@/features/serial-debug/transp
 import type { SerialDebugTransport } from "@/features/serial-debug/transport";
 import { useSerialDebugStore } from "@/stores/serial-debug";
 import { SerialDebugLogLineRenderer } from "@/features/serial-debug/log-line-renderer";
+import { formatHexDumpFromChunks } from "@/features/serial-debug/hex-format";
+import type {
+  DebugLogLine,
+  HexBytesPerRow,
+} from "@/features/serial-debug/types";
 import SerialDebugLogView from "./SerialDebugLogView.vue";
 
 const VIEWPORT_HEIGHT = 200;
+// Mirrors the component: overscan rows above/below the viewport, and the
+// vertical inset of the hex dump inside its pane.
+const OVERSCAN_ROWS = 10;
+const HEX_DUMP_INSET_Y = 12;
 
 function fakeTransport(): SerialDebugTransport {
   const noopUnsub = (): void => {};
@@ -70,10 +80,15 @@ async function flush(): Promise<void> {
 describe("SerialDebugLogView auto-scroll", () => {
   let app: ReturnType<typeof createApp> | null = null;
   let host: HTMLDivElement | null = null;
+  // Refs, not mount arguments: the hex tests change these after mounting.
+  const hexBytesPerRow = ref<HexBytesPerRow>(16);
+  const hexViewProp = ref(false);
 
   beforeEach(() => {
     setActivePinia(createPinia());
     __setSerialDebugTransportForTest(fakeTransport());
+    hexBytesPerRow.value = 16;
+    hexViewProp.value = false;
     host = document.createElement("div");
     document.body.appendChild(host);
   });
@@ -88,14 +103,15 @@ describe("SerialDebugLogView auto-scroll", () => {
   });
 
   function mountComponent(hexView = false): ComponentPublicInstance {
+    hexViewProp.value = hexView;
     app = createApp(
       defineComponent({
         setup() {
           return () =>
             h(SerialDebugLogView, {
               lines: [],
-              hexView,
-              hexBytesPerRow: 16,
+              hexView: hexViewProp.value,
+              hexBytesPerRow: hexBytesPerRow.value,
               ansiEnabled: false,
             });
         },
@@ -175,6 +191,47 @@ describe("SerialDebugLogView auto-scroll", () => {
 
   function renderedIds(): number[] {
     return renderedRows().map((el) => Number(el.dataset.lineId));
+  }
+
+  /** The hex dump text actually mounted (the probe row is not part of it). */
+  function mountedDump(): string {
+    const el = host!.querySelector<HTMLElement>(".virt-window pre");
+    if (!el) throw new Error("hex dump not rendered");
+    return el.textContent ?? "";
+  }
+
+  /**
+   * The dump the whole visible buffer would produce — the pre-virtualization
+   * output. Every mounted window must be a verbatim row-aligned slice of it,
+   * which is what keeps the hex view one continuous dump.
+   */
+  function fullDumpRows(
+    lines: readonly DebugLogLine[],
+    bytesPerRow: HexBytesPerRow = hexBytesPerRow.value,
+  ): string[] {
+    const chunks = lines.map((l) =>
+      Uint8Array.from([
+        ...(l.rawBytes ?? new TextEncoder().encode(l.text)),
+        0x0a,
+      ]),
+    );
+    const dump = formatHexDumpFromChunks(chunks, bytesPerRow);
+    return dump === "" ? [] : dump.split("\n");
+  }
+
+  /** Row index the mounted window starts at, verifying it is a verbatim slice. */
+  function mountedWindowStartRow(rows: string[]): number {
+    const dump = rows.join("\n");
+    const at = dump.indexOf(mountedDump());
+    expect(at).toBeGreaterThanOrEqual(0);
+    expect(at === 0 || dump[at - 1] === "\n").toBe(true);
+    return at === 0 ? 0 : dump.slice(0, at).split("\n").length - 1;
+  }
+
+  function hexRowHeight(rows: number): number {
+    // contentHeight = rows * rowHeight + 2 * inset (happy-dom has no layout, so
+    // the component falls back to its font-size estimate).
+    return (spacerHeight() - 2 * HEX_DUMP_INSET_Y) / rows;
   }
 
   /** Open the Ctrl+F bar and type a query. */
@@ -353,5 +410,219 @@ describe("SerialDebugLogView auto-scroll", () => {
 
     expect(s.lines.length).toBe(50);
     expect(renderer.cacheSize()).toBe(50);
+  });
+
+  // ── hex view virtualization ───────────────────────────────────────────
+  // The hex view is one continuous dump of the buffer's byte stream, so its rows
+  // are byte ranges, not log lines. What is asserted below is that the mounted
+  // window stays a verbatim, correctly positioned slice of that dump (visual
+  // output unchanged) while its size stays bounded.
+
+  it("mounts a bounded hex window no matter how large the buffer gets", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 20000;
+    for (let i = 0; i < 500; i++) appendLine(s, i);
+    mountComponent(true);
+    await flush();
+    const el = pane();
+    stubGeometry(el);
+    await scrollTo(el, Number.MAX_SAFE_INTEGER);
+
+    const dumpAt500 = mountedDump();
+    const rowsAt500 = dumpAt500.split("\n").length;
+    expect(rowsAt500).toBeGreaterThan(0);
+    expect(rowsAt500).toBeLessThan(80);
+    // The whole buffer is far bigger than what is mounted.
+    expect(fullDumpRows(s.lines).length).toBeGreaterThan(3 * rowsAt500);
+
+    for (let i = 500; i < 5000; i++) appendLine(s, i);
+    await flush();
+
+    expect(s.lines.length).toBe(5000);
+    const rows = fullDumpRows(s.lines);
+    // 10x the buffer, same amount of DOM …
+    expect(mountedDump().split("\n").length).toBe(rowsAt500);
+    // … still following the tail, and still a verbatim slice of the full dump.
+    expect(mountedDump().endsWith(rows[rows.length - 1])).toBe(true);
+    expect(mountedWindowStartRow(rows)).toBe(rows.length - rowsAt500);
+  });
+
+  it("mounts the hex rows around the current scroll offset", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 2000;
+    for (let i = 0; i < 600; i++) appendLine(s, i);
+    mountComponent(true);
+    await flush();
+    const el = pane();
+    stubGeometry(el);
+    await scrollTo(el, Number.MAX_SAFE_INTEGER);
+
+    const rows = fullDumpRows(s.lines);
+    const rowHeight = hexRowHeight(rows.length);
+    expect(rowHeight).toBeGreaterThan(0);
+
+    const targetRow = Math.floor(rows.length / 2);
+    await scrollTo(el, targetRow * rowHeight + HEX_DUMP_INSET_Y);
+
+    const startRow = mountedWindowStartRow(rows);
+    expect(startRow).toBe(targetRow - OVERSCAN_ROWS);
+    // Neither end of the buffer is mounted.
+    expect(mountedDump()).not.toContain(rows[0]);
+    expect(mountedDump()).not.toContain(rows[rows.length - 1]);
+  });
+
+  it("re-cuts the hex row model when bytesPerRow changes", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 2000;
+    for (let i = 0; i < 400; i++) appendLine(s, i);
+    mountComponent(true);
+    await flush();
+    const el = pane();
+    stubGeometry(el);
+    await scrollTo(el, Number.MAX_SAFE_INTEGER);
+
+    const rowsAt16 = fullDumpRows(s.lines, 16).length;
+    expect(hexRowHeight(rowsAt16)).toBeGreaterThan(0);
+
+    hexBytesPerRow.value = 8;
+    await flush();
+
+    // Half as many bytes per row means twice as many rows to scroll through
+    // (minus one when the final 16-byte row was already a partial one).
+    const rows = fullDumpRows(s.lines, 8);
+    expect(rows.length).toBeGreaterThanOrEqual(2 * rowsAt16 - 1);
+    expect(rows.length).toBeLessThanOrEqual(2 * rowsAt16);
+    expect(hexRowHeight(rows.length)).toBeGreaterThan(0);
+    // The index survived the switch: the window is still a slice of the *new*
+    // dump, and auto-scroll still sits on the last row.
+    expect(mountedWindowStartRow(rows)).toBeGreaterThan(0);
+    expect(mountedDump().endsWith(rows[rows.length - 1])).toBe(true);
+  });
+
+  it("keeps following the tail in hex view and stops when scrolled up", async () => {
+    const s = useSerialDebugStore();
+    // Saturated window: every append drops one line off the head, so the byte
+    // stream re-bases under the viewport on every batch.
+    s.logWindowLines = 200;
+    for (let i = 0; i < 200; i++) appendLine(s, i);
+    mountComponent(true);
+    await flush();
+    const el = pane();
+    const { writes } = stubGeometry(el);
+    await scrollTo(el, Number.MAX_SAFE_INTEGER);
+    writes.length = 0;
+
+    for (let i = 200; i < 210; i++) appendLine(s, i);
+    await flush();
+
+    expect(s.lines.length).toBe(200);
+
+    expect(writes.length).toBeGreaterThan(0);
+    const rows = fullDumpRows(s.lines);
+    expect(mountedDump().endsWith(rows[rows.length - 1])).toBe(true);
+
+    // User scrolls up: no more scrollTop writes, and the head of the buffer is
+    // what is mounted.
+    await scrollTo(el, 0);
+    writes.length = 0;
+    for (let i = 210; i < 220; i++) appendLine(s, i);
+    await flush();
+
+    expect(writes).toEqual([]);
+    expect(mountedWindowStartRow(fullDumpRows(s.lines))).toBe(0);
+  });
+
+  it("re-measures the hex row height when the font size changes", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 2000;
+    for (let i = 0; i < 300; i++) appendLine(s, i);
+    mountComponent(true);
+    await flush();
+    const el = pane();
+    stubGeometry(el);
+    await scrollTo(el, Number.MAX_SAFE_INTEGER);
+
+    const rows = fullDumpRows(s.lines);
+    const before = hexRowHeight(rows.length);
+
+    s.logFontSize = 18;
+    await flush();
+
+    // Taller rows, same row count: the byte index does not depend on layout.
+    expect(hexRowHeight(rows.length)).toBeGreaterThan(before);
+    expect(fullDumpRows(s.lines).length).toBe(rows.length);
+    expect(mountedDump().endsWith(rows[rows.length - 1])).toBe(true);
+  });
+
+  it("renders an archive-backed filter tab in hex view", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 2000;
+    for (let i = 0; i < 100; i++) appendLine(s, i);
+    mountComponent(true);
+    await flush();
+    stubGeometry(pane());
+    await scrollTo(pane(), Number.MAX_SAFE_INTEGER);
+
+    // Filter tabs are fed from the Rust session archive: text only, no
+    // rawBytes, so the byte index has to re-encode. The first line stands in
+    // for the localized archive-cap sentinel — non-ASCII text, several UTF-8
+    // bytes per character.
+    const items: DebugLogLine[] = Array.from({ length: 400 }, (_, i) => ({
+      id: 100_000 + i,
+      tsMs: i,
+      direction: i === 0 ? "sys" : "rx",
+      text: i === 0 ? "日志归档已达上限 256 MiB" : `match-${i}`,
+    }));
+    s.filterPagesById = {
+      chipA: { filterId: "chipA", totalMatches: 400, start: 0, items },
+    };
+    s.activeChipId = "chipA";
+    await flush();
+    stubGeometry(pane());
+    await scrollTo(pane(), Number.MAX_SAFE_INTEGER);
+
+    const rows = fullDumpRows(items);
+    expect(rows.length).toBeGreaterThan(100);
+    expect(mountedDump().split("\n").length).toBeLessThan(80);
+    expect(mountedDump().endsWith(rows[rows.length - 1])).toBe(true);
+
+    // The head of that tab, including the non-ASCII sys line.
+    await scrollTo(pane(), 0);
+    expect(mountedWindowStartRow(rows)).toBe(0);
+    expect(mountedDump().startsWith(rows[0])).toBe(true);
+  });
+
+  it("switches between the hex and line panes without losing the row model", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 2000;
+    for (let i = 0; i < 300; i++) appendLine(s, i);
+    mountComponent(true);
+    await flush();
+    stubGeometry(pane());
+    await scrollTo(pane(), Number.MAX_SAFE_INTEGER);
+    const hexSpacer = spacerHeight();
+    expect(hexSpacer).toBeGreaterThan(0);
+
+    // hexView is a prop; flip it on the wrapper. v-if/v-else swaps the pane
+    // element, so the geometry stub has to be re-applied.
+    hexViewProp.value = false;
+    await flush();
+    stubGeometry(pane());
+    await scrollTo(pane(), Number.MAX_SAFE_INTEGER);
+
+    expect(host!.querySelector(".virt-window pre")).toBeNull();
+    expect(renderedRows().length).toBeGreaterThan(0);
+    // The line row model is in charge now: 300 lines, bounded DOM, at the tail.
+    expect(renderedRows().length).toBeLessThan(80);
+    expect(renderedIds()).toContain(s.lines[299].id);
+
+    hexViewProp.value = true;
+    await flush();
+    stubGeometry(pane());
+    await scrollTo(pane(), Number.MAX_SAFE_INTEGER);
+
+    const rows = fullDumpRows(s.lines);
+    expect(mountedDump().endsWith(rows[rows.length - 1])).toBe(true);
+    expect(mountedDump().split("\n").length).toBeLessThan(80);
   });
 });

--- a/src/features/serial-debug/components/SerialDebugLogView.vue
+++ b/src/features/serial-debug/components/SerialDebugLogView.vue
@@ -4,27 +4,29 @@ import {
   nextTick,
   onActivated,
   onDeactivated,
+  onUnmounted,
   reactive,
   ref,
   watch,
+  watchEffect,
 } from "vue";
 import { useI18n } from "vue-i18n";
 import { faCircleNotch, faFloppyDisk } from "@fortawesome/free-solid-svg-icons";
 import { useSerialDebugStore } from "@/stores/serial-debug";
 import { serialDebugTransport } from "@/features/serial-debug/transport";
 import { isTauriRuntime } from "@/runtime";
-import { stripAnsi, type AnsiStyle } from "@/features/serial-debug/ansi-parse";
+import type { AnsiStyle } from "@/features/serial-debug/ansi-parse";
 import {
   SerialDebugLogLineRenderer,
   type RenderedLogLine,
 } from "@/features/serial-debug/log-line-renderer";
 import { SerialDebugHexViewRenderer } from "@/features/serial-debug/hex-view-renderer";
 import { makeStamp, formatTs } from "@/features/serial-debug/utils";
+import { formatExportLine } from "@/features/serial-debug/archive-line-text";
 import { EXPORT_PAGE_SIZE } from "@/features/serial-debug/constants";
 import type {
   DebugLogLine,
   HexBytesPerRow,
-  SerialDebugLine,
 } from "@/features/serial-debug/types";
 import SerialDebugChipBar from "./SerialDebugChipBar.vue";
 
@@ -57,9 +59,107 @@ const activeChip = computed(() =>
     : null,
 );
 
-const displayLines = computed(() => s.activeDisplayLines);
+// A getter, not a computed: the store's live line buffer is a shallowRef whose
+// array identity stays the same across appends, and a computed that returns an
+// identity-stable value never notifies its subscribers. Calling through makes
+// every computed/watcher below depend on the store refs directly.
+const displayLines = (): DebugLogLine[] => s.activeDisplayLines();
 
 const scrollRef = ref<HTMLDivElement | null>(null);
+
+// ── viewport virtualization (ASCII line view only) ──────────────────────
+// Only the rows inside the viewport — plus OVERSCAN_ROWS above and below so a
+// fast scroll never shows a blank band — are turned into DOM. Rows are
+// fixed-height by construction (`.line` pins line-height and `.text` is
+// `white-space: pre`, so the pane scrolls horizontally instead of wrapping),
+// which makes a row's offset exactly `index * rowHeight` — no per-row
+// measurement, no reading `scrollHeight`.
+const OVERSCAN_ROWS = 10;
+
+const rowProbeRef = ref<HTMLDivElement | null>(null);
+const scrollTop = ref(0);
+const viewportHeight = ref(0);
+const measuredRowHeight = ref(0);
+
+// Used until the probe has been measured (first frame) and in environments
+// without a layout engine (happy-dom): mirrors the `.line` box — line-height
+// 1.5 plus 2 x 0.1875rem of vertical padding.
+function estimateRowHeight(fontSize: number): number {
+  return Math.round(fontSize * 1.5) + 6;
+}
+
+const rowHeight = computed(
+  () => measuredRowHeight.value || estimateRowHeight(s.logFontSize),
+);
+
+// Row height must never be hard-coded: the font size is user-adjustable
+// (10–18px). The probe is a real `.line` rendered inside the pane, so it picks
+// up every inherited style change.
+function measureLayout(): void {
+  const paneEl = scrollRef.value;
+  if (paneEl && paneEl.clientHeight > 0) {
+    viewportHeight.value = paneEl.clientHeight;
+  }
+  // getBoundingClientRect, not offsetHeight: a fractional row height (e.g.
+  // 19.5px at 13px font) rounded to an integer would drift the mounted rows out
+  // of their computed slots across the window.
+  const probeHeight = rowProbeRef.value?.getBoundingClientRect().height ?? 0;
+  if (probeHeight > 0) measuredRowHeight.value = probeHeight;
+}
+
+let resizeObserver: ResizeObserver | null = null;
+watch(
+  [scrollRef, rowProbeRef],
+  ([paneEl, probeEl]) => {
+    if (typeof ResizeObserver === "undefined") return;
+    resizeObserver ??= new ResizeObserver(() => measureLayout());
+    resizeObserver.disconnect();
+    if (paneEl) resizeObserver.observe(paneEl);
+    if (probeEl) resizeObserver.observe(probeEl);
+    measureLayout();
+  },
+  { flush: "post" },
+);
+onUnmounted(() => resizeObserver?.disconnect());
+
+// Font size changed: fall back to the estimate for one frame, then re-measure.
+watch(
+  () => s.logFontSize,
+  () => {
+    measuredRowHeight.value = 0;
+    void nextTick().then(measureLayout);
+  },
+);
+
+const contentHeight = computed(() => displayLines().length * rowHeight.value);
+const maxScrollTop = computed(() =>
+  Math.max(0, contentHeight.value - viewportHeight.value),
+);
+
+const visibleRange = computed<{ start: number; end: number }>(() => {
+  const total = displayLines().length;
+  const rh = rowHeight.value;
+  const top = Math.min(Math.max(scrollTop.value, 0), maxScrollTop.value);
+  return {
+    start: Math.max(0, Math.floor(top / rh) - OVERSCAN_ROWS),
+    end: Math.min(
+      total,
+      Math.ceil((top + viewportHeight.value) / rh) + OVERSCAN_ROWS,
+    ),
+  };
+});
+
+const windowOffsetY = computed(
+  () => visibleRange.value.start * rowHeight.value,
+);
+
+function applyScrollTop(el: HTMLElement, top: number): void {
+  // Keep the model in sync with the DOM: a programmatic scrollTop write fires
+  // its `scroll` event asynchronously (and never at all in tests), so the
+  // visible range would otherwise lag a frame behind.
+  scrollTop.value = top;
+  el.scrollTop = top;
+}
 
 // Per-tab scroll lock. Key: activeChipId (null = "All" tab).
 // Each tab maintains its own pause state independently.
@@ -76,11 +176,21 @@ async function scrollToBottom(): Promise<void> {
   await nextTick();
   const el = scrollRef.value;
   if (!el || lockAutoScroll.value) return;
-  el.scrollTop = el.scrollHeight;
+  // The hex pane is a single <pre> with no row model, so it still asks the DOM.
+  // The line pane derives the target from the row model instead: reading
+  // scrollHeight there would force a synchronous layout on every batch.
+  applyScrollTop(el, props.hexView ? el.scrollHeight : maxScrollTop.value);
 }
 
+// Track the newest line id, not the array length: once the visible window is
+// saturated (logWindowLines) the store drops one line off the head for
+// every line it appends, so the length stops changing while new lines keep
+// arriving — a length watcher goes permanently deaf at that point.
 watch(
-  () => displayLines.value.length,
+  () => {
+    const current = displayLines();
+    return current[current.length - 1]?.id ?? -1;
+  },
   () => {
     void scrollToBottom();
   },
@@ -126,7 +236,11 @@ watchLayoutChange(() => s.logFontSize);
 function onScroll(): void {
   const el = scrollRef.value;
   if (!el) return;
-  const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  scrollTop.value = el.scrollTop;
+  if (el.clientHeight > 0) viewportHeight.value = el.clientHeight;
+  const atBottom = props.hexView
+    ? el.scrollHeight - el.scrollTop - el.clientHeight < 80
+    : contentHeight.value - scrollTop.value - viewportHeight.value < 80;
   lockAutoScroll.value = !atBottom;
 }
 
@@ -137,7 +251,7 @@ async function resumeScroll(): Promise<void> {
 
 const hexRendered = computed(() => {
   if (!props.hexView) return null;
-  return hexViewRenderer.render(displayLines.value, props.hexBytesPerRow);
+  return hexViewRenderer.render(displayLines(), props.hexBytesPerRow);
 });
 
 function spanStyle(style: AnsiStyle): Record<string, string | undefined> {
@@ -152,6 +266,11 @@ function spanStyle(style: AnsiStyle): Record<string, string | undefined> {
 
 const ctxMenu = ref<{ x: number; y: number; selected: string } | null>(null);
 
+// Known limitation of the virtualized pane: the native selection can only cover
+// mounted rows, so a selection dragged past the viewport stops at the rows that
+// happen to be in the DOM. Selecting inside the viewport (the copy / to-hex /
+// to-ascii actions below) works as before. A selection model spanning unmounted
+// rows would need its own text layer and is deliberately out of scope.
 function onContextMenu(ev: MouseEvent): void {
   const sel = window.getSelection()?.toString() ?? "";
   if (!sel) {
@@ -190,10 +309,11 @@ onActivated(async () => {
   await nextTick();
   const el = scrollRef.value;
   if (!el) return;
+  measureLayout();
   if (lockAutoScroll.value && savedScrollTop !== null) {
-    el.scrollTop = savedScrollTop;
+    applyScrollTop(el, savedScrollTop);
   } else if (!lockAutoScroll.value) {
-    el.scrollTop = el.scrollHeight;
+    applyScrollTop(el, props.hexView ? el.scrollHeight : maxScrollTop.value);
   }
   savedScrollTop = null;
 });
@@ -206,17 +326,34 @@ const searchIndex = ref(0);
 const searchInputRef = ref<HTMLInputElement | null>(null);
 
 const searchQuery = computed(() => searchText.value.trim().toLowerCase());
-const displayLineViews = computed<RenderedLogLine[]>(() =>
-  lineRenderer.render(displayLines.value, props.ansiEnabled, searchQuery.value),
-);
 
-// Single pass: ordered list of matching IDs; Set derived from it for O(1) template lookup.
-const matchingLineIdList = computed<number[]>(() => {
-  if (!searchQuery.value) return [];
-  return displayLineViews.value
-    .filter((view) => view.hasMatch)
-    .map((view) => view.line.id);
+// Cache eviction must not hang off either template branch. Two paths fill the
+// renderer's per-line cache — the span building below (ASCII branch only) and
+// the whole-buffer match scan (runs in both branches, since the search bar sits
+// above the pane) — so tying eviction to the ASCII render would leak every line
+// that ages out of the buffer while the hex view is up with a search active.
+// This effect re-runs on every buffer publish regardless of what is mounted,
+// and it replaces (not adds to) the per-render prune the old code did: it no
+// longer re-scans on a pure scroll, when only the visible slice moves.
+watchEffect(() => lineRenderer.retain(displayLines()));
+
+// Spans are built for the mounted slice only.
+const visibleLineViews = computed<RenderedLogLine[]>(() => {
+  const all = displayLines();
+  const { start, end } = visibleRange.value;
+  return lineRenderer.render(
+    all.slice(start, end),
+    props.ansiEnabled,
+    searchQuery.value,
+  );
 });
+
+// Search stays whole-buffer: matching is a plain substring scan over every
+// line, decoupled from the span building above, so the count and the
+// prev/next order do not degrade to "whatever happens to be on screen".
+const matchingLineIdList = computed<number[]>(() =>
+  lineRenderer.matchingLineIds(displayLines(), searchQuery.value),
+);
 
 const matchingLineIds = computed<Set<number>>(
   () => new Set(matchingLineIdList.value),
@@ -265,12 +402,29 @@ async function navigateSearch(delta: number): Promise<void> {
   await scrollToMatch();
 }
 
+// Scroll by index, not by element lookup: a match outside the mounted window
+// has no DOM node to scroll into view.
 async function scrollToMatch(): Promise<void> {
   const id = currentMatchLineId.value;
   if (id === null) return;
   await nextTick();
-  const el = scrollRef.value?.querySelector(`[data-line-id="${id}"]`);
-  el?.scrollIntoView({ block: "nearest" });
+  const el = scrollRef.value;
+  if (!el) return;
+  const index = displayLines().findIndex((line) => line.id === id);
+  if (index < 0) return;
+  const rh = rowHeight.value;
+  const rowTop = index * rh;
+  const current = scrollTop.value;
+  // Equivalent of scrollIntoView({ block: "nearest" }): only move when the row
+  // sits outside the viewport.
+  let next = current;
+  if (rowTop < current) {
+    next = rowTop;
+  } else if (rowTop + rh > current + viewportHeight.value) {
+    next = rowTop + rh - viewportHeight.value;
+  }
+  if (next === current) return;
+  applyScrollTop(el, Math.min(Math.max(next, 0), maxScrollTop.value));
 }
 
 function onContainerKeydown(ev: KeyboardEvent): void {
@@ -304,12 +458,6 @@ async function writeFile(
   a.download = defaultName;
   a.click();
   URL.revokeObjectURL(url);
-}
-
-function formatExportLine(line: SerialDebugLine): string {
-  const dir =
-    line.direction === "tx" ? "TX " : line.direction === "rx" ? "RX " : "SYS";
-  return `[${formatTs(line.tsMs)}] [${dir}] ${stripAnsi(line.text)}`;
 }
 
 function linesAvailableForSession(): boolean {
@@ -634,53 +782,69 @@ async function saveLog(): Promise<void> {
       @scroll="onScroll"
       @contextmenu="onContextMenu"
     >
-      <div
-        v-for="lineView in displayLineViews"
-        :key="lineView.line.id"
-        :data-line-id="lineView.line.id"
-        class="line"
-        :data-dir="lineView.line.direction"
-        :class="{
-          'line-search-match':
-            matchingLineIds.has(lineView.line.id) &&
-            lineView.line.id !== currentMatchLineId,
-          'line-search-current': lineView.line.id === currentMatchLineId,
-        }"
-      >
-        <span v-if="s.showTimestamp || s.showDirBadge" class="prefix">
-          <span v-if="s.showTimestamp" class="ts">{{
-            formatTs(lineView.line.tsMs)
-          }}</span>
-          <span v-if="s.showDirBadge" class="dir-badge">{{
-            lineView.line.direction === "tx"
-              ? "TX"
-              : lineView.line.direction === "rx"
-                ? "RX"
-                : "SYS"
-          }}</span>
+      <!-- Row-height probe: an invisible real row, measured so the virtual
+           scroller tracks the current font size instead of a hard-coded value. -->
+      <div ref="rowProbeRef" class="line line-probe" aria-hidden="true">
+        <span class="prefix">
+          <span class="ts">00:00:00.000</span>
+          <span class="dir-badge">RX</span>
         </span>
-        <span class="text">
-          <span
-            v-for="(span, si) in lineView.spans"
-            :key="si"
-            :style="spanStyle(span.style)"
+        <span class="text">0</span>
+      </div>
+      <div class="virt-spacer" :style="{ height: contentHeight + 'px' }">
+        <div
+          class="virt-window"
+          :style="{ transform: `translateY(${windowOffsetY}px)` }"
+        >
+          <div
+            v-for="lineView in visibleLineViews"
+            :key="lineView.line.id"
+            :data-line-id="lineView.line.id"
+            class="line"
+            :data-dir="lineView.line.direction"
+            :class="{
+              'line-search-match':
+                matchingLineIds.has(lineView.line.id) &&
+                lineView.line.id !== currentMatchLineId,
+              'line-search-current': lineView.line.id === currentMatchLineId,
+            }"
           >
-            <template
-              v-if="searchQuery && matchingLineIds.has(lineView.line.id)"
-            >
-              <template v-for="(seg, sj) in span.segments" :key="sj">
-                <mark v-if="seg.isMatch" class="search-keyword-mark">{{
-                  seg.text
-                }}</mark
-                ><template v-else>{{ seg.text }}</template>
-              </template>
-            </template>
-            <template v-else>{{ span.text }}</template>
-          </span>
-        </span>
+            <span v-if="s.showTimestamp || s.showDirBadge" class="prefix">
+              <span v-if="s.showTimestamp" class="ts">{{
+                formatTs(lineView.line.tsMs)
+              }}</span>
+              <span v-if="s.showDirBadge" class="dir-badge">{{
+                lineView.line.direction === "tx"
+                  ? "TX"
+                  : lineView.line.direction === "rx"
+                    ? "RX"
+                    : "SYS"
+              }}</span>
+            </span>
+            <span class="text">
+              <span
+                v-for="(span, si) in lineView.spans"
+                :key="si"
+                :style="spanStyle(span.style)"
+              >
+                <template
+                  v-if="searchQuery && matchingLineIds.has(lineView.line.id)"
+                >
+                  <template v-for="(seg, sj) in span.segments" :key="sj">
+                    <mark v-if="seg.isMatch" class="search-keyword-mark">{{
+                      seg.text
+                    }}</mark
+                    ><template v-else>{{ seg.text }}</template>
+                  </template>
+                </template>
+                <template v-else>{{ span.text }}</template>
+              </span>
+            </span>
+          </div>
+        </div>
       </div>
       <div
-        v-if="displayLines.length === 0"
+        v-if="contentHeight === 0"
         class="px-3 py-2 text-[var(--ty-text-muted)]"
       >
         {{ t("serialDebug.log.waitingData") }}
@@ -854,6 +1018,25 @@ async function saveLog(): Promise<void> {
   white-space: nowrap;
   min-width: 5rem;
 }
+/* virtualized line window: the spacer carries the full scroll height, the
+   window holds the mounted slice and is offset to the slice's first row. */
+.virt-spacer {
+  position: relative;
+}
+.virt-window {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: max-content;
+  min-width: 100%;
+}
+.line-probe {
+  position: absolute;
+  top: 0;
+  visibility: hidden;
+  pointer-events: none;
+  user-select: none;
+}
 /* log lines */
 .line {
   display: flex;
@@ -861,6 +1044,9 @@ async function saveLog(): Promise<void> {
   gap: 0.625rem;
   padding: 0.1875rem 0.625rem;
   font-size: inherit;
+  /* Fixed row height is what makes index-based virtual scrolling correct;
+     keep this in sync with estimateRowHeight() in the script block. */
+  line-height: 1.5;
 }
 .line[data-dir="tx"] {
 }
@@ -914,10 +1100,9 @@ async function saveLog(): Promise<void> {
   color: var(--ty-text-muted);
 }
 .text {
-  flex: 1;
-  min-width: 0;
-  white-space: pre-wrap;
-  word-break: break-word;
+  /* `pre`, not `pre-wrap`: soft wrapping would make row heights vary and break
+     the fixed-height row model. Long lines scroll horizontally instead. */
+  white-space: pre;
 }
 mark.search-keyword-mark {
   background: #fbbf24;

--- a/src/features/serial-debug/components/SerialDebugLogView.vue
+++ b/src/features/serial-debug/components/SerialDebugLogView.vue
@@ -289,11 +289,176 @@ function onScroll(): void {
   scrollTop.value = el.scrollTop;
   if (el.clientHeight > 0) viewportHeight.value = el.clientHeight;
   lockAutoScroll.value = maxScrollTop.value - scrollTop.value >= 80;
+  void onScrollEdge();
 }
 
 async function resumeScroll(): Promise<void> {
+  // Without this the badge would scroll to the bottom of the *history window*
+  // instead of to the live tail — the buffer under the pane is a different one.
+  if (s.historyMode) s.exitHistoryMode();
   lockAutoScroll.value = false;
   await scrollToBottom();
+}
+
+// ── full-session scrollback ("All" tab) ─────────────────────────────────
+// Scrolling past the top of the live ring buffer switches the pane over to a
+// bounded sliding window on the Rust session archive; scrolling back past its
+// end switches back. The two buffers are never concatenated — see
+// `useSerialDebugHistory` for why that is not merely a simplification.
+
+/**
+ * How far the content above the viewport moved when `prepended` lines were
+ * added at the head. In the ASCII view a row *is* a log line, so it is the line
+ * count; in the hex view a row is `bytesPerRow` bytes of the concatenated byte
+ * stream, so the answer is the row the previous first line — now at index
+ * `prepended` — starts on.
+ *
+ * Read off the *new* buffer rather than as a `totalRows` delta on purpose: the
+ * same step may also trim the window's tail to stay within budget, and a tail
+ * trim shortens contentHeight below the viewport, where it must not be
+ * compensated for. When nothing is trimmed the two agree to within the ≤1 row
+ * of jitter a non-row-aligned byte prefix causes anyway.
+ */
+function headRowsForPrepend(prepended: number): number {
+  return props.hexView
+    ? hexViewRenderer.rowOfLine(displayLines(), props.hexBytesPerRow, prepended)
+    : prepended;
+}
+
+/** Keep the line that was at `beforeTop` where it is after a head-side change. */
+function compensateScroll(
+  el: HTMLElement,
+  beforeTop: number,
+  rows: number,
+): void {
+  // Clamp at the call site: applyScrollTop writes the *requested* value into the
+  // model, so asking for more than the DOM will accept desynchronizes the two.
+  applyScrollTop(
+    el,
+    Math.min(
+      Math.max(beforeTop + rows * rowHeight.value, 0),
+      maxScrollTop.value,
+    ),
+  );
+}
+
+async function enterHistory(): Promise<void> {
+  const el = scrollRef.value;
+  if (!el) return;
+  const wasLocked = lockAutoScroll.value;
+  // Explicit, not incidental: the mode switch changes the id of the last line,
+  // which is exactly what the follow-tail watcher tracks, so it fires once on
+  // the switch. `scrollToBottom` bails out while the lock is set.
+  lockAutoScroll.value = true;
+  const entered = await s.enterHistoryMode(s.lines.length);
+  if (!entered) {
+    lockAutoScroll.value = wasLocked;
+    return;
+  }
+  await nextTick();
+  const offset = s.historyEntryOffsetLines;
+  const row = props.hexView
+    ? hexViewRenderer.rowOfLine(displayLines(), props.hexBytesPerRow, offset)
+    : offset;
+  applyScrollTop(
+    el,
+    Math.min(row * rowHeight.value + insetTop.value, maxScrollTop.value),
+  );
+}
+
+async function loadOlderHistoryAtTop(): Promise<void> {
+  const el = scrollRef.value;
+  if (!el) return;
+  const beforeTop = scrollTop.value;
+  const { prepended, reanchored } = await s.loadOlderHistory();
+  if (!prepended && !reanchored) return;
+  await nextTick();
+  // A re-anchor replaced the window instead of extending it, so there is no
+  // old position to preserve; show the top of what was loaded.
+  if (reanchored) {
+    applyScrollTop(el, 0);
+    return;
+  }
+  compensateScroll(el, beforeTop, headRowsForPrepend(prepended));
+}
+
+async function loadNewerHistoryAtBottom(): Promise<void> {
+  const el = scrollRef.value;
+  if (!el) return;
+  const beforeTop = scrollTop.value;
+  const before = displayLines();
+  const dropped = await s.loadNewerHistory();
+  // Appended rows land below the viewport; only what left the head moves it.
+  if (dropped <= 0) return;
+  const rows = props.hexView
+    ? hexViewRenderer.rowOfLine(before, props.hexBytesPerRow, dropped)
+    : dropped;
+  await nextTick();
+  compensateScroll(el, beforeTop, -rows);
+}
+
+async function jumpToSessionStart(): Promise<void> {
+  if (!(await s.jumpToSessionStart())) return;
+  await nextTick();
+  const el = scrollRef.value;
+  if (el) applyScrollTop(el, 0);
+}
+
+async function loadOlderFilterMatchesAtTop(): Promise<void> {
+  const el = scrollRef.value;
+  const beforeTop = scrollTop.value;
+  const prepended = await s.loadOlderActiveFilterMatches();
+  if (prepended <= 0 || !el) return;
+  await nextTick();
+  compensateScroll(el, beforeTop, headRowsForPrepend(prepended));
+}
+
+/**
+ * Infinite scroll for the "All" tab. Re-entry is blocked three ways: by
+ * `historyLoading` while a read is in flight, by the compensation having moved
+ * `scrollTop` away from the edge once it lands, and by the
+ * `historyAtSessionStart` / `historyAtArchiveEnd` end stops.
+ */
+async function onScrollEdge(): Promise<void> {
+  if (s.activeChipId !== null || s.historyLoading) return;
+  // Not scrollable at all: there is no "the user scrolled up" to react to, and
+  // entering history mode here would lock auto-scroll for no reason.
+  if (maxScrollTop.value <= 0) return;
+  if (scrollTop.value <= rowHeight.value) {
+    if (!s.historyMode) {
+      await enterHistory();
+    } else if (!s.historyAtSessionStart) {
+      await loadOlderHistoryAtTop();
+    }
+    return;
+  }
+  if (!s.historyMode) return;
+  if (maxScrollTop.value - scrollTop.value > rowHeight.value) return;
+  if (s.historyAtArchiveEnd) {
+    await resumeScroll();
+  } else {
+    await loadNewerHistoryAtBottom();
+  }
+}
+
+/**
+ * Ctrl+F keeps its "within the buffer currently on screen" meaning in history
+ * mode. Whole-session search already exists as a filter chip (it is archive
+ * backed, with an authoritative count and its own tab), so offer that instead of
+ * building a second scan pipeline.
+ */
+async function searchWholeSession(): Promise<void> {
+  const keyword = searchText.value.trim();
+  if (!keyword) return;
+  const existing = s.watchChips.find(
+    (c) => c.keyword === keyword && !c.useRegex,
+  );
+  if (existing) {
+    await s.setActiveChip(existing.id);
+  } else if ((await s.addChip(keyword, false)) !== "ok") {
+    return;
+  }
+  closeSearch();
 }
 
 // Only the windowed rows are formatted, and the result is byte-identical to the
@@ -752,7 +917,7 @@ async function saveLog(): Promise<void> {
         type="button"
         class="btn-tool"
         :disabled="s.activeFilterLoading"
-        @click="s.loadOlderActiveFilterMatches"
+        @click="loadOlderFilterMatchesAtTop"
       >
         <FontAwesomeIcon :icon="['fas', 'arrow-up']" class="size-3 shrink-0" />
         {{
@@ -761,6 +926,62 @@ async function saveLog(): Promise<void> {
             : t("serialDebug.log.loadOlderMatches")
         }}
       </button>
+    </div>
+
+    <!-- history mode banner: the scrollbar only spans the loaded window, so the
+         position readout is what tells the user where in the session they are -->
+    <div
+      v-if="!activeChip && s.historyMode"
+      class="history-bar flex items-center gap-2 border-b border-[var(--ty-border)] px-3 py-1"
+    >
+      <FontAwesomeIcon
+        :icon="['fas', 'clock-rotate-left']"
+        class="size-3 shrink-0"
+      />
+      <span class="history-title">{{
+        t("serialDebug.log.historyBanner")
+      }}</span>
+      <span class="history-position">{{
+        t("serialDebug.log.historyPosition", {
+          from: s.historyStartLineNo,
+          to: s.historyEndLineNo,
+          total: s.historyTotalLines,
+        })
+      }}</span>
+      <button
+        v-if="!s.historyAtSessionStart"
+        type="button"
+        class="btn-tool"
+        :disabled="s.historyLoading"
+        @click="loadOlderHistoryAtTop"
+      >
+        <FontAwesomeIcon :icon="['fas', 'arrow-up']" class="size-3 shrink-0" />
+        {{
+          s.historyLoading
+            ? t("serialDebug.log.loadingOlderLines")
+            : t("serialDebug.log.loadOlderLines")
+        }}
+      </button>
+      <span v-else class="history-position">{{
+        t("serialDebug.log.atSessionStart")
+      }}</span>
+      <div class="ml-auto flex items-center gap-1">
+        <button
+          type="button"
+          class="btn-tool"
+          :disabled="s.historyLoading || s.historyAtSessionStart"
+          @click="jumpToSessionStart"
+        >
+          {{ t("serialDebug.log.jumpToSessionStart") }}
+        </button>
+        <button type="button" class="btn-tool" @click="resumeScroll">
+          <FontAwesomeIcon
+            :icon="['fas', 'arrow-down']"
+            class="size-3 shrink-0"
+          />
+          {{ t("serialDebug.log.backToLive") }}
+        </button>
+      </div>
     </div>
 
     <!-- Ctrl+F search bar -->
@@ -789,6 +1010,21 @@ async function saveLog(): Promise<void> {
           {{ t("serialDebug.search.noMatch") }}
         </template>
       </span>
+      <!-- In history mode the pane holds a window on the archive, not the live
+           buffer, so say so rather than let the count read as session-wide. -->
+      <span v-if="!activeChip && s.historyMode" class="search-scope-hint">
+        {{ t("serialDebug.search.scopeHistory") }}
+      </span>
+      <button
+        v-if="searchText.trim()"
+        type="button"
+        class="btn-tool"
+        :aria-label="t('serialDebug.search.wholeSession')"
+        @click="searchWholeSession"
+      >
+        <FontAwesomeIcon :icon="['fas', 'filter']" class="size-3 shrink-0" />
+        {{ t("serialDebug.search.wholeSession") }}
+      </button>
       <button
         type="button"
         class="btn-tool"
@@ -1091,6 +1327,27 @@ async function saveLog(): Promise<void> {
   color: var(--ty-text-muted);
   white-space: nowrap;
   min-width: 5rem;
+}
+.search-scope-hint {
+  font-size: 0.75rem;
+  color: var(--ty-text-muted);
+  white-space: nowrap;
+}
+/* history mode banner */
+.history-bar {
+  background: var(--ty-surface);
+}
+.history-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--ty-text);
+  white-space: nowrap;
+}
+.history-position {
+  font-size: 0.75rem;
+  color: var(--ty-text-muted);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 /* virtualized line window: the spacer carries the full scroll height, the
    window holds the mounted slice and is offset to the slice's first row. */

--- a/src/features/serial-debug/components/SerialDebugLogView.vue
+++ b/src/features/serial-debug/components/SerialDebugLogView.vue
@@ -32,7 +32,6 @@ import SerialDebugChipBar from "./SerialDebugChipBar.vue";
 
 const props = withDefaults(
   defineProps<{
-    lines: DebugLogLine[];
     hexView: boolean;
     hexBytesPerRow: HexBytesPerRow;
     ansiEnabled: boolean;
@@ -201,8 +200,15 @@ function applyScrollTop(el: HTMLElement, top: number): void {
   // Keep the model in sync with the DOM: a programmatic scrollTop write fires
   // its `scroll` event asynchronously (and never at all in tests), so the
   // visible range would otherwise lag a frame behind.
-  scrollTop.value = top;
+  //
+  // Read the value back instead of storing the requested one: the DOM clamps a
+  // write to [0, scrollHeight - clientHeight], and a model holding the
+  // unclamped request would compute a window the scrollbar is not actually on.
+  // Callers may therefore ask for any number and let the DOM decide. The
+  // read-back is not an extra reflow — assigning scrollTop already has to
+  // resolve layout to clamp, so the value is there for the taking.
   el.scrollTop = top;
+  scrollTop.value = el.scrollTop;
 }
 
 // Per-tab scroll lock. Key: activeChipId (null = "All" tab).
@@ -331,15 +337,7 @@ function compensateScroll(
   beforeTop: number,
   rows: number,
 ): void {
-  // Clamp at the call site: applyScrollTop writes the *requested* value into the
-  // model, so asking for more than the DOM will accept desynchronizes the two.
-  applyScrollTop(
-    el,
-    Math.min(
-      Math.max(beforeTop + rows * rowHeight.value, 0),
-      maxScrollTop.value,
-    ),
-  );
+  applyScrollTop(el, beforeTop + rows * rowHeight.value);
 }
 
 async function enterHistory(): Promise<void> {
@@ -360,10 +358,7 @@ async function enterHistory(): Promise<void> {
   const row = props.hexView
     ? hexViewRenderer.rowOfLine(displayLines(), props.hexBytesPerRow, offset)
     : offset;
-  applyScrollTop(
-    el,
-    Math.min(row * rowHeight.value + insetTop.value, maxScrollTop.value),
-  );
+  applyScrollTop(el, row * rowHeight.value + insetTop.value);
 }
 
 async function loadOlderHistoryAtTop(): Promise<void> {
@@ -653,7 +648,7 @@ async function scrollToMatch(): Promise<void> {
     next = rowTop + rh - viewportHeight.value;
   }
   if (next === current) return;
-  applyScrollTop(el, Math.min(Math.max(next, 0), maxScrollTop.value));
+  applyScrollTop(el, next);
 }
 
 function onContainerKeydown(ev: KeyboardEvent): void {

--- a/src/features/serial-debug/components/SerialDebugLogView.vue
+++ b/src/features/serial-debug/components/SerialDebugLogView.vue
@@ -67,25 +67,44 @@ const displayLines = (): DebugLogLine[] => s.activeDisplayLines();
 
 const scrollRef = ref<HTMLDivElement | null>(null);
 
-// ── viewport virtualization (ASCII line view only) ──────────────────────
+// ── viewport virtualization (both views) ────────────────────────────────
 // Only the rows inside the viewport — plus OVERSCAN_ROWS above and below so a
 // fast scroll never shows a blank band — are turned into DOM. Rows are
 // fixed-height by construction (`.line` pins line-height and `.text` is
 // `white-space: pre`, so the pane scrolls horizontally instead of wrapping),
 // which makes a row's offset exactly `index * rowHeight` — no per-row
 // measurement, no reading `scrollHeight`.
+//
+// Both views share this machinery; only what a "row" is differs. In the ASCII
+// view a row is a log line, so the row count is the buffer length. In the hex
+// view a row is 16 (or 8 / 32) bytes of the buffer's concatenated byte stream,
+// so the row count comes from the byte index in
+// `SerialDebugHexViewRenderer` — see its doc comment for why log-line indices
+// cannot address hex rows.
 const OVERSCAN_ROWS = 10;
 
-const rowProbeRef = ref<HTMLDivElement | null>(null);
+// Inset of the hex dump from the top and bottom of its pane. It used to be the
+// pane's own `p-3`; the vertical half now lives in the row model (added to the
+// spacer height and to the window's translateY) because padding on the scroll
+// box would not be part of `contentHeight` and would offset every row by a
+// constant the model has to know anyway. The horizontal half stays a plain
+// `px-3` on the pane.
+const HEX_DUMP_INSET_Y = 12;
+
+const rowProbeRef = ref<HTMLElement | null>(null);
 const scrollTop = ref(0);
 const viewportHeight = ref(0);
 const measuredRowHeight = ref(0);
 
 // Used until the probe has been measured (first frame) and in environments
-// without a layout engine (happy-dom): mirrors the `.line` box — line-height
-// 1.5 plus 2 x 0.1875rem of vertical padding.
+// without a layout engine (happy-dom). ASCII mirrors the `.line` box —
+// line-height 1.5 plus 2 x 0.1875rem of vertical padding. A hex row is a bare
+// `<pre>` line: no padding, and the line-height it inherits from the pane's
+// `text-xs` (4/3, unitless in Tailwind v4, so it tracks the font size).
 function estimateRowHeight(fontSize: number): number {
-  return Math.round(fontSize * 1.5) + 6;
+  return props.hexView
+    ? Math.round((fontSize * 4) / 3)
+    : Math.round(fontSize * 1.5) + 6;
 }
 
 const rowHeight = computed(
@@ -93,8 +112,10 @@ const rowHeight = computed(
 );
 
 // Row height must never be hard-coded: the font size is user-adjustable
-// (10–18px). The probe is a real `.line` rendered inside the pane, so it picks
-// up every inherited style change.
+// (10–18px). The probe is a real row rendered inside the pane it measures (a
+// `.line` for the ASCII view, a one-line `<pre>` for the hex view — the two
+// have different boxes), so it picks up every inherited style change. Only one
+// of the two panes is ever mounted, so both probes can share the ref.
 function measureLayout(): void {
   const paneEl = scrollRef.value;
   if (paneEl && paneEl.clientHeight > 0) {
@@ -131,15 +152,38 @@ watch(
   },
 );
 
-const contentHeight = computed(() => displayLines().length * rowHeight.value);
+// Hex rows are addressed by byte offset, so the count comes from the renderer's
+// index rather than from the buffer length. Reading it also refreshes that index
+// for `hexRendered` below.
+const hexRowCount = computed(() =>
+  props.hexView
+    ? hexViewRenderer.rowCount(displayLines(), props.hexBytesPerRow)
+    : 0,
+);
+
+const totalRows = computed(() =>
+  props.hexView ? hexRowCount.value : displayLines().length,
+);
+const insetTop = computed(() => (props.hexView ? HEX_DUMP_INSET_Y : 0));
+const contentHeight = computed(() =>
+  totalRows.value === 0
+    ? 0
+    : totalRows.value * rowHeight.value + insetTop.value * 2,
+);
 const maxScrollTop = computed(() =>
   Math.max(0, contentHeight.value - viewportHeight.value),
 );
 
 const visibleRange = computed<{ start: number; end: number }>(() => {
-  const total = displayLines().length;
+  const total = totalRows.value;
   const rh = rowHeight.value;
-  const top = Math.min(Math.max(scrollTop.value, 0), maxScrollTop.value);
+  // Content space: row 0 starts `insetTop` below the top of the scroll box.
+  // Ignoring the inset would misplace the window by less than one row, which
+  // the overscan absorbs, but `maxScrollTop` above needs it to be exact.
+  const top = Math.min(
+    Math.max(scrollTop.value - insetTop.value, 0),
+    maxScrollTop.value,
+  );
   return {
     start: Math.max(0, Math.floor(top / rh) - OVERSCAN_ROWS),
     end: Math.min(
@@ -150,7 +194,7 @@ const visibleRange = computed<{ start: number; end: number }>(() => {
 });
 
 const windowOffsetY = computed(
-  () => visibleRange.value.start * rowHeight.value,
+  () => visibleRange.value.start * rowHeight.value + insetTop.value,
 );
 
 function applyScrollTop(el: HTMLElement, top: number): void {
@@ -176,10 +220,9 @@ async function scrollToBottom(): Promise<void> {
   await nextTick();
   const el = scrollRef.value;
   if (!el || lockAutoScroll.value) return;
-  // The hex pane is a single <pre> with no row model, so it still asks the DOM.
-  // The line pane derives the target from the row model instead: reading
-  // scrollHeight there would force a synchronous layout on every batch.
-  applyScrollTop(el, props.hexView ? el.scrollHeight : maxScrollTop.value);
+  // Both panes derive the target from the row model: reading scrollHeight would
+  // force a synchronous layout on every batch.
+  applyScrollTop(el, maxScrollTop.value);
 }
 
 // Track the newest line id, not the array length: once the visible window is
@@ -204,10 +247,14 @@ watch(
   },
 );
 
-// hexView toggle swaps the scrollRef DOM node (v-if/v-else); scroll into the new element.
+// hexView toggle swaps the scrollRef DOM node (v-if/v-else); scroll into the new
+// element. The row box differs between the two panes, so drop the measurement
+// and let the new pane's probe re-measure (the estimate covers the gap frame).
 watch(
   () => props.hexView,
   () => {
+    measuredRowHeight.value = 0;
+    void nextTick().then(measureLayout);
     void scrollToBottom();
   },
 );
@@ -232,16 +279,16 @@ function watchLayoutChange(source: () => unknown): void {
 }
 
 watchLayoutChange(() => s.logFontSize);
+// A different bytesPerRow re-cuts the byte stream into a different number of
+// rows, so the whole scroll extent changes under the viewport.
+watchLayoutChange(() => props.hexBytesPerRow);
 
 function onScroll(): void {
   const el = scrollRef.value;
   if (!el) return;
   scrollTop.value = el.scrollTop;
   if (el.clientHeight > 0) viewportHeight.value = el.clientHeight;
-  const atBottom = props.hexView
-    ? el.scrollHeight - el.scrollTop - el.clientHeight < 80
-    : contentHeight.value - scrollTop.value - viewportHeight.value < 80;
-  lockAutoScroll.value = !atBottom;
+  lockAutoScroll.value = maxScrollTop.value - scrollTop.value >= 80;
 }
 
 async function resumeScroll(): Promise<void> {
@@ -249,9 +296,17 @@ async function resumeScroll(): Promise<void> {
   await scrollToBottom();
 }
 
+// Only the windowed rows are formatted, and the result is byte-identical to the
+// matching slice of the full-buffer dump — the view stays one continuous dump.
 const hexRendered = computed(() => {
   if (!props.hexView) return null;
-  return hexViewRenderer.render(displayLines(), props.hexBytesPerRow);
+  const { start, end } = visibleRange.value;
+  return hexViewRenderer.renderRows(
+    displayLines(),
+    props.hexBytesPerRow,
+    start,
+    end,
+  );
 });
 
 function spanStyle(style: AnsiStyle): Record<string, string | undefined> {
@@ -313,7 +368,7 @@ onActivated(async () => {
   if (lockAutoScroll.value && savedScrollTop !== null) {
     applyScrollTop(el, savedScrollTop);
   } else if (!lockAutoScroll.value) {
-    applyScrollTop(el, props.hexView ? el.scrollHeight : maxScrollTop.value);
+    applyScrollTop(el, maxScrollTop.value);
   }
   savedScrollTop = null;
 });
@@ -337,8 +392,11 @@ const searchQuery = computed(() => searchText.value.trim().toLowerCase());
 // longer re-scans on a pure scroll, when only the visible slice moves.
 watchEffect(() => lineRenderer.retain(displayLines()));
 
-// Spans are built for the mounted slice only.
+// Spans are built for the mounted slice only. `visibleRange` counts hex rows
+// when the hex view is up, which would address the wrong lines — that branch
+// mounts no `.line` at all, so bail out rather than build spans nothing reads.
 const visibleLineViews = computed<RenderedLogLine[]>(() => {
+  if (props.hexView) return [];
   const all = displayLines();
   const { start, end } = visibleRange.value;
   return lineRenderer.render(
@@ -410,10 +468,16 @@ async function scrollToMatch(): Promise<void> {
   await nextTick();
   const el = scrollRef.value;
   if (!el) return;
-  const index = displayLines().findIndex((line) => line.id === id);
+  const lines = displayLines();
+  const index = lines.findIndex((line) => line.id === id);
   if (index < 0) return;
   const rh = rowHeight.value;
-  const rowTop = index * rh;
+  // In the hex view a scroll offset is a byte offset, not a line index: map the
+  // matched line to the hex row its first byte lands on.
+  const row = props.hexView
+    ? hexViewRenderer.rowOfLine(lines, props.hexBytesPerRow, index)
+    : index;
+  const rowTop = row * rh + insetTop.value;
   const current = scrollTop.value;
   // Equivalent of scrollIntoView({ block: "nearest" }): only move when the row
   // sits outside the viewport.
@@ -766,11 +830,21 @@ async function saveLog(): Promise<void> {
     <div
       v-if="hexView"
       ref="scrollRef"
-      class="pane flex-1 overflow-auto p-3 font-mono text-xs"
+      class="pane flex-1 overflow-auto px-3 font-mono text-xs"
       :style="{ fontSize: s.logFontSize + 'px' }"
       @scroll="onScroll"
     >
-      <pre class="whitespace-pre">{{ hexRendered }}</pre>
+      <!-- Row-height probe: one real dump row, measured so the virtual scroller
+           tracks the current font size instead of a hard-coded value. -->
+      <pre ref="rowProbeRef" class="hex-probe" aria-hidden="true">00</pre>
+      <div class="virt-spacer" :style="{ height: contentHeight + 'px' }">
+        <div
+          class="virt-window"
+          :style="{ transform: `translateY(${windowOffsetY}px)` }"
+        >
+          <pre class="whitespace-pre">{{ hexRendered }}</pre>
+        </div>
+      </div>
     </div>
 
     <!-- ASCII line view -->
@@ -1030,7 +1104,8 @@ async function saveLog(): Promise<void> {
   width: max-content;
   min-width: 100%;
 }
-.line-probe {
+.line-probe,
+.hex-probe {
   position: absolute;
   top: 0;
   visibility: hidden;

--- a/src/features/serial-debug/constants.ts
+++ b/src/features/serial-debug/constants.ts
@@ -15,12 +15,36 @@ export const DEFAULT_PARITY: DebugParity = "none";
 export const DEFAULT_STOP_BITS: DebugStopBits = "one";
 export const DEFAULT_HEX_BYTES_PER_ROW: HexBytesPerRow = 16;
 
-export const VISIBLE_LOG_WINDOW_LINES = 3000;
+export const DEFAULT_VISIBLE_LOG_WINDOW_LINES = 5000;
+export const MIN_VISIBLE_LOG_WINDOW_LINES = 500;
+export const MAX_VISIBLE_LOG_WINDOW_LINES = 20000;
+export const VISIBLE_LOG_WINDOW_PRESETS = [
+  1000, 3000, 5000, 10000, 20000,
+] as const;
+// Per-session cap for the Rust-side archive (crates/tyutool-core/src/serial_debug.rs).
+// MiB, not lines: a line is 1–4096 B, so a line count says nothing about disk
+// use — and `logWindowLines` above already means "lines" in a different sense.
+// Keep DEFAULT in sync with DEFAULT_SERIAL_DEBUG_ARCHIVE_MAX_BYTES in Rust,
+// which bounds the window before this setting is pushed down.
+export const DEFAULT_ARCHIVE_LIMIT_MIB = 256;
+export const MIN_ARCHIVE_LIMIT_MIB = 16;
+export const MAX_ARCHIVE_LIMIT_MIB = 4096;
+export const ARCHIVE_LIMIT_PRESETS = [64, 128, 256, 512, 1024] as const;
 export const FILTER_PAGE_SIZE = 400;
 export const EXPORT_PAGE_SIZE = 1000;
 export const FILTER_LIVE_REFRESH_MS = 120;
 export const MAX_PENDING_LINE_BYTES = 4096;
 export const AUTO_SAVE_FLUSH_MAX_CHARS = 128 * 1024;
+// Max appends one periodic (non-drainAll) auto-save flush issues before it
+// gives the tick back. 16 x AUTO_SAVE_FLUSH_MAX_CHARS = 2 MiB per 5 s tick,
+// ~3x what a 921600-baud port can produce in that window, so a backlog still
+// converges to empty while one tick can never occupy the IPC channel
+// indefinitely.
+export const AUTO_SAVE_FLUSH_MAX_APPENDS_PER_TICK = 16;
+// Archive lines per page when backfilling a mid-session auto-save enable.
+// Same order of magnitude as EXPORT_PAGE_SIZE: one page is read, formatted and
+// appended before the next is requested, so peak memory is one page.
+export const AUTO_SAVE_BACKFILL_PAGE_SIZE = 1000;
 export const MAX_SEND_HISTORY = 20;
 
 // Six distinct colors that cycle when chips are added

--- a/src/features/serial-debug/constants.ts
+++ b/src/features/serial-debug/constants.ts
@@ -31,6 +31,17 @@ export const MIN_ARCHIVE_LIMIT_MIB = 16;
 export const MAX_ARCHIVE_LIMIT_MIB = 4096;
 export const ARCHIVE_LIMIT_PRESETS = [64, 128, 256, 512, 1024] as const;
 export const FILTER_PAGE_SIZE = 400;
+// Archive lines per request while the "All" tab pages back through the session
+// archive. Deliberately the same order as FILTER_PAGE_SIZE and *not*
+// EXPORT_PAGE_SIZE: `serial_debug_session_read_page` costs four syscalls plus a
+// JSON parse per line and holds the Rust-side archive lock for the whole
+// request, so a read issued while the user is scrolling has to stay short
+// enough not to stall the serial writer.
+export const HISTORY_PAGE_SIZE = 400;
+// Pages fetched when history mode is entered (or when jumping to the session
+// start): enough to fill a screen and leave room to scroll before the next
+// request, while the window still grows on demand up to `logWindowLines`.
+export const HISTORY_ENTRY_PAGES = 3;
 export const EXPORT_PAGE_SIZE = 1000;
 export const FILTER_LIVE_REFRESH_MS = 120;
 export const MAX_PENDING_LINE_BYTES = 4096;

--- a/src/features/serial-debug/hex-view-renderer.test.ts
+++ b/src/features/serial-debug/hex-view-renderer.test.ts
@@ -36,6 +36,19 @@ describe("SerialDebugHexViewRenderer", () => {
     expect(formatHexDumpFromChunksMock).toHaveBeenCalledTimes(1);
   });
 
+  it("re-encodes text for archive lines that carry no rawBytes", () => {
+    const renderer = new SerialDebugHexViewRenderer();
+    // Lines paged back from the Rust session archive have no rawBytes: the
+    // archive stores text only. The dump must show the text bytes, not blanks.
+    renderer.render([{ ...line(1), text: "AB" }], 16);
+
+    const calls = formatHexDumpFromChunksMock.mock.calls as unknown as [
+      Uint8Array[],
+    ][];
+    const [chunks] = calls[calls.length - 1];
+    expect(Array.from(chunks[0])).toEqual([0x41, 0x42, 0x0a]);
+  });
+
   it("drops byte-chunk cache entries for lines that are no longer visible", () => {
     const renderer = new SerialDebugHexViewRenderer();
     renderer.render([line(1, [0x41]), line(2, [0x42])], 16);

--- a/src/features/serial-debug/hex-view-renderer.test.ts
+++ b/src/features/serial-debug/hex-view-renderer.test.ts
@@ -1,19 +1,8 @@
 // @vitest-environment node
-import { describe, expect, it, vi } from "vitest";
-import type { DebugLogLine } from "./types";
+import { describe, expect, it } from "vitest";
+import type { DebugLogLine, HexBytesPerRow } from "./types";
+import { formatHexDumpFromChunks } from "./hex-format";
 import { SerialDebugHexViewRenderer } from "./hex-view-renderer";
-
-const { formatHexDumpFromChunksMock } = vi.hoisted(() => ({
-  formatHexDumpFromChunksMock: vi.fn(() => "hex-dump"),
-}));
-
-vi.mock("./hex-format", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./hex-format")>();
-  return {
-    ...actual,
-    formatHexDumpFromChunks: formatHexDumpFromChunksMock,
-  };
-});
 
 function line(id: number, rawBytes?: number[]): DebugLogLine {
   return {
@@ -25,36 +14,164 @@ function line(id: number, rawBytes?: number[]): DebugLogLine {
   };
 }
 
+/** Bytes a line contributes to the dump stream: its own plus the line feed. */
+function chunkOf(l: DebugLogLine): Uint8Array {
+  const raw = l.rawBytes ?? new TextEncoder().encode(l.text);
+  return Uint8Array.from([...raw, 0x0a]);
+}
+
+/** The dump the pre-virtualization renderer produced for the whole buffer. */
+function fullDump(
+  lines: readonly DebugLogLine[],
+  bytesPerRow: HexBytesPerRow,
+): string[] {
+  const dump = formatHexDumpFromChunks(lines.map(chunkOf), bytesPerRow);
+  return dump === "" ? [] : dump.split("\n");
+}
+
+function buffer(count: number, bytesPerLine = 7): DebugLogLine[] {
+  return Array.from({ length: count }, (_, i) =>
+    line(
+      i + 1,
+      Array.from({ length: bytesPerLine }, (_, j) => 0x30 + ((i + j) % 0x40)),
+    ),
+  );
+}
+
 describe("SerialDebugHexViewRenderer", () => {
-  it("reuses the cached dump when visible lines and bytesPerRow are unchanged", () => {
+  it("counts hex rows from the byte stream, not from the line count", () => {
     const renderer = new SerialDebugHexViewRenderer();
-    const lines = [line(1, [0x41, 0x0a]), line(2, [0x42, 0x0a])];
+    // 10 lines x (7 bytes + 1 line feed) = 80 bytes.
+    const lines = buffer(10);
 
-    expect(renderer.render(lines, 16)).toBe("hex-dump");
-    expect(renderer.render(lines, 16)).toBe("hex-dump");
+    expect(renderer.rowCount(lines, 8)).toBe(10);
+    expect(renderer.rowCount(lines, 16)).toBe(5);
+    expect(renderer.rowCount(lines, 32)).toBe(3);
+    expect(renderer.rowCount([], 16)).toBe(0);
+  });
 
-    expect(formatHexDumpFromChunksMock).toHaveBeenCalledTimes(1);
+  it("renders a window byte-identical to the same rows of the full dump", () => {
+    const renderer = new SerialDebugHexViewRenderer();
+    const lines = buffer(200);
+
+    for (const bytesPerRow of [8, 16, 32] as const) {
+      const expected = fullDump(lines, bytesPerRow);
+      expect(renderer.rowCount(lines, bytesPerRow)).toBe(expected.length);
+
+      // A mid-buffer window: rows here straddle log-line boundaries in both
+      // directions, which is the whole reason the byte index exists.
+      expect(renderer.renderRows(lines, bytesPerRow, 20, 35)).toBe(
+        expected.slice(20, 35).join("\n"),
+      );
+      // The head and the tail, including the last (padded) partial row.
+      expect(renderer.renderRows(lines, bytesPerRow, 0, 3)).toBe(
+        expected.slice(0, 3).join("\n"),
+      );
+      const total = expected.length;
+      expect(renderer.renderRows(lines, bytesPerRow, total - 4, total)).toBe(
+        expected.slice(total - 4).join("\n"),
+      );
+      // A window past the end clamps instead of inventing rows.
+      expect(
+        renderer.renderRows(lines, bytesPerRow, total - 1, total + 50),
+      ).toBe(expected[total - 1]);
+      expect(renderer.renderRows(lines, bytesPerRow, total, total + 10)).toBe(
+        "",
+      );
+    }
+  });
+
+  it("renders a window whose rows all come from one very long line", () => {
+    const renderer = new SerialDebugHexViewRenderer();
+    // One line of 500 bytes spans ~32 rows on its own.
+    const lines = [
+      line(
+        1,
+        Array.from({ length: 500 }, (_, i) => i & 0xff),
+      ),
+    ];
+    const expected = fullDump(lines, 16);
+
+    expect(renderer.rowCount(lines, 16)).toBe(expected.length);
+    expect(renderer.renderRows(lines, 16, 10, 14)).toBe(
+      expected.slice(10, 14).join("\n"),
+    );
+  });
+
+  it("re-bases the stream when lines are dropped off the head", () => {
+    const renderer = new SerialDebugHexViewRenderer();
+    const lines = buffer(40);
+    renderer.renderRows(lines, 16, 0, 5);
+
+    // The store drops the oldest lines; every byte offset shifts, so the dump
+    // must be the one for the *remaining* buffer, not a suffix of the old one.
+    const rolled = lines.slice(10);
+    const expected = fullDump(rolled, 16);
+    expect(renderer.rowCount(rolled, 16)).toBe(expected.length);
+    expect(renderer.renderRows(rolled, 16, 0, 4)).toBe(
+      expected.slice(0, 4).join("\n"),
+    );
   });
 
   it("re-encodes text for archive lines that carry no rawBytes", () => {
     const renderer = new SerialDebugHexViewRenderer();
     // Lines paged back from the Rust session archive have no rawBytes: the
     // archive stores text only. The dump must show the text bytes, not blanks.
-    renderer.render([{ ...line(1), text: "AB" }], 16);
+    // Non-ASCII text (a translated sys line, e.g. the archive-cap notice)
+    // contributes its UTF-8 bytes.
+    const lines = [
+      { ...line(1), text: "AB" },
+      { ...line(2), text: "±" },
+    ];
 
-    const calls = formatHexDumpFromChunksMock.mock.calls as unknown as [
-      Uint8Array[],
-    ][];
-    const [chunks] = calls[calls.length - 1];
-    expect(Array.from(chunks[0])).toEqual([0x41, 0x42, 0x0a]);
+    expect(renderer.renderRows(lines, 16, 0, 1)).toBe(fullDump(lines, 16)[0]);
+    expect(renderer.renderRows(lines, 16, 0, 1)).toContain("41 42 0a c2 b1 0a");
+  });
+
+  it("maps a line index to the hex row its first byte lands on", () => {
+    const renderer = new SerialDebugHexViewRenderer();
+    const lines = buffer(20); // 8 bytes of stream per line
+
+    expect(renderer.rowOfLine(lines, 16, 0)).toBe(0);
+    expect(renderer.rowOfLine(lines, 16, 2)).toBe(1); // byte 16
+    expect(renderer.rowOfLine(lines, 16, 5)).toBe(2); // byte 40
+    expect(renderer.rowOfLine(lines, 8, 5)).toBe(5); // byte 40
+    // Out of range indices clamp instead of returning NaN.
+    expect(renderer.rowOfLine(lines, 16, -3)).toBe(0);
+    expect(renderer.rowOfLine(lines, 16, 999)).toBe(10);
   });
 
   it("drops byte-chunk cache entries for lines that are no longer visible", () => {
     const renderer = new SerialDebugHexViewRenderer();
-    renderer.render([line(1, [0x41]), line(2, [0x42])], 16);
+    renderer.rowCount([line(1, [0x41]), line(2, [0x42])], 16);
     expect(renderer.cacheSize()).toBe(2);
 
-    renderer.render([line(2, [0x42])], 16);
+    renderer.rowCount([line(2, [0x42])], 16);
     expect(renderer.cacheSize()).toBe(1);
+
+    renderer.rowCount([], 16);
+    expect(renderer.cacheSize()).toBe(0);
+  });
+
+  it("keeps the byte-chunk cache bounded across a rolling buffer", () => {
+    const renderer = new SerialDebugHexViewRenderer();
+    const window = 50;
+    const perFlush = 5;
+    let next = 1;
+    let lines = Array.from({ length: window }, () => line(next++, [0x41]));
+    renderer.rowCount(lines, 16);
+
+    // Saturated buffer: every flush drops as many lines off the head as it
+    // appends. The sweep is amortized, so the bound is the window plus the
+    // slack, not an exact match on every publish.
+    for (let flush = 0; flush < 50; flush += 1) {
+      lines = [
+        ...lines.slice(perFlush),
+        ...Array.from({ length: perFlush }, () => line(next++, [0x41])),
+      ];
+      renderer.rowCount(lines, 16);
+      expect(renderer.cacheSize()).toBeLessThanOrEqual(window * 1.2 + perFlush);
+    }
+    expect(renderer.cacheSize()).toBeGreaterThanOrEqual(window);
   });
 });

--- a/src/features/serial-debug/hex-view-renderer.ts
+++ b/src/features/serial-debug/hex-view-renderer.ts
@@ -1,8 +1,15 @@
 import { formatHexDumpFromChunks } from "./hex-format";
 import type { DebugLogLine, HexBytesPerRow } from "./types";
 
+const textEncoder = new TextEncoder();
+
 function lineChunk(line: DebugLogLine): Uint8Array {
-  const raw = line.rawBytes ?? new Uint8Array();
+  // Live lines carry rawBytes (the store splits DebugChunk.bytes itself).
+  // Lines paged back from the Rust session archive do not: the archive stores
+  // text only, so a `number[]` of the same bytes does not cost 3x the IPC
+  // payload. Re-encoding text is byte-identical for any valid UTF-8 log, which
+  // is all the archive can round-trip anyway (it decodes lossily on write).
+  const raw = line.rawBytes ?? textEncoder.encode(line.text);
   const chunk = new Uint8Array(raw.length + 1);
   chunk.set(raw, 0);
   chunk[chunk.length - 1] = 0x0a;

--- a/src/features/serial-debug/hex-view-renderer.ts
+++ b/src/features/serial-debug/hex-view-renderer.ts
@@ -16,44 +16,156 @@ function lineChunk(line: DebugLogLine): Uint8Array {
   return chunk;
 }
 
+/**
+ * Windowed renderer for the hex view.
+ *
+ * The hex view is one continuous dump of the whole visible buffer: every line's
+ * bytes plus a trailing 0x0a are concatenated into a single byte stream, and hex
+ * row k shows bytes `[k * bytesPerRow, (k + 1) * bytesPerRow)` of it. Rows
+ * therefore do not line up with log lines — one row can straddle several lines
+ * and a long line spans many rows — so the ASCII view's `lineIndex * rowHeight`
+ * row model does not carry over. What replaces it is a byte-offset index:
+ *
+ * - `starts` is a prefix sum of chunk lengths over the *current* buffer, so
+ *   `starts[i]` is line i's byte offset and `starts[n]` is the total byte count.
+ *   All offsets are relative to the current head, which is exactly what the
+ *   rendered dump is relative to. When the store drops lines off the head the
+ *   whole stream shifts; rebuilding the prefix sum re-bases every offset in one
+ *   numeric pass, so no absolute-offset bookkeeping (and no per-line id → offset
+ *   map that would have to be rebased anyway) is needed.
+ * - The rebuild only runs when the visible line list actually changes; a pure
+ *   scroll reuses the index.
+ * - `bytesPerRow` is deliberately not part of the index: it only divides the
+ *   byte axis into rows, so switching it re-derives the row count and the window
+ *   without touching the index.
+ *
+ * Byte chunks are cached per line id (`Uint8Array` views are handed to the
+ * formatter with `subarray`, so windowing copies no bytes).
+ */
 export class SerialDebugHexViewRenderer {
   private chunkByLineId = new Map<number, Uint8Array>();
-  private cachedLineIds: number[] = [];
-  private cachedBytesPerRow: HexBytesPerRow | null = null;
-  private cachedDump = "";
+  private ids: number[] = [];
+  // Length is `ids.length + 1`; starts[0] is always 0.
+  private starts: number[] = [0];
 
-  render(lines: readonly DebugLogLine[], bytesPerRow: HexBytesPerRow): string {
-    const nextIds = lines.map((line) => line.id);
-    if (
-      this.cachedBytesPerRow === bytesPerRow &&
-      nextIds.length === this.cachedLineIds.length &&
-      nextIds.every((id, index) => id === this.cachedLineIds[index])
-    ) {
-      return this.cachedDump;
-    }
+  /** Total number of hex rows the current buffer occupies. */
+  rowCount(
+    lines: readonly DebugLogLine[],
+    bytesPerRow: HexBytesPerRow,
+  ): number {
+    this.syncIndex(lines);
+    return Math.ceil(this.totalBytes() / bytesPerRow);
+  }
 
-    const visibleIds = new Set(nextIds);
-    for (const existingId of this.chunkByLineId.keys()) {
-      if (!visibleIds.has(existingId)) {
-        this.chunkByLineId.delete(existingId);
-      }
-    }
+  /**
+   * Dump text for hex rows `[startRow, endRow)`. Byte-identical to the matching
+   * slice of the full-buffer dump: `startRow * bytesPerRow` is row-aligned by
+   * construction, and the trailing partial row can only appear when the window
+   * reaches the end of the stream.
+   */
+  renderRows(
+    lines: readonly DebugLogLine[],
+    bytesPerRow: HexBytesPerRow,
+    startRow: number,
+    endRow: number,
+  ): string {
+    this.syncIndex(lines);
+    const from = Math.max(0, startRow) * bytesPerRow;
+    const to = Math.min(endRow * bytesPerRow, this.totalBytes());
+    if (from >= to) return "";
+    return formatHexDumpFromChunks(this.sliceChunks(from, to), bytesPerRow);
+  }
 
-    const chunks = lines.map((line) => {
-      const cached = this.chunkByLineId.get(line.id);
-      if (cached) return cached;
-      const chunk = lineChunk(line);
-      this.chunkByLineId.set(line.id, chunk);
-      return chunk;
-    });
-
-    this.cachedLineIds = nextIds;
-    this.cachedBytesPerRow = bytesPerRow;
-    this.cachedDump = formatHexDumpFromChunks(chunks, bytesPerRow);
-    return this.cachedDump;
+  /**
+   * Hex row that line `lineIndex` of the current buffer starts on — the bridge
+   * the search / scroll-to-match path needs to turn a line index into a scroll
+   * offset while the hex view is up.
+   */
+  rowOfLine(
+    lines: readonly DebugLogLine[],
+    bytesPerRow: HexBytesPerRow,
+    lineIndex: number,
+  ): number {
+    this.syncIndex(lines);
+    if (lineIndex <= 0) return 0;
+    const clamped = Math.min(lineIndex, this.ids.length);
+    return Math.floor(this.starts[clamped] / bytesPerRow);
   }
 
   cacheSize(): number {
     return this.chunkByLineId.size;
+  }
+
+  private totalBytes(): number {
+    return this.starts[this.ids.length];
+  }
+
+  /** Byte views covering `[from, to)` of the current stream. */
+  private sliceChunks(from: number, to: number): Uint8Array[] {
+    const out: Uint8Array[] = [];
+    for (let i = this.lineAt(from); i < this.ids.length; i += 1) {
+      const start = this.starts[i];
+      if (start >= to) break;
+      const chunk = this.chunkByLineId.get(this.ids[i]);
+      if (!chunk) continue;
+      const head = Math.max(from - start, 0);
+      const tail = Math.min(to - start, chunk.length);
+      out.push(
+        head === 0 && tail === chunk.length
+          ? chunk
+          : chunk.subarray(head, tail),
+      );
+    }
+    return out;
+  }
+
+  /** First line index whose chunk contains `byteOffset`. */
+  private lineAt(byteOffset: number): number {
+    let lo = 0;
+    let hi = this.ids.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (this.starts[mid + 1] > byteOffset) hi = mid;
+      else lo = mid + 1;
+    }
+    return Math.max(lo, 0);
+  }
+
+  private syncIndex(lines: readonly DebugLogLine[]): void {
+    const n = lines.length;
+    if (n === this.ids.length) {
+      let i = 0;
+      while (i < n && lines[i].id === this.ids[i]) i += 1;
+      if (i === n) return;
+    }
+
+    // Reused in place: at 20000 lines a fresh pair of arrays per publish would
+    // be ~320 KB of garbage per flush for no benefit.
+    const { ids, starts } = this;
+    ids.length = n;
+    starts.length = n + 1;
+    for (let i = 0; i < n; i += 1) {
+      const line = lines[i];
+      let chunk = this.chunkByLineId.get(line.id);
+      if (chunk === undefined) {
+        chunk = lineChunk(line);
+        this.chunkByLineId.set(line.id, chunk);
+      }
+      ids[i] = line.id;
+      starts[i + 1] = starts[i] + chunk.length;
+    }
+
+    // Every visible id is in the cache by now, so a cache larger than the
+    // buffer is the only case that can hold stale entries. Sweeping is O(cache)
+    // and a saturated buffer strands `logWindowLines / 1000`-ish entries per
+    // flush, so tolerate a fifth of slack and sweep once per few hundred
+    // flushes instead of on every one: it is the dominant cost of a publish
+    // otherwise, and the cache stays bounded either way.
+    if (this.chunkByLineId.size > n * 1.2) {
+      const visible = new Set(ids);
+      for (const existingId of this.chunkByLineId.keys()) {
+        if (!visible.has(existingId)) this.chunkByLineId.delete(existingId);
+      }
+    }
   }
 }

--- a/src/features/serial-debug/log-line-renderer.test.ts
+++ b/src/features/serial-debug/log-line-renderer.test.ts
@@ -45,14 +45,29 @@ describe("SerialDebugLogLineRenderer", () => {
     expect(stripAnsiMock).toHaveBeenCalledTimes(2);
   });
 
-  it("drops cached entries for lines that are no longer visible", () => {
+  it("drops cached entries for lines that left the buffer", () => {
     const renderer = new SerialDebugLogLineRenderer();
 
     renderer.render([line(1, "one"), line(2, "two")], true, "");
     expect(renderer.cacheSize()).toBe(2);
 
+    // `render` sees only the visible slice, so rendering fewer lines must not
+    // evict anything — eviction is driven by `retain` with the full buffer.
     renderer.render([line(2, "two")], true, "");
+    expect(renderer.cacheSize()).toBe(2);
+
+    renderer.retain([line(2, "two")]);
     expect(renderer.cacheSize()).toBe(1);
+  });
+
+  it("matches over the whole buffer without building spans", () => {
+    const renderer = new SerialDebugLogLineRenderer();
+    parseAnsiMock.mockClear();
+    const lines = [line(1, "alpha"), line(2, "beta"), line(3, "alphabet")];
+
+    expect(renderer.matchingLineIds(lines, "  ALPHA  ")).toEqual([1, 3]);
+    expect(renderer.matchingLineIds(lines, "")).toEqual([]);
+    expect(parseAnsiMock).not.toHaveBeenCalled();
   });
 
   describe("level-prefix fallback colors (no ANSI fg)", () => {

--- a/src/features/serial-debug/log-line-renderer.ts
+++ b/src/features/serial-debug/log-line-renderer.ts
@@ -29,11 +29,15 @@ type CachedRenderedLine = {
   view: RenderedLogLine;
 };
 
+// `ansiSpans`/`plainSpans` are built lazily: the log view scans the whole
+// buffer for search matches (needs `lowerPlainText` only) but builds spans for
+// the visible slice alone, so parsing every line's ANSI eagerly would undo the
+// saving.
 type CachedLineBase = {
   plainText: string;
   lowerPlainText: string;
-  ansiSpans: AnsiSpan[];
-  plainSpans: AnsiSpan[];
+  ansiSpans?: AnsiSpan[];
+  plainSpans?: AnsiSpan[];
   lastRendered?: CachedRenderedLine;
 };
 
@@ -96,22 +100,51 @@ function splitByKeyword(
 export class SerialDebugLogLineRenderer {
   private baseByLineId = new Map<number, CachedLineBase>();
 
+  /**
+   * Build display spans. Callers pass the slice they are about to mount (the
+   * visible window), so this must NOT drive cache eviction — call `retain` with
+   * the full buffer for that.
+   */
   render(
     lines: readonly DebugLogLine[],
     ansiEnabled: boolean,
     searchQuery: string,
   ): RenderedLogLine[] {
     const normalizedQuery = searchQuery.trim().toLowerCase();
-    const visibleIds = new Set(lines.map((line) => line.id));
-    for (const existingId of this.baseByLineId.keys()) {
-      if (!visibleIds.has(existingId)) {
-        this.baseByLineId.delete(existingId);
-      }
-    }
-
     return lines.map((line) =>
       this.renderLine(line, ansiEnabled, normalizedQuery),
     );
+  }
+
+  /** Drop cached data for lines that have left the buffer. */
+  retain(lines: readonly DebugLogLine[]): void {
+    if (this.baseByLineId.size === 0) return;
+    const liveIds = new Set(lines.map((line) => line.id));
+    for (const existingId of this.baseByLineId.keys()) {
+      if (!liveIds.has(existingId)) {
+        this.baseByLineId.delete(existingId);
+      }
+    }
+  }
+
+  /**
+   * Ids of every line whose text contains `searchQuery`, over the whole buffer.
+   * Substring test only — no span building — so it stays affordable for lines
+   * that are never mounted.
+   */
+  matchingLineIds(
+    lines: readonly DebugLogLine[],
+    searchQuery: string,
+  ): number[] {
+    const normalizedQuery = searchQuery.trim().toLowerCase();
+    if (!normalizedQuery) return [];
+    const ids: number[] = [];
+    for (const line of lines) {
+      if (this.getOrCreateBase(line).lowerPlainText.includes(normalizedQuery)) {
+        ids.push(line.id);
+      }
+    }
+    return ids;
   }
 
   cacheSize(): number {
@@ -133,13 +166,11 @@ export class SerialDebugLogLineRenderer {
       return cached.view;
     }
 
-    const spans = (ansiEnabled ? base.ansiSpans : base.plainSpans).map(
-      (span) => ({
-        text: span.text,
-        style: span.style,
-        segments: splitByKeyword(span.text, searchQuery),
-      }),
-    );
+    const spans = this.spansFor(line, base, ansiEnabled).map((span) => ({
+      text: span.text,
+      style: span.style,
+      segments: splitByKeyword(span.text, searchQuery),
+    }));
     const view: RenderedLogLine = {
       line,
       spans,
@@ -154,6 +185,23 @@ export class SerialDebugLogLineRenderer {
     return view;
   }
 
+  private spansFor(
+    line: DebugLogLine,
+    base: CachedLineBase,
+    ansiEnabled: boolean,
+  ): AnsiSpan[] {
+    if (ansiEnabled) {
+      base.ansiSpans ??= applyLevelFallback(
+        line,
+        base.plainText,
+        parseAnsi(line.text),
+      );
+      return base.ansiSpans;
+    }
+    base.plainSpans ??= [{ text: base.plainText, style: {} }];
+    return base.plainSpans;
+  }
+
   private getOrCreateBase(line: DebugLogLine): CachedLineBase {
     let existing = this.baseByLineId.get(line.id);
     if (existing) {
@@ -164,8 +212,6 @@ export class SerialDebugLogLineRenderer {
     existing = {
       plainText,
       lowerPlainText: plainText.toLowerCase(),
-      ansiSpans: applyLevelFallback(line, plainText, parseAnsi(line.text)),
-      plainSpans: [{ text: plainText, style: {} }],
     };
     this.baseByLineId.set(line.id, existing);
     return existing;

--- a/src/features/serial-debug/transport.ts
+++ b/src/features/serial-debug/transport.ts
@@ -1,6 +1,7 @@
 import { isTauriRuntime } from "@/runtime";
 import { wsTransport } from "@/transport/ws-transport";
 import type {
+  ArchiveCappedPayload,
   DebugChunk,
   DebugConfig,
   DisconnectPayload,
@@ -13,6 +14,7 @@ type ChunkListener = (chunk: DebugChunk) => void;
 type ChunkBatchListener = (chunks: DebugChunk[]) => void;
 type DisconnectListener = (p: DisconnectPayload) => void;
 type FilterListener = (payload: SerialDebugFilterUpdatePayload) => void;
+type ArchiveCappedListener = (p: ArchiveCappedPayload) => void;
 
 export interface SerialDebugTransport {
   open(cfg: DebugConfig): Promise<void>;
@@ -35,10 +37,18 @@ export interface SerialDebugTransport {
     start: number,
     limit: number,
   ): Promise<SerialDebugSessionPage>;
+  /** Push the session-archive byte cap down to Rust (0 = unlimited). */
+  setArchiveLimit(maxBytes: number): Promise<void>;
   onChunk(cb: ChunkListener): () => void; // returns unsubscribe
   onChunkBatch(cb: ChunkBatchListener): () => void;
   onDisconnect(cb: DisconnectListener): () => void;
   onFilterUpdated(cb: FilterListener): () => void;
+  /**
+   * The session archive stopped recording. Its own event because the live view
+   * is fed by the raw chunk stream and never sees archived lines — the notice
+   * the archive wrote into itself would otherwise be invisible to the user.
+   */
+  onArchiveCapped(cb: ArchiveCappedListener): () => void;
 }
 
 /** Lazy Tauri transport — uses @tauri-apps/api. Loads dynamically so web builds stay lean. */
@@ -47,10 +57,12 @@ class TauriTransport implements SerialDebugTransport {
   private chunkBatchListeners = new Set<ChunkBatchListener>();
   private disconnectListeners = new Set<DisconnectListener>();
   private filterListeners = new Set<FilterListener>();
+  private archiveCappedListeners = new Set<ArchiveCappedListener>();
   private unlistenChunk?: () => void;
   private unlistenChunkBatch?: () => void;
   private unlistenDisconnect?: () => void;
   private unlistenFilterUpdated?: () => void;
+  private unlistenArchiveCapped?: () => void;
   private listenersReady: Promise<void>;
 
   constructor() {
@@ -62,7 +74,8 @@ class TauriTransport implements SerialDebugTransport {
       this.unlistenChunk &&
       this.unlistenChunkBatch &&
       this.unlistenDisconnect &&
-      this.unlistenFilterUpdated
+      this.unlistenFilterUpdated &&
+      this.unlistenArchiveCapped
     ) {
       return;
     }
@@ -95,6 +108,12 @@ class TauriTransport implements SerialDebugTransport {
       "serial-debug-filter-updated",
       (ev) => {
         this.filterListeners.forEach((l) => l(ev.payload));
+      },
+    );
+    this.unlistenArchiveCapped = await listen<ArchiveCappedPayload>(
+      "serial-debug-archive-capped",
+      (ev) => {
+        this.archiveCappedListeners.forEach((l) => l(ev.payload));
       },
     );
   }
@@ -162,6 +181,11 @@ class TauriTransport implements SerialDebugTransport {
     return await invoke("serial_debug_session_read_page", { start, limit });
   }
 
+  async setArchiveLimit(maxBytes: number): Promise<void> {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("serial_debug_set_archive_limit", { maxBytes });
+  }
+
   onChunk(cb: ChunkListener): () => void {
     this.chunkListeners.add(cb);
     return () => {
@@ -189,6 +213,13 @@ class TauriTransport implements SerialDebugTransport {
       this.filterListeners.delete(cb);
     };
   }
+
+  onArchiveCapped(cb: ArchiveCappedListener): () => void {
+    this.archiveCappedListeners.add(cb);
+    return () => {
+      this.archiveCappedListeners.delete(cb);
+    };
+  }
 }
 
 /** Web mode transport — talks to `tyutool-cli serve` over WebSocket via wsTransport. */
@@ -197,6 +228,7 @@ class WebTransport implements SerialDebugTransport {
   private chunkBatchListeners = new Set<ChunkBatchListener>();
   private disconnectListeners = new Set<DisconnectListener>();
   private filterListeners = new Set<FilterListener>();
+  private archiveCappedListeners = new Set<ArchiveCappedListener>();
   private isOpen = false;
 
   async open(cfg: DebugConfig): Promise<void> {
@@ -214,6 +246,7 @@ class WebTransport implements SerialDebugTransport {
       },
       (reason) => this.disconnectListeners.forEach((l) => l({ reason })),
       (payload) => this.filterListeners.forEach((l) => l(payload)),
+      (payload) => this.archiveCappedListeners.forEach((l) => l(payload)),
     );
     this.isOpen = true;
   }
@@ -267,6 +300,10 @@ class WebTransport implements SerialDebugTransport {
     return await wsTransport.serialDebugSessionReadPage(start, limit);
   }
 
+  async setArchiveLimit(maxBytes: number): Promise<void> {
+    await wsTransport.serialDebugSetArchiveLimit(maxBytes);
+  }
+
   onChunk(cb: ChunkListener): () => void {
     this.chunkListeners.add(cb);
     return () => {
@@ -292,6 +329,13 @@ class WebTransport implements SerialDebugTransport {
     this.filterListeners.add(cb);
     return () => {
       this.filterListeners.delete(cb);
+    };
+  }
+
+  onArchiveCapped(cb: ArchiveCappedListener): () => void {
+    this.archiveCappedListeners.add(cb);
+    return () => {
+      this.archiveCappedListeners.delete(cb);
     };
   }
 }

--- a/src/features/serial-debug/transport.ts
+++ b/src/features/serial-debug/transport.ts
@@ -2,6 +2,7 @@ import { isTauriRuntime } from "@/runtime";
 import { wsTransport } from "@/transport/ws-transport";
 import type {
   ArchiveCappedPayload,
+  ChunksDroppedPayload,
   DebugChunk,
   DebugConfig,
   DisconnectPayload,
@@ -15,6 +16,7 @@ type ChunkBatchListener = (chunks: DebugChunk[]) => void;
 type DisconnectListener = (p: DisconnectPayload) => void;
 type FilterListener = (payload: SerialDebugFilterUpdatePayload) => void;
 type ArchiveCappedListener = (p: ArchiveCappedPayload) => void;
+type ChunksDroppedListener = (p: ChunksDroppedPayload) => void;
 
 export interface SerialDebugTransport {
   open(cfg: DebugConfig): Promise<void>;
@@ -49,6 +51,15 @@ export interface SerialDebugTransport {
    * the archive wrote into itself would otherwise be invisible to the user.
    */
   onArchiveCapped(cb: ArchiveCappedListener): () => void;
+  /**
+   * Device output was dropped because the backend could not keep up. Its own
+   * event for the same reason as `onArchiveCapped` — plus a second one: the live
+   * view has to close its pending line buffer at the gap, or the bytes either
+   * side of it get spliced into one line the device never printed.
+   *
+   * Optional so an older backend (or a test fake) simply reports no drops.
+   */
+  onChunksDropped?(cb: ChunksDroppedListener): () => void;
 }
 
 /** Lazy Tauri transport — uses @tauri-apps/api. Loads dynamically so web builds stay lean. */
@@ -58,11 +69,13 @@ class TauriTransport implements SerialDebugTransport {
   private disconnectListeners = new Set<DisconnectListener>();
   private filterListeners = new Set<FilterListener>();
   private archiveCappedListeners = new Set<ArchiveCappedListener>();
+  private chunksDroppedListeners = new Set<ChunksDroppedListener>();
   private unlistenChunk?: () => void;
   private unlistenChunkBatch?: () => void;
   private unlistenDisconnect?: () => void;
   private unlistenFilterUpdated?: () => void;
   private unlistenArchiveCapped?: () => void;
+  private unlistenChunksDropped?: () => void;
   private listenersReady: Promise<void>;
 
   constructor() {
@@ -75,7 +88,8 @@ class TauriTransport implements SerialDebugTransport {
       this.unlistenChunkBatch &&
       this.unlistenDisconnect &&
       this.unlistenFilterUpdated &&
-      this.unlistenArchiveCapped
+      this.unlistenArchiveCapped &&
+      this.unlistenChunksDropped
     ) {
       return;
     }
@@ -114,6 +128,12 @@ class TauriTransport implements SerialDebugTransport {
       "serial-debug-archive-capped",
       (ev) => {
         this.archiveCappedListeners.forEach((l) => l(ev.payload));
+      },
+    );
+    this.unlistenChunksDropped = await listen<ChunksDroppedPayload>(
+      "serial-debug-chunks-dropped",
+      (ev) => {
+        this.chunksDroppedListeners.forEach((l) => l(ev.payload));
       },
     );
   }
@@ -220,6 +240,13 @@ class TauriTransport implements SerialDebugTransport {
       this.archiveCappedListeners.delete(cb);
     };
   }
+
+  onChunksDropped(cb: ChunksDroppedListener): () => void {
+    this.chunksDroppedListeners.add(cb);
+    return () => {
+      this.chunksDroppedListeners.delete(cb);
+    };
+  }
 }
 
 /** Web mode transport — talks to `tyutool-cli serve` over WebSocket via wsTransport. */
@@ -229,6 +256,7 @@ class WebTransport implements SerialDebugTransport {
   private disconnectListeners = new Set<DisconnectListener>();
   private filterListeners = new Set<FilterListener>();
   private archiveCappedListeners = new Set<ArchiveCappedListener>();
+  private chunksDroppedListeners = new Set<ChunksDroppedListener>();
   private isOpen = false;
 
   async open(cfg: DebugConfig): Promise<void> {
@@ -247,6 +275,7 @@ class WebTransport implements SerialDebugTransport {
       (reason) => this.disconnectListeners.forEach((l) => l({ reason })),
       (payload) => this.filterListeners.forEach((l) => l(payload)),
       (payload) => this.archiveCappedListeners.forEach((l) => l(payload)),
+      (payload) => this.chunksDroppedListeners.forEach((l) => l(payload)),
     );
     this.isOpen = true;
   }
@@ -336,6 +365,13 @@ class WebTransport implements SerialDebugTransport {
     this.archiveCappedListeners.add(cb);
     return () => {
       this.archiveCappedListeners.delete(cb);
+    };
+  }
+
+  onChunksDropped(cb: ChunksDroppedListener): () => void {
+    this.chunksDroppedListeners.add(cb);
+    return () => {
+      this.chunksDroppedListeners.delete(cb);
     };
   }
 }

--- a/src/features/serial-debug/transport.ts
+++ b/src/features/serial-debug/transport.ts
@@ -23,7 +23,17 @@ export interface SerialDebugTransport {
   close(): Promise<void>;
   send(bytes: Uint8Array): Promise<void>;
   clearSession(): Promise<void>;
-  appendSysLine(tsMs: number, text: string): Promise<void>;
+  /**
+   * Archive one `sys` line.
+   *
+   * @returns the archive `lineNo` it was written as, or `null` when it was not
+   * archived at all (the archive is capped, or the web backend does not report a
+   * position). The store needs it because a sys line reaches the live view
+   * before it reaches the archive, so `DebugChunk.archivedBefore`'s trick — read
+   * the position while writing — is not available; `null` therefore means "not
+   * in the archive", which keeps the line out of the auto-save discard pass.
+   */
+  appendSysLine(tsMs: number, text: string): Promise<number | null>;
   addFilter(
     keyword: string,
     useRegex: boolean,
@@ -159,9 +169,14 @@ class TauriTransport implements SerialDebugTransport {
     await invoke("serial_debug_session_clear");
   }
 
-  async appendSysLine(tsMs: number, text: string): Promise<void> {
+  async appendSysLine(tsMs: number, text: string): Promise<number | null> {
     const { invoke } = await import("@tauri-apps/api/core");
-    await invoke("serial_debug_append_sys_line", { tsMs, text });
+    return (
+      (await invoke<number | null>("serial_debug_append_sys_line", {
+        tsMs,
+        text,
+      })) ?? null
+    );
   }
 
   async addFilter(
@@ -294,8 +309,12 @@ class WebTransport implements SerialDebugTransport {
     await wsTransport.serialDebugSessionClear();
   }
 
-  async appendSysLine(tsMs: number, text: string): Promise<void> {
+  async appendSysLine(tsMs: number, text: string): Promise<number | null> {
     await wsTransport.serialDebugAppendSysLine(tsMs, text);
+    // The WS message is fire-and-forget, so the archive position never comes
+    // back. Harmless: auto-save — the only consumer of the position — writes
+    // through `invoke("append_text_file")` and so never runs in web mode.
+    return null;
   }
 
   async addFilter(

--- a/src/features/serial-debug/types.ts
+++ b/src/features/serial-debug/types.ts
@@ -41,6 +41,16 @@ export interface ArchiveCappedPayload {
   limitMib: number;
 }
 
+/**
+ * Mirrors the `serial-debug-chunks-dropped` Tauri event and the
+ * `serial_debug_chunks_dropped` WS message (whose `dropped_bytes` is mapped to
+ * `droppedBytes` in `ws-transport.ts`). Device output the backend could not keep
+ * up with; the wording comes from `serialDebug.log.chunksDropped`.
+ */
+export interface ChunksDroppedPayload {
+  droppedBytes: number;
+}
+
 export type DebugLineDirection = "tx" | "rx" | "sys";
 
 export interface DebugLogLine {

--- a/src/features/serial-debug/types.ts
+++ b/src/features/serial-debug/types.ts
@@ -19,12 +19,17 @@ export interface DebugChunk {
   direction: "tx" | "rx";
   tsMs: number;
   bytes: number[]; // Tauri deserializes Vec<u8> as a number[]
-}
-
-export interface SerialDebugSessionMeta {
-  sessionId: string;
-  logPath: string;
-  totalLines: number;
+  /**
+   * How many lines the Rust session archive held *before* this chunk was
+   * appended to it (`ArchivedChunk` in `src-tauri/src/serial_debug.rs`). It is
+   * what makes the mid-session auto-save handoff exact: a live line is already
+   * inside a backfill snapshot `N` iff its chunk's `archivedBefore < N`.
+   *
+   * Optional only so an older backend or a test fake can leave it out; missing
+   * means "position unknown", and the store then never discards the line — the
+   * no-gap direction, i.e. at worst the old duplicate window.
+   */
+  archivedBefore?: number;
 }
 
 export interface DisconnectPayload {
@@ -39,6 +44,8 @@ export interface DisconnectPayload {
  */
 export interface ArchiveCappedPayload {
   limitMib: number;
+  /** `archivedBefore` of the cap sentinel itself; see `DebugChunk`. */
+  archivedBefore?: number;
 }
 
 /**
@@ -49,6 +56,12 @@ export interface ArchiveCappedPayload {
  */
 export interface ChunksDroppedPayload {
   droppedBytes: number;
+  /**
+   * `archivedBefore` of the two lines `append_gap` wrote for this notice (the
+   * cut-off partial line and the sentinel); see `DebugChunk`. Both were written
+   * under one archive lock, so one number covers both.
+   */
+  archivedBefore?: number;
 }
 
 export type DebugLineDirection = "tx" | "rx" | "sys";

--- a/src/features/serial-debug/types.ts
+++ b/src/features/serial-debug/types.ts
@@ -31,6 +31,16 @@ export interface DisconnectPayload {
   reason: string;
 }
 
+/**
+ * Mirrors the `serial-debug-archive-capped` Tauri event and the
+ * `serial_debug_archive_capped` WS message (whose `limit_mib` is mapped to
+ * `limitMib` in `ws-transport.ts`). Only the number crosses — the wording comes
+ * from `serialDebug.log.archiveCapped`.
+ */
+export interface ArchiveCappedPayload {
+  limitMib: number;
+}
+
 export type DebugLineDirection = "tx" | "rx" | "sys";
 
 export interface DebugLogLine {

--- a/src/features/serial-debug/useSerialAutoSave.test.ts
+++ b/src/features/serial-debug/useSerialAutoSave.test.ts
@@ -42,6 +42,15 @@ const noArchive: SessionPageHandler = async () => {
 
 let sessionPageHandler: SessionPageHandler = noArchive;
 
+/**
+ * What the fake archive answers when the store archives a `sys` line: the
+ * `lineNo` it was written as, or null for "not archived". Set per test.
+ */
+let sysLineArchivePosition: number | null = null;
+
+/** Holds the sys-line archive write open, to model a slow round trip. */
+let sysLineGate: Promise<void> | null = null;
+
 /** Serve `lines` as an archive; `growBy` fakes a session that keeps growing. */
 function archivePages(
   lines: readonly SerialDebugLine[],
@@ -65,7 +74,10 @@ function fakeTransport(): SerialDebugTransport {
     async close() {},
     async send() {},
     async clearSession() {},
-    async appendSysLine() {},
+    async appendSysLine() {
+      if (sysLineGate) await sysLineGate;
+      return sysLineArchivePosition;
+    },
     async addFilter() {
       throw new Error("not implemented");
     },
@@ -138,6 +150,8 @@ describe("useSerialAutoSave", () => {
     vi.useFakeTimers();
     invokeSpy.mockReset();
     sessionPageHandler = noArchive;
+    sysLineArchivePosition = null;
+    sysLineGate = null;
     setActivePinia(createPinia());
     __setSerialDebugTransportForTest(fakeTransport());
   });
@@ -527,6 +541,269 @@ describe("useSerialAutoSave", () => {
     expect(writtenContents()).toEqual([
       `[${formatTs(1000)}] [RX ] old\n`,
       `[${formatTs(2000)}] [RX ] live\n`,
+    ]);
+  });
+
+  /**
+   * The handoff race, from the duplicate side: a line the archive already held
+   * when the snapshot was taken, but whose chunk event only reached the frontend
+   * after the session file existed. It is in the backfilled half *and* in the
+   * live queue, and only its `archivedBefore` says so.
+   */
+  it("writes a line archived before the snapshot but delivered after it exactly once", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+
+    s.port = "/dev/ttyUSB0";
+    s.open = true;
+    await nextTick();
+
+    let releasePage: ((page: SerialDebugSessionPage) => void) | null = null;
+    sessionPageHandler = () =>
+      new Promise<SerialDebugSessionPage>((resolve) => {
+        releasePage = resolve;
+      });
+    invokeSpy.mockResolvedValue(undefined);
+
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    await nextTick();
+    await settle();
+
+    // Archived as line 3 (so the archive held 2 lines before its chunk), which
+    // is inside the snapshot below — the backfill will write it.
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 2000,
+      bytes: [...Buffer.from("straddler\n")],
+      archivedBefore: 2,
+    });
+
+    (releasePage as ((page: SerialDebugSessionPage) => void) | null)?.({
+      totalLines: 3,
+      start: 0,
+      items: [
+        { lineNo: 1, tsMs: 1000, direction: "rx", text: "a" },
+        { lineNo: 2, tsMs: 1001, direction: "rx", text: "b" },
+        { lineNo: 3, tsMs: 2000, direction: "rx", text: "straddler" },
+      ],
+    });
+    await settle();
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    const file = writtenContents().join("");
+    expect(file.split("straddler")).toHaveLength(2); // i.e. exactly one hit
+    expect(file).toBe(
+      `[${formatTs(1000)}] [RX ] a\n` +
+        `[${formatTs(1001)}] [RX ] b\n` +
+        `[${formatTs(2000)}] [RX ] straddler\n`,
+    );
+  });
+
+  /**
+   * The same race from the gap side: a line archived *after* the snapshot is the
+   * live half's responsibility, and the discard pass must leave it alone even
+   * though it arrived while the backfill was still running.
+   */
+  it("keeps a line archived after the snapshot that arrived during the backfill", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+
+    s.port = "/dev/ttyUSB0";
+    s.open = true;
+    await nextTick();
+
+    let releasePage: ((page: SerialDebugSessionPage) => void) | null = null;
+    sessionPageHandler = () =>
+      new Promise<SerialDebugSessionPage>((resolve) => {
+        releasePage = resolve;
+      });
+    invokeSpy.mockResolvedValue(undefined);
+
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    await nextTick();
+    await settle();
+
+    // The archive held 2 lines before this chunk, i.e. it became line 3 — one
+    // past the snapshot of 2 that the backfill is about to report.
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 2000,
+      bytes: [...Buffer.from("after-snapshot\n")],
+      archivedBefore: 2,
+    });
+
+    (releasePage as ((page: SerialDebugSessionPage) => void) | null)?.({
+      totalLines: 2,
+      start: 0,
+      items: [
+        { lineNo: 1, tsMs: 1000, direction: "rx", text: "a" },
+        { lineNo: 2, tsMs: 1001, direction: "rx", text: "b" },
+      ],
+    });
+    await settle();
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    expect(writtenContents().join("")).toBe(
+      `[${formatTs(1000)}] [RX ] a\n` +
+        `[${formatTs(1001)}] [RX ] b\n` +
+        `[${formatTs(2000)}] [RX ] after-snapshot\n`,
+    );
+  });
+
+  /**
+   * A sys line reaches the live queue before it reaches the archive, so its
+   * position is only known once the backend answers. The discard has to wait for
+   * that answer — here it is still outstanding when the backfill finishes.
+   */
+  it("waits for an in-flight sys line's archive position before discarding", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+
+    s.port = "/dev/ttyUSB0";
+    s.open = true;
+    await nextTick();
+
+    let releasePage: ((page: SerialDebugSessionPage) => void) | null = null;
+    sessionPageHandler = () =>
+      new Promise<SerialDebugSessionPage>((resolve) => {
+        releasePage = resolve;
+      });
+    invokeSpy.mockResolvedValue(undefined);
+
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    await nextTick();
+    await settle();
+
+    let releaseSysLine: (() => void) | null = null;
+    sysLineGate = new Promise<void>((resolve) => {
+      releaseSysLine = resolve;
+    });
+    sysLineArchivePosition = 2; // archived as line 2, inside the snapshot
+    void s.appendSysLine("connected");
+    await settle();
+
+    (releasePage as ((page: SerialDebugSessionPage) => void) | null)?.({
+      totalLines: 2,
+      start: 0,
+      items: [
+        { lineNo: 1, tsMs: 1000, direction: "rx", text: "a" },
+        { lineNo: 2, tsMs: 1001, direction: "sys", text: "connected" },
+      ],
+    });
+    await settle();
+
+    (releaseSysLine as (() => void) | null)?.();
+    await settle();
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    const file = writtenContents().join("");
+    expect(file.split("connected")).toHaveLength(2); // exactly one hit
+    expect(file).toBe(
+      `[${formatTs(1000)}] [RX ] a\n` + `[${formatTs(1001)}] [SYS] connected\n`,
+    );
+  });
+
+  /**
+   * A sys line the archive refused (it is capped) exists only in the live view,
+   * so the backfill can never hold a copy and it must survive the discard.
+   */
+  it("keeps a sys line the capped archive refused", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+
+    s.port = "/dev/ttyUSB0";
+    s.open = true;
+    await nextTick();
+
+    let releasePage: ((page: SerialDebugSessionPage) => void) | null = null;
+    sessionPageHandler = () =>
+      new Promise<SerialDebugSessionPage>((resolve) => {
+        releasePage = resolve;
+      });
+    invokeSpy.mockResolvedValue(undefined);
+
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    await nextTick();
+    await settle();
+
+    sysLineArchivePosition = null; // archive capped: nothing was written
+    await s.appendSysLine("port closed");
+
+    (releasePage as ((page: SerialDebugSessionPage) => void) | null)?.({
+      totalLines: 1,
+      start: 0,
+      items: [{ lineNo: 1, tsMs: 1000, direction: "rx", text: "a" }],
+    });
+    await settle();
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    expect(writtenContents().join("")).toContain("[SYS] port closed\n");
+  });
+
+  /**
+   * Once the archive is capped its line count freezes, so every later chunk
+   * reports the same `archivedBefore` — which is exactly the snapshot. The
+   * predicate is `<`, so those lines are kept and the file keeps growing where
+   * the archive stopped.
+   */
+  it("keeps recording live lines after the archive has stopped at its cap", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+
+    // Mirrors serial_debug_archive_cap_sentinel in
+    // crates/tyutool-core/src/serial_debug.rs.
+    const SOH = String.fromCharCode(1);
+    const sentinel = `${SOH}tyutool:archive-capped:16${SOH}`;
+
+    s.port = "/dev/ttyUSB0";
+    s.open = true;
+    await nextTick();
+
+    // A capped archive: 2 lines, frozen there for the rest of the session.
+    sessionPageHandler = archivePages([
+      { lineNo: 1, tsMs: 1000, direction: "rx", text: "a" },
+      { lineNo: 2, tsMs: 1001, direction: "sys", text: sentinel },
+    ]);
+    invokeSpy.mockResolvedValue(undefined);
+
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    await nextTick();
+    await settle();
+
+    // Frozen counter: both chunks report the same position as the snapshot.
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 2000,
+      bytes: [...Buffer.from("after-cap-1\n")],
+      archivedBefore: 2,
+    });
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 2001,
+      bytes: [...Buffer.from("after-cap-2\n")],
+      archivedBefore: 2,
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    const written = writtenContents().join("").trimEnd().split("\n");
+    expect(written).toHaveLength(4);
+    expect(written[0]).toBe(`[${formatTs(1000)}] [RX ] a`);
+    // The cap notice is translated on the way out, never the raw sentinel.
+    expect(written[1]).toContain("16 MiB");
+    expect(written[1]).not.toContain(SOH);
+    expect(written.slice(2)).toEqual([
+      `[${formatTs(2000)}] [RX ] after-cap-1`,
+      `[${formatTs(2001)}] [RX ] after-cap-2`,
     ]);
   });
 

--- a/src/features/serial-debug/useSerialAutoSave.test.ts
+++ b/src/features/serial-debug/useSerialAutoSave.test.ts
@@ -4,9 +4,14 @@ import { createApp, defineComponent, nextTick } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SerialDebugTransport } from "./transport";
 import { __setSerialDebugTransportForTest } from "./transport";
-import { AUTO_SAVE_FLUSH_MAX_CHARS } from "./constants";
+import {
+  AUTO_SAVE_BACKFILL_PAGE_SIZE,
+  AUTO_SAVE_FLUSH_MAX_CHARS,
+} from "./constants";
 import { useSerialDebugStore } from "@/stores/serial-debug";
 import { useSerialAutoSave } from "./useSerialAutoSave";
+import { formatTs } from "./utils";
+import type { SerialDebugLine, SerialDebugSessionPage } from "./types";
 
 const invokeSpy = vi.fn();
 
@@ -25,6 +30,35 @@ vi.mock("vue-i18n", async (importOriginal) => {
   };
 });
 
+type SessionPageHandler = (
+  start: number,
+  limit: number,
+) => Promise<SerialDebugSessionPage>;
+
+/** Default: no session archive at all (port never opened). */
+const noArchive: SessionPageHandler = async () => {
+  throw new Error("no session");
+};
+
+let sessionPageHandler: SessionPageHandler = noArchive;
+
+/** Serve `lines` as an archive; `growBy` fakes a session that keeps growing. */
+function archivePages(
+  lines: readonly SerialDebugLine[],
+  growBy = 0,
+): SessionPageHandler {
+  let calls = 0;
+  return async (start, limit) => {
+    const totalLines = lines.length + calls * growBy;
+    calls += 1;
+    return {
+      totalLines,
+      start,
+      items: lines.slice(start, start + limit),
+    };
+  };
+}
+
 function fakeTransport(): SerialDebugTransport {
   return {
     async open() {},
@@ -39,9 +73,10 @@ function fakeTransport(): SerialDebugTransport {
     async readFilterMatches() {
       throw new Error("not implemented");
     },
-    async readSessionPage() {
-      throw new Error("not implemented");
+    async readSessionPage(start, limit) {
+      return await sessionPageHandler(start, limit);
     },
+    async setArchiveLimit() {},
     onChunk() {
       return () => {};
     },
@@ -54,6 +89,9 @@ function fakeTransport(): SerialDebugTransport {
     onFilterUpdated() {
       return () => {};
     },
+    onArchiveCapped() {
+      return () => {};
+    },
   };
 }
 
@@ -63,6 +101,35 @@ async function flushMicrotasks(): Promise<void> {
   await nextTick();
 }
 
+/** Enough microtask rounds for a multi-page backfill to run to completion. */
+async function settle(rounds = 12): Promise<void> {
+  for (let i = 0; i < rounds; i += 1) {
+    await flushMicrotasks();
+  }
+}
+
+const BACKLOG_LINE_CHARS = 512;
+// Mirrors the store's estimatedChars (text.length + 48) and the drain budget.
+const BACKLOG_LINES_PER_APPEND = Math.floor(
+  AUTO_SAVE_FLUSH_MAX_CHARS / (BACKLOG_LINE_CHARS + 48),
+);
+
+/** Feed `lineCount` lines of BACKLOG_LINE_CHARS chars through the store. */
+function feedBacklog(
+  s: ReturnType<typeof useSerialDebugStore>,
+  lineCount: number,
+): void {
+  const sliceLines = 200;
+  for (let sent = 0; sent < lineCount; sent += sliceLines) {
+    const n = Math.min(sliceLines, lineCount - sent);
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 1000,
+      bytes: [...Buffer.from(`${"x".repeat(BACKLOG_LINE_CHARS)}\n`.repeat(n))],
+    });
+  }
+}
+
 describe("useSerialAutoSave", () => {
   let app: ReturnType<typeof createApp> | null = null;
   let host: HTMLDivElement | null = null;
@@ -70,6 +137,7 @@ describe("useSerialAutoSave", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     invokeSpy.mockReset();
+    sessionPageHandler = noArchive;
     setActivePinia(createPinia());
     __setSerialDebugTransportForTest(fakeTransport());
   });
@@ -82,6 +150,26 @@ describe("useSerialAutoSave", () => {
     __setSerialDebugTransportForTest(null);
     vi.useRealTimers();
   });
+
+  function mountAutoSave(s: ReturnType<typeof useSerialDebugStore>): void {
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    app = createApp(
+      defineComponent({
+        setup() {
+          useSerialAutoSave(s);
+          return () => null;
+        },
+      }),
+    );
+    app.mount(host);
+  }
+
+  function writtenContents(): string[] {
+    return invokeSpy.mock.calls.map(
+      (call) => (call[1] as { content: string }).content,
+    );
+  }
 
   it("waits for an in-flight flush to finish before dropping the session path", async () => {
     const s = useSerialDebugStore();
@@ -172,9 +260,9 @@ describe("useSerialAutoSave", () => {
 
     s.open = false;
     await nextTick();
-    await flushMicrotasks();
-    await flushMicrotasks();
-    await flushMicrotasks();
+    // The final flush first awaits the (empty) archive backfill, so give it more
+    // than a couple of microtask rounds.
+    await settle();
 
     expect(invokeSpy.mock.calls.length).toBeGreaterThan(1);
     expect(s.sessionAutoSavePath).toBeNull();
@@ -183,5 +271,294 @@ describe("useSerialAutoSave", () => {
         AUTO_SAVE_FLUSH_MAX_CHARS * 2,
       );
     }
+  });
+
+  it("drains the whole backlog within one periodic tick", async () => {
+    const s = useSerialDebugStore();
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    app = createApp(
+      defineComponent({
+        setup() {
+          useSerialAutoSave(s);
+          return () => null;
+        },
+      }),
+    );
+    app.mount(host);
+
+    s.port = "/dev/ttyUSB0";
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    s.open = true;
+    await nextTick();
+
+    invokeSpy.mockResolvedValue(undefined);
+    feedBacklog(s, BACKLOG_LINES_PER_APPEND * 5 + 10);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await flushMicrotasks();
+
+    // A single append per tick would leave most of this behind forever.
+    expect(invokeSpy.mock.calls.length).toBeGreaterThanOrEqual(5);
+    expect(s.drainPendingAutoSaveLines(Infinity)).toEqual([]);
+  });
+
+  it("stops after the per-tick append cap and resumes on the next tick", async () => {
+    const s = useSerialDebugStore();
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    app = createApp(
+      defineComponent({
+        setup() {
+          useSerialAutoSave(s);
+          return () => null;
+        },
+      }),
+    );
+    app.mount(host);
+
+    s.port = "/dev/ttyUSB0";
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    s.open = true;
+    await nextTick();
+
+    invokeSpy.mockResolvedValue(undefined);
+    feedBacklog(s, BACKLOG_LINES_PER_APPEND * 20);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await flushMicrotasks();
+
+    // 20 batches of backlog, capped at 16 appends for this tick.
+    const firstTickAppends = invokeSpy.mock.calls.length;
+    expect(firstTickAppends).toBe(16);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await flushMicrotasks();
+
+    expect(invokeSpy.mock.calls.length).toBeGreaterThan(firstTickAppends);
+    expect(s.drainPendingAutoSaveLines(Infinity)).toEqual([]);
+  });
+
+  it("backfills the session archive when auto-save is enabled mid-session", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+
+    s.port = "/dev/ttyUSB0";
+    s.open = true;
+    await nextTick();
+    expect(s.sessionAutoSavePath).toBeNull();
+
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 1000,
+      bytes: [...Buffer.from("before-1\n")],
+    });
+    // The leak fix means these lines were never held in memory — the archive is
+    // the only place they can be recovered from.
+    expect(s.drainPendingAutoSaveLines(Infinity)).toEqual([]);
+
+    sessionPageHandler = archivePages([
+      { lineNo: 1, tsMs: 1000, direction: "rx", text: "before-1" },
+      { lineNo: 2, tsMs: 1001, direction: "tx", text: "before-2" },
+      { lineNo: 3, tsMs: 1002, direction: "sys", text: "before-3" },
+    ]);
+    invokeSpy.mockResolvedValue(undefined);
+
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    await nextTick();
+    await settle();
+
+    expect(s.sessionAutoSavePath).not.toBeNull();
+    expect(invokeSpy).toHaveBeenCalledTimes(1);
+    expect(invokeSpy).toHaveBeenCalledWith("append_text_file", {
+      path: s.sessionAutoSavePath,
+      content:
+        `[${formatTs(1000)}] [RX ] before-1\n` +
+        `[${formatTs(1001)}] [TX ] before-2\n` +
+        `[${formatTs(1002)}] [SYS] before-3\n`,
+    });
+  });
+
+  it("writes backfilled and live lines in the same format, oldest first", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+
+    s.port = "/dev/ttyUSB0";
+    // The format switch must apply to both halves of the file, not just live.
+    s.autoSaveTimestamp = false;
+    s.open = true;
+    await nextTick();
+
+    sessionPageHandler = archivePages([
+      { lineNo: 1, tsMs: 1000, direction: "rx", text: "old" },
+    ]);
+    invokeSpy.mockResolvedValue(undefined);
+
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    await nextTick();
+    await settle();
+
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 2000,
+      bytes: [...Buffer.from("new\n")],
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    expect(writtenContents()).toEqual(["old\n", "new\n"]);
+  });
+
+  // The archive stores the cap notice as a sentinel so the wording can come from
+  // the i18n catalogue; the saved file must contain the translation, never the
+  // marker. Both halves of the file are checked — the pre-enable backfill and
+  // the live queue.
+  it("translates the archive cap sentinel on both the backfill and the live route", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+
+    // Mirrors serial_debug_archive_cap_sentinel in
+    // crates/tyutool-core/src/serial_debug.rs.
+    const SOH = String.fromCharCode(1);
+    const sentinel = `${SOH}tyutool:archive-capped:128${SOH}`;
+
+    s.port = "/dev/ttyUSB0";
+    s.open = true;
+    await nextTick();
+
+    sessionPageHandler = archivePages([
+      { lineNo: 1, tsMs: 1000, direction: "sys", text: sentinel },
+    ]);
+    invokeSpy.mockResolvedValue(undefined);
+
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    await nextTick();
+    await settle();
+
+    await s.appendSysLine(sentinel);
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    const contents = writtenContents();
+    expect(contents).toHaveLength(2);
+    for (const content of contents) {
+      expect(content).not.toContain(SOH);
+      expect(content).not.toContain("archive-capped");
+      expect(content).toContain("128 MiB");
+    }
+  });
+
+  it("pages the backfill and stops at the snapshot taken when auto-save started", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+
+    s.port = "/dev/ttyUSB0";
+    s.open = true;
+    await nextTick();
+
+    const archived: SerialDebugLine[] = Array.from(
+      { length: AUTO_SAVE_BACKFILL_PAGE_SIZE + 250 },
+      (_, i) => ({
+        lineNo: i + 1,
+        tsMs: 1000,
+        direction: "rx" as const,
+        text: `a-${i}`,
+      }),
+    );
+    // totalLines keeps growing while the backfill pages through the archive; the
+    // snapshot from the first page is what caps the backfilled half.
+    sessionPageHandler = archivePages(archived, 100);
+    invokeSpy.mockResolvedValue(undefined);
+
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    await nextTick();
+    await settle();
+
+    const lineCounts = writtenContents().map(
+      (content) => content.trimEnd().split("\n").length,
+    );
+    expect(lineCounts).toEqual([AUTO_SAVE_BACKFILL_PAGE_SIZE, 250]);
+  });
+
+  it("holds live lines back until the backfill has been written", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+
+    s.port = "/dev/ttyUSB0";
+    s.open = true;
+    await nextTick();
+
+    let releasePage: ((page: SerialDebugSessionPage) => void) | null = null;
+    sessionPageHandler = () =>
+      new Promise<SerialDebugSessionPage>((resolve) => {
+        releasePage = resolve;
+      });
+    invokeSpy.mockResolvedValue(undefined);
+
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    await nextTick();
+    await settle();
+
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 2000,
+      bytes: [...Buffer.from("live\n")],
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    // The periodic flush fired but must not overtake the pending backfill.
+    expect(invokeSpy).not.toHaveBeenCalled();
+
+    (releasePage as ((page: SerialDebugSessionPage) => void) | null)?.({
+      totalLines: 1,
+      start: 0,
+      items: [{ lineNo: 1, tsMs: 1000, direction: "rx", text: "old" }],
+    });
+    await settle();
+
+    expect(writtenContents()).toEqual([
+      `[${formatTs(1000)}] [RX ] old\n`,
+      `[${formatTs(2000)}] [RX ] live\n`,
+    ]);
+  });
+
+  it("starts recording normally when there is no session archive", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+
+    // sessionPageHandler defaults to rejecting — port never opened, no archive.
+    s.port = "/dev/ttyUSB0";
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    s.open = true;
+    await nextTick();
+    await settle();
+
+    expect(s.sessionAutoSavePath).not.toBeNull();
+    expect(invokeSpy).not.toHaveBeenCalled();
+    expect(
+      s.lines.some((line) =>
+        line.text.startsWith("serialDebug.autoSave.errWrite"),
+      ),
+    ).toBe(false);
+
+    invokeSpy.mockResolvedValue(undefined);
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 1000,
+      bytes: [...Buffer.from("live\n")],
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    expect(writtenContents()).toEqual([`[${formatTs(1000)}] [RX ] live\n`]);
   });
 });

--- a/src/features/serial-debug/useSerialAutoSave.ts
+++ b/src/features/serial-debug/useSerialAutoSave.ts
@@ -83,38 +83,53 @@ export function useSerialAutoSave(s: SerialDebugStore): void {
    * with nothing draining it). Paged and streamed: one page is read, formatted
    * and appended before the next is requested, so memory stays bounded.
    *
-   * Handoff with the live queue — deliberately "rather duplicate than gap":
-   * `sessionAutoSavePath` is set *before* this runs, so live queuing has
-   * already started when the snapshot (`totalLines` of the first page) is
-   * taken. The backend appends a line to the archive before it emits the chunk
-   * event, so every line the frontend has ever seen is already archived,
-   * therefore inside the snapshot → no gap is possible. The flip side is that
-   * lines archived just before the snapshot but only delivered to the frontend
-   * after the path was set land in both halves and appear twice. That window
-   * is one chunk-batch tick (16 ms in the store) plus one IPC round trip —
-   * a few KiB at 921600 baud, tens of lines at worst.
+   * Handoff with the live queue — neither duplicated nor gapped:
+   * `sessionAutoSavePath` is set *before* this runs, so live queuing has already
+   * started when the snapshot (`totalLines` of the first page) is taken, and the
+   * two halves therefore overlap in time. The overlap is resolved by position,
+   * not by timing: every live line carries the archive position it was written
+   * at (`DebugChunk.archivedBefore`), so the store can discard exactly the
+   * queued lines this backfill already covers — no more, no less. See
+   * `dropBackfilledAutoSaveLines`.
+   *
+   * The discard is handed the number of archive lines this backfill *actually
+   * wrote*, not the snapshot: a page that fails halfway (unreadable archive,
+   * rejected write) then still leaves whatever the live queue holds of the
+   * missing range in the file, instead of discarding it as "already written".
+   * Nothing live can reach the file before the backfill finishes (`flush` awaits
+   * `backfillPromise`), so waiting until then costs no ordering.
    */
   async function backfillFromArchive(path: string): Promise<void> {
     const { invoke } = await import("@tauri-apps/api/core");
     let start = 0;
     let total: number | null = null;
-    while (true) {
-      const limit =
-        total === null
-          ? AUTO_SAVE_BACKFILL_PAGE_SIZE
-          : Math.min(AUTO_SAVE_BACKFILL_PAGE_SIZE, total - start);
-      if (limit <= 0) break;
-      const page = await transport.readSessionPage(start, limit);
-      if (total === null) total = page.totalLines;
-      // Auto-save may have been switched off (or restarted) while the page was
-      // in flight; that file is no longer ours to append to.
-      if (s.sessionAutoSavePath !== path) return;
-      if (page.items.length === 0) break;
-      await invoke("append_text_file", {
-        path,
-        content: formatAutoSaveBlock(page.items),
-      });
-      start += page.items.length;
+    try {
+      while (true) {
+        const limit =
+          total === null
+            ? AUTO_SAVE_BACKFILL_PAGE_SIZE
+            : Math.min(AUTO_SAVE_BACKFILL_PAGE_SIZE, total - start);
+        if (limit <= 0) break;
+        const page = await transport.readSessionPage(start, limit);
+        if (total === null) total = page.totalLines;
+        // Auto-save may have been switched off (or restarted) while the page was
+        // in flight; that file is no longer ours to append to.
+        if (s.sessionAutoSavePath !== path) return;
+        if (page.items.length === 0) break;
+        await invoke("append_text_file", {
+          path,
+          content: formatAutoSaveBlock(page.items),
+        });
+        start += page.items.length;
+      }
+    } finally {
+      // A sys line reaches the live queue before it reaches the archive, so its
+      // position can still be in flight; wait for those answers, or the discard
+      // would have to guess.
+      await s.settleAutoSaveMarkers();
+      if (s.sessionAutoSavePath === path) {
+        s.dropBackfilledAutoSaveLines(start);
+      }
     }
   }
 

--- a/src/features/serial-debug/useSerialAutoSave.ts
+++ b/src/features/serial-debug/useSerialAutoSave.ts
@@ -1,11 +1,22 @@
 import { onActivated, onDeactivated, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import type { useSerialDebugStore } from "@/stores/serial-debug";
-import { AUTO_SAVE_FLUSH_MAX_CHARS } from "./constants";
+import { rLog } from "@/utils/log";
+import {
+  AUTO_SAVE_BACKFILL_PAGE_SIZE,
+  AUTO_SAVE_FLUSH_MAX_APPENDS_PER_TICK,
+  AUTO_SAVE_FLUSH_MAX_CHARS,
+} from "./constants";
+import { serialDebugTransport } from "./transport";
+import type { DebugLogLine } from "./types";
 import { sanitizePortName, makeStamp, formatTs } from "./utils";
+import { localizeArchiveLineText } from "./archive-line-text";
 import { stripAnsi } from "./ansi-parse";
 
 type SerialDebugStore = ReturnType<typeof useSerialDebugStore>;
+
+/** The only fields the auto-save file format needs from a line. */
+type AutoSaveLine = Pick<DebugLogLine, "direction" | "tsMs" | "text">;
 
 /**
  * Drive the periodic flush of the live serial buffer to disk for the
@@ -22,17 +33,88 @@ type SerialDebugStore = ReturnType<typeof useSerialDebugStore>;
  */
 export function useSerialAutoSave(s: SerialDebugStore): void {
   const { t } = useI18n();
+  const transport = serialDebugTransport();
 
   let autoSaveInterval: ReturnType<typeof setInterval> | null = null;
   let flushInFlight = false;
   let currentFlushPromise: Promise<void> | null = null;
   let replayFlushRequested = false;
   let replayFlushDrainAll = false;
+  let backfillPromise: Promise<void> | null = null;
 
   function stopInterval(): void {
     if (autoSaveInterval !== null) {
       clearInterval(autoSaveInterval);
       autoSaveInterval = null;
+    }
+  }
+
+  /**
+   * The auto-save file format. Shared by the live flush and the archive
+   * backfill so that enabling auto-save mid-session cannot produce a file with
+   * two different line formats (the backfilled part and the live part).
+   */
+  function formatAutoSaveBlock(batch: readonly AutoSaveLine[]): string {
+    const withTimestamp = s.autoSaveTimestamp;
+    return (
+      batch
+        .map((l) => {
+          const dir =
+            l.direction === "tx" ? "TX " : l.direction === "rx" ? "RX " : "SYS";
+          // Both halves pass through here — the live queue and the archive
+          // backfill — so the archive-cap sentinel is translated on either
+          // route and never reaches the file verbatim.
+          const text = stripAnsi(localizeArchiveLineText(l.direction, l.text));
+          if (withTimestamp) {
+            return `[${formatTs(l.tsMs)}] [${dir}] ${text}`;
+          }
+          return text;
+        })
+        .join("\n") + "\n"
+    );
+  }
+
+  /**
+   * Write the lines that already existed before auto-save was switched on.
+   *
+   * The complete session lives in the Rust-side archive (`.ndjson` + `.idx`),
+   * which is the only full record — `pendingAutoSaveLines` is deliberately not
+   * filled while no session file exists (it would grow ~11 MiB/min at 921600
+   * with nothing draining it). Paged and streamed: one page is read, formatted
+   * and appended before the next is requested, so memory stays bounded.
+   *
+   * Handoff with the live queue — deliberately "rather duplicate than gap":
+   * `sessionAutoSavePath` is set *before* this runs, so live queuing has
+   * already started when the snapshot (`totalLines` of the first page) is
+   * taken. The backend appends a line to the archive before it emits the chunk
+   * event, so every line the frontend has ever seen is already archived,
+   * therefore inside the snapshot → no gap is possible. The flip side is that
+   * lines archived just before the snapshot but only delivered to the frontend
+   * after the path was set land in both halves and appear twice. That window
+   * is one chunk-batch tick (16 ms in the store) plus one IPC round trip —
+   * a few KiB at 921600 baud, tens of lines at worst.
+   */
+  async function backfillFromArchive(path: string): Promise<void> {
+    const { invoke } = await import("@tauri-apps/api/core");
+    let start = 0;
+    let total: number | null = null;
+    while (true) {
+      const limit =
+        total === null
+          ? AUTO_SAVE_BACKFILL_PAGE_SIZE
+          : Math.min(AUTO_SAVE_BACKFILL_PAGE_SIZE, total - start);
+      if (limit <= 0) break;
+      const page = await transport.readSessionPage(start, limit);
+      if (total === null) total = page.totalLines;
+      // Auto-save may have been switched off (or restarted) while the page was
+      // in flight; that file is no longer ours to append to.
+      if (s.sessionAutoSavePath !== path) return;
+      if (page.items.length === 0) break;
+      await invoke("append_text_file", {
+        path,
+        content: formatAutoSaveBlock(page.items),
+      });
+      start += page.items.length;
     }
   }
 
@@ -48,7 +130,12 @@ export function useSerialAutoSave(s: SerialDebugStore): void {
       flushInFlight = true;
       try {
         const { invoke } = await import("@tauri-apps/api/core");
+        // Ordering guarantee: nothing live may reach the file before the
+        // pre-enable backfill has finished, otherwise the file would read
+        // newest-then-oldest around the handoff.
+        if (backfillPromise) await backfillPromise;
         let keepDraining = drainAll;
+        let appends = 0;
         while (true) {
           const path = s.sessionAutoSavePath;
           if (!path) break;
@@ -58,29 +145,22 @@ export function useSerialAutoSave(s: SerialDebugStore): void {
           );
           if (newLines.length === 0) break;
 
-          const content =
-            newLines
-              .map((l) => {
-                const dir =
-                  l.direction === "tx"
-                    ? "TX "
-                    : l.direction === "rx"
-                      ? "RX "
-                      : "SYS";
-                if (s.autoSaveTimestamp) {
-                  return `[${formatTs(l.tsMs)}] [${dir}] ${stripAnsi(l.text)}`;
-                }
-                return stripAnsi(l.text);
-              })
-              .join("\n") + "\n";
+          await invoke("append_text_file", {
+            path,
+            content: formatAutoSaveBlock(newLines),
+          });
+          appends += 1;
 
-          await invoke("append_text_file", { path, content });
-
+          if (replayFlushRequested) {
+            keepDraining ||= replayFlushDrainAll;
+            replayFlushRequested = false;
+            replayFlushDrainAll = false;
+          }
+          // A periodic flush keeps draining too, otherwise one 128 KiB append
+          // per 5 s tick falls permanently behind a fast port; it just yields
+          // once it has done its share of the work.
           if (keepDraining) continue;
-          if (!replayFlushRequested) break;
-          keepDraining = replayFlushDrainAll;
-          replayFlushRequested = false;
-          replayFlushDrainAll = false;
+          if (appends >= AUTO_SAVE_FLUSH_MAX_APPENDS_PER_TICK) break;
         }
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
@@ -107,11 +187,31 @@ export function useSerialAutoSave(s: SerialDebugStore): void {
 
   function startAutoSave(): void {
     if (!s.autoSave || !s.autoSaveDir) return;
+    // Idempotent: when autoSave, autoSaveDir and open all flip in one tick both
+    // watchers below fire, and Vue runs them in trigger order — so this can be
+    // reached twice for the same session. A second call would start a second
+    // backfill whose bookkeeping races the first one's.
+    if (s.sessionAutoSavePath !== null) return;
     stopInterval();
     const portDir = sanitizePortName(s.port);
     const filename = `serial-debug-${makeStamp()}.txt`;
     // path separator: Tauri on all platforms accepts forward slash
-    s.sessionAutoSavePath = `${s.autoSaveDir}/${portDir}/${filename}`;
+    const path = `${s.autoSaveDir}/${portDir}/${filename}`;
+    s.sessionAutoSavePath = path;
+    backfillPromise = backfillFromArchive(path)
+      .catch((e) => {
+        // No archive yet (port never opened) or an unreadable one must not stop
+        // auto-save: the live half still records from here on. Developer-only
+        // diagnostic — the user has nothing to act on.
+        rLog.warn(
+          `[SerialDebug] auto-save backfill skipped: ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+        );
+      })
+      .finally(() => {
+        backfillPromise = null;
+      });
     autoSaveInterval = setInterval(() => {
       void flush();
     }, 5000);

--- a/src/features/serial-debug/useSerialDebugHistory.ts
+++ b/src/features/serial-debug/useSerialDebugHistory.ts
@@ -1,0 +1,367 @@
+/**
+ * Full-session scrollback for the serial-debug "All" tab.
+ *
+ * The live view is a ring buffer capped at `logWindowLines`; everything older
+ * only exists in the Rust session archive. This composable owns a *second*,
+ * completely separate buffer: a bounded sliding window over that archive,
+ * anchored by archive `lineNo`. The two never mix — archive lines are never
+ * pushed into the live ring (`trimVisibleLines` would eat them off the head on
+ * the next batch anyway), and the live ring is never paged from the archive.
+ *
+ * They are kept apart because the two line streams provably diverge, so
+ * "frontend line index == archive line_no" is not a usable anchor:
+ *
+ *  - a dropped chunk (bounded backend queue) is written to the archive but never
+ *    reaches the frontend, so the archive gains lines the live view never saw;
+ *  - once the archive hits its size cap it stops recording and `totalLines`
+ *    freezes while the live view keeps growing;
+ *  - the archive never contains the still-unterminated trailing line, so it is
+ *    permanently 0-2 lines short of the live view.
+ *
+ * Splicing the two on that assumption would silently show wrong content exactly
+ * in the sessions where scrollback matters most (fast port, long run, dropped
+ * bytes). Switching between them instead makes each mode internally consistent;
+ * the only approximation left is where the viewport lands on the frame the mode
+ * changes, which is a presentation detail the position readout compensates for.
+ *
+ * Because the window is one contiguous `DebugLogLine[]`, every consumer — ASCII
+ * virtualization, the hex byte index, Ctrl+F, the renderer cache eviction — sees
+ * the exact shape a filter tab already hands it and needs no change.
+ */
+import { computed, ref, shallowRef } from "vue";
+import { HISTORY_ENTRY_PAGES, HISTORY_PAGE_SIZE } from "./constants";
+import { localizeArchiveLineText } from "./archive-line-text";
+import { archiveLineToLogLine } from "./utils";
+import type {
+  DebugLogLine,
+  SerialDebugLine,
+  SerialDebugSessionPage,
+} from "./types";
+
+export interface SerialDebugHistoryDeps {
+  /** Reads `[start, start + limit)` of the session archive (0-based `start`). */
+  readSessionPage: (
+    start: number,
+    limit: number,
+  ) => Promise<SerialDebugSessionPage>;
+  /** Store-owned memo handing out a stable display id per archive line number. */
+  archiveLineId: (lineNo: number) => number;
+  /** Upper bound on window size — reuses the `logWindowLines` setting. */
+  historyBudget: () => number;
+  /** Surfaces a read failure to the user; receives the raw error message. */
+  reportError: (message: string) => void;
+}
+
+/** Outcome of one "load older" step, as the scroll compensation needs it. */
+export interface HistoryOlderResult {
+  /** Lines prepended to the head of the window (0 when nothing was added). */
+  prepended: number;
+  /** The window was re-anchored on the archive tail instead of being extended. */
+  reanchored: boolean;
+}
+
+export function useSerialDebugHistory(deps: SerialDebugHistoryDeps) {
+  const historyMode = ref(false);
+  // shallowRef for the same reason the live buffer is one: these arrays hold up
+  // to `logWindowLines` never-mutated objects, and they are always replaced
+  // wholesale here (never spliced in place), so no `triggerRef` is needed.
+  const historyLines = shallowRef<DebugLogLine[]>([]);
+  /** Archive line number of `historyLines[0]`; 0 when the window is empty. */
+  const historyStartLineNo = ref(0);
+  const historyTotalLines = ref(0);
+  const historyLoading = ref(false);
+  const historyAtSessionStart = ref(false);
+  const historyAtArchiveEnd = ref(true);
+  /**
+   * Where to put the viewport on the frame history mode is entered, as an index
+   * into the window. The store produces a line index (pure data); turning it
+   * into a `scrollTop` needs the row height and the hex/ASCII row model, so that
+   * half stays in the component.
+   */
+  const historyEntryOffsetLines = ref(0);
+
+  const historyEndLineNo = computed(() =>
+    historyLines.value.length === 0
+      ? 0
+      : historyStartLineNo.value + historyLines.value.length - 1,
+  );
+
+  // Bumped whenever the window is torn down, so an in-flight read that resolves
+  // after `clear()` (new session, line numbers restart at 1) cannot resurrect a
+  // window anchored in the old session.
+  let generation = 0;
+
+  function budget(): number {
+    return Math.max(deps.historyBudget(), HISTORY_PAGE_SIZE);
+  }
+
+  function toDisplayLines(items: readonly SerialDebugLine[]): DebugLogLine[] {
+    return items.map((line) =>
+      archiveLineToLogLine(
+        { ...line, text: localizeArchiveLineText(line.direction, line.text) },
+        deps.archiveLineId(line.lineNo),
+      ),
+    );
+  }
+
+  /**
+   * Reads a range in `HISTORY_PAGE_SIZE` pieces. One big request would hold the
+   * Rust-side archive lock for the whole range (the `limit` is unbounded on
+   * every layer), which at a fast baud rate is a visible write stall.
+   */
+  async function readRange(
+    start: number,
+    limit: number,
+  ): Promise<{ items: SerialDebugLine[]; totalLines: number }> {
+    const items: SerialDebugLine[] = [];
+    let totalLines = 0;
+    while (items.length < limit) {
+      const page = await deps.readSessionPage(
+        start + items.length,
+        Math.min(HISTORY_PAGE_SIZE, limit - items.length),
+      );
+      totalLines = page.totalLines;
+      if (page.items.length === 0) break;
+      items.push(...page.items);
+    }
+    return { items, totalLines };
+  }
+
+  function applyWindow(
+    items: readonly SerialDebugLine[],
+    totalLines: number,
+    atArchiveEnd: boolean,
+  ): void {
+    historyLines.value = toDisplayLines(items);
+    historyStartLineNo.value = items[0].lineNo;
+    historyTotalLines.value = totalLines;
+    // `page.start` is useless for this: an out-of-range `start` is silently
+    // clamped and the clamped value is what comes back. The line numbers are
+    // the only thing that says where we actually are.
+    historyAtSessionStart.value = items[0].lineNo === 1;
+    historyAtArchiveEnd.value = atArchiveEnd;
+  }
+
+  /** Loads the last `HISTORY_ENTRY_PAGES` pages of the archive into the window. */
+  async function loadTailWindow(): Promise<boolean> {
+    // One cheap read just to learn `totalLines`; the range read follows.
+    const probe = await deps.readSessionPage(0, 1);
+    const total = probe.totalLines;
+    historyTotalLines.value = total;
+    if (total === 0) return false;
+    const want = Math.min(
+      HISTORY_PAGE_SIZE * HISTORY_ENTRY_PAGES,
+      total,
+      budget(),
+    );
+    const { items, totalLines } = await readRange(total - want, want);
+    if (items.length === 0) return false;
+    // Deliberately `true` even if the archive grew during the reads: the window
+    // ends where the archive ended when the user asked for it, and "scroll back
+    // down to leave history mode" must stay reachable on a live port.
+    applyWindow(items, Math.max(totalLines, total), true);
+    return true;
+  }
+
+  function fail(e: unknown): void {
+    exitHistoryMode();
+    deps.reportError(e instanceof Error ? e.message : String(e));
+  }
+
+  /**
+   * @param liveLineCount how many lines the live buffer currently holds; the
+   * window is positioned so the viewport starts roughly where the live buffer
+   * did, i.e. `windowLength - liveLineCount` lines from its head.
+   */
+  async function enterHistoryMode(liveLineCount: number): Promise<boolean> {
+    if (historyMode.value || historyLoading.value) return false;
+    const gen = generation;
+    historyLoading.value = true;
+    try {
+      const ok = await loadTailWindow();
+      if (gen !== generation || !ok) return false;
+      const windowLength = historyLines.value.length;
+      historyEntryOffsetLines.value = Math.min(
+        Math.max(windowLength - liveLineCount, 0),
+        Math.max(windowLength - 1, 0),
+      );
+      historyMode.value = true;
+      return true;
+    } catch (e) {
+      fail(e);
+      return false;
+    } finally {
+      historyLoading.value = false;
+    }
+  }
+
+  async function loadOlderHistory(): Promise<HistoryOlderResult> {
+    const none: HistoryOlderResult = { prepended: 0, reanchored: false };
+    if (
+      !historyMode.value ||
+      historyLoading.value ||
+      historyAtSessionStart.value
+    ) {
+      return none;
+    }
+    const firstLineNo = historyStartLineNo.value;
+    const want = Math.min(HISTORY_PAGE_SIZE, firstLineNo - 1);
+    if (want <= 0) {
+      historyAtSessionStart.value = true;
+      return none;
+    }
+    const gen = generation;
+    historyLoading.value = true;
+    try {
+      const page = await deps.readSessionPage(firstLineNo - 1 - want, want);
+      if (gen !== generation) return none;
+      historyTotalLines.value = Math.max(
+        page.totalLines,
+        historyTotalLines.value,
+      );
+      const items = page.items;
+      if (items.length === 0) {
+        historyAtSessionStart.value = true;
+        return none;
+      }
+      // Continuity self-check. Today the archive never renumbers (`stopWriting`
+      // when full, never `dropOldest`), so this cannot fire; keeping it means a
+      // future head-dropping policy degrades this feature to "re-anchors once"
+      // rather than "silently shows the wrong lines".
+      if (items[items.length - 1].lineNo !== firstLineNo - 1) {
+        const ok = await loadTailWindow();
+        if (gen !== generation) return none;
+        if (!ok) exitHistoryMode();
+        return { prepended: 0, reanchored: ok };
+      }
+      const merged = [...toDisplayLines(items), ...historyLines.value];
+      const max = budget();
+      if (merged.length > max) {
+        // Trim the *tail*: it sits below the viewport, so dropping it shortens
+        // contentHeight without moving anything the user is looking at. Trimming
+        // the head would need its own scroll compensation.
+        merged.length = max;
+        historyAtArchiveEnd.value = false;
+      }
+      historyLines.value = merged;
+      historyStartLineNo.value = items[0].lineNo;
+      historyAtSessionStart.value = items[0].lineNo === 1;
+      return { prepended: items.length, reanchored: false };
+    } catch (e) {
+      fail(e);
+      return none;
+    } finally {
+      historyLoading.value = false;
+    }
+  }
+
+  /**
+   * Extends the window forwards. Returns how many lines were dropped off the
+   * *head* to stay within budget — the only part of the change that moves what
+   * is above the viewport, so it is what the scroll compensation needs.
+   */
+  async function loadNewerHistory(): Promise<number> {
+    if (
+      !historyMode.value ||
+      historyLoading.value ||
+      historyAtArchiveEnd.value
+    ) {
+      return 0;
+    }
+    const lastLineNo = historyEndLineNo.value;
+    if (lastLineNo === 0) return 0;
+    const gen = generation;
+    historyLoading.value = true;
+    try {
+      // `lastLineNo` as a 0-based offset is the line right after the window.
+      const page = await deps.readSessionPage(lastLineNo, HISTORY_PAGE_SIZE);
+      if (gen !== generation) return 0;
+      historyTotalLines.value = Math.max(
+        page.totalLines,
+        historyTotalLines.value,
+      );
+      const items = page.items;
+      if (items.length === 0) {
+        historyAtArchiveEnd.value = true;
+        return 0;
+      }
+      if (items[0].lineNo !== lastLineNo + 1) {
+        const ok = await loadTailWindow();
+        if (gen === generation && !ok) exitHistoryMode();
+        return 0;
+      }
+      const merged = [...historyLines.value, ...toDisplayLines(items)];
+      const dropped = Math.max(0, merged.length - budget());
+      if (dropped > 0) {
+        merged.splice(0, dropped);
+        historyAtSessionStart.value = false;
+      }
+      historyLines.value = merged;
+      historyStartLineNo.value += dropped;
+      // A short page means the archive was exhausted at read time. Checking that
+      // as well as the line number matters on a live port, where `totalLines`
+      // keeps moving and the second test alone would never become true — leaving
+      // "scroll back down to return to live" permanently out of reach.
+      historyAtArchiveEnd.value =
+        items.length < HISTORY_PAGE_SIZE ||
+        items[items.length - 1].lineNo >= historyTotalLines.value;
+      return dropped;
+    } catch (e) {
+      fail(e);
+      return 0;
+    } finally {
+      historyLoading.value = false;
+    }
+  }
+
+  async function jumpToSessionStart(): Promise<boolean> {
+    if (!historyMode.value || historyLoading.value) return false;
+    const gen = generation;
+    historyLoading.value = true;
+    try {
+      const want = Math.min(HISTORY_PAGE_SIZE * HISTORY_ENTRY_PAGES, budget());
+      const { items, totalLines } = await readRange(0, want);
+      if (gen !== generation) return false;
+      if (items.length === 0) return false;
+      applyWindow(
+        items,
+        totalLines,
+        items[items.length - 1].lineNo >= totalLines,
+      );
+      return true;
+    } catch (e) {
+      fail(e);
+      return false;
+    } finally {
+      historyLoading.value = false;
+    }
+  }
+
+  function exitHistoryMode(): void {
+    generation += 1;
+    historyMode.value = false;
+    historyLines.value = [];
+    historyStartLineNo.value = 0;
+    historyTotalLines.value = 0;
+    historyAtSessionStart.value = false;
+    historyAtArchiveEnd.value = true;
+    historyEntryOffsetLines.value = 0;
+  }
+
+  return {
+    historyMode,
+    historyLines,
+    historyStartLineNo,
+    historyEndLineNo,
+    historyTotalLines,
+    historyLoading,
+    historyAtSessionStart,
+    historyAtArchiveEnd,
+    historyEntryOffsetLines,
+    enterHistoryMode,
+    loadOlderHistory,
+    loadNewerHistory,
+    jumpToSessionStart,
+    exitHistoryMode,
+  };
+}

--- a/src/features/settings/SettingsPage.vue
+++ b/src/features/settings/SettingsPage.vue
@@ -4,6 +4,10 @@ import { useI18n } from "vue-i18n";
 import { APP_VERSION } from "@/config/app";
 import { useSettingsStore, resolveLocale } from "@/stores/settings";
 import { useSerialDebugStore } from "@/stores/serial-debug";
+import {
+  ARCHIVE_LIMIT_PRESETS,
+  VISIBLE_LOG_WINDOW_PRESETS,
+} from "@/features/serial-debug/constants";
 import type {
   AutoUpdateIntervalId,
   LogLevelId,
@@ -49,6 +53,34 @@ const autoUpdateIntervalOptions = computed<TySelectOption[]>(() => [
   { value: "12h", label: t("settings.autoUpdate12h") },
   { value: "24h", label: t("settings.autoUpdate24h") },
 ]);
+
+const logWindowOptions = computed<TySelectOption[]>(() =>
+  VISIBLE_LOG_WINDOW_PRESETS.map((lines) => ({
+    value: String(lines),
+    label: t("serialDebug.logWindow.lines", { count: lines }),
+  })),
+);
+
+const logWindowValue = computed({
+  get: () => String(sd.logWindowLines),
+  set: (val: string) => {
+    sd.logWindowLines = Number(val);
+  },
+});
+
+const archiveLimitOptions = computed<TySelectOption[]>(() =>
+  ARCHIVE_LIMIT_PRESETS.map((mib) => ({
+    value: String(mib),
+    label: t("serialDebug.archiveLimit.size", { mib }),
+  })),
+);
+
+const archiveLimitValue = computed({
+  get: () => String(sd.archiveLimitMib),
+  set: (val: string) => {
+    sd.archiveLimitMib = Number(val);
+  },
+});
 
 const localeValue = computed({
   get: () => settings.locale,
@@ -506,6 +538,46 @@ function resetBatchAuthDisclaimer(): void {
           <TySwitch
             v-model="sd.autoSaveTimestamp"
             :aria-label="t('serialDebug.autoSave.timestamp')"
+          />
+        </div>
+        <div class="settings-row">
+          <div class="settings-row__copy">
+            <span class="settings-row__title">{{
+              t("serialDebug.logWindow.label")
+            }}</span>
+            <p class="settings-row__hint">
+              {{ t("serialDebug.logWindow.hint") }}
+            </p>
+          </div>
+          <TySelect
+            id="settings-serial-log-window"
+            v-model="logWindowValue"
+            :options="logWindowOptions"
+            :placeholder="
+              t('serialDebug.logWindow.lines', { count: sd.logWindowLines })
+            "
+            class="settings-row__control settings-row__control--select"
+            style="height: 2.5rem"
+          />
+        </div>
+        <div class="settings-row">
+          <div class="settings-row__copy">
+            <span class="settings-row__title">{{
+              t("serialDebug.archiveLimit.label")
+            }}</span>
+            <p class="settings-row__hint">
+              {{ t("serialDebug.archiveLimit.hint") }}
+            </p>
+          </div>
+          <TySelect
+            id="settings-serial-archive-limit"
+            v-model="archiveLimitValue"
+            :options="archiveLimitOptions"
+            :placeholder="
+              t('serialDebug.archiveLimit.size', { mib: sd.archiveLimitMib })
+            "
+            class="settings-row__control settings-row__control--select"
+            style="height: 2.5rem"
           />
         </div>
       </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -546,6 +546,7 @@
     },
     "log": {
       "archiveCapped": "[tyutool] The session archive reached its {mib} MiB limit. Lines from here on are shown live but not archived, so history, filters and export stop at this point.",
+      "chunksDropped": "[tyutool] {bytes} bytes of device output were lost here: tyutool could not keep up with the port. The lines before and after this notice are not continuous. Lower the baud rate or reduce device-side logging.",
       "waitingData": "Waiting for data…",
       "title": "Log",
       "pausedScroll": "Scroll to bottom",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -542,7 +542,9 @@
       "next": "Next",
       "close": "Close",
       "count": "{current} / {total}",
-      "noMatch": "No matches"
+      "noMatch": "No matches",
+      "scopeHistory": "Loaded history window only",
+      "wholeSession": "Search whole session"
     },
     "log": {
       "archiveCapped": "[tyutool] The session archive reached its {mib} MiB limit. Lines from here on are shown live but not archived, so history, filters and export stop at this point.",
@@ -559,6 +561,14 @@
       "saveLog": "Save log",
       "loadOlderMatches": "Load older matches",
       "loadingOlderMatches": "Loading…",
+      "historyBanner": "Session history",
+      "historyPosition": "Lines {from}–{to} of {total}",
+      "loadOlderLines": "Load older lines",
+      "loadingOlderLines": "Loading…",
+      "atSessionStart": "Start of session",
+      "jumpToSessionStart": "Jump to start",
+      "backToLive": "Back to live",
+      "historyLoadFailed": "Could not read the session archive: {msg}",
       "fontDecrease": "Smaller",
       "fontIncrease": "Larger",
       "fontSize": "Font",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -545,6 +545,7 @@
       "noMatch": "No matches"
     },
     "log": {
+      "archiveCapped": "[tyutool] The session archive reached its {mib} MiB limit. Lines from here on are shown live but not archived, so history, filters and export stop at this point.",
       "waitingData": "Waiting for data…",
       "title": "Log",
       "pausedScroll": "Scroll to bottom",
@@ -576,6 +577,16 @@
       "timestamp": "Include timestamp per line",
       "timestampFmtOn": "[12:00:00.000] [RX] [data]",
       "timestampFmtOff": "[RX] [data]"
+    },
+    "logWindow": {
+      "label": "Visible log line limit",
+      "hint": "Oldest lines are dropped past this limit; auto-saved files are unaffected",
+      "lines": "{count} lines"
+    },
+    "archiveLimit": {
+      "label": "Session archive size limit",
+      "hint": "Once the session archive reaches this size it stops recording; what was already captured is kept. History, filters and export stop there — auto-saved files are unaffected",
+      "size": "{mib} MiB"
     },
     "hexPopup": {
       "titleHex": "Hex view",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -542,7 +542,9 @@
       "next": "下一个",
       "close": "关闭",
       "count": "{current} / {total}",
-      "noMatch": "无匹配"
+      "noMatch": "无匹配",
+      "scopeHistory": "仅搜索已加载的历史窗口",
+      "wholeSession": "搜索整个会话"
     },
     "log": {
       "archiveCapped": "[tyutool] 会话归档已达到 {mib} MiB 上限，之后的日志仅实时显示、不再归档，历史、筛选和导出到此为止。",
@@ -559,6 +561,14 @@
       "saveLog": "保存日志",
       "loadOlderMatches": "加载更早匹配",
       "loadingOlderMatches": "加载中…",
+      "historyBanner": "会话历史",
+      "historyPosition": "第 {from} – {to} 行 / 共 {total} 行",
+      "loadOlderLines": "加载更早的日志",
+      "loadingOlderLines": "加载中…",
+      "atSessionStart": "已到会话开头",
+      "jumpToSessionStart": "跳到会话开头",
+      "backToLive": "回到实时",
+      "historyLoadFailed": "读取会话归档失败：{msg}",
       "fontDecrease": "缩小字体",
       "fontIncrease": "放大字体",
       "fontSize": "字体",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -546,6 +546,7 @@
     },
     "log": {
       "archiveCapped": "[tyutool] 会话归档已达到 {mib} MiB 上限，之后的日志仅实时显示、不再归档，历史、筛选和导出到此为止。",
+      "chunksDropped": "[tyutool] 此处丢失了 {bytes} 字节设备输出：tyutool 处理速度跟不上串口。本行前后的日志并不连续。请降低波特率，或减少设备侧日志输出。",
       "waitingData": "等待数据…",
       "title": "日志",
       "pausedScroll": "滚动到底部",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -545,6 +545,7 @@
       "noMatch": "无匹配"
     },
     "log": {
+      "archiveCapped": "[tyutool] 会话归档已达到 {mib} MiB 上限，之后的日志仅实时显示、不再归档，历史、筛选和导出到此为止。",
       "waitingData": "等待数据…",
       "title": "日志",
       "pausedScroll": "滚动到底部",
@@ -576,6 +577,16 @@
       "timestamp": "每行包含时间戳",
       "timestampFmtOn": "[12:00:00.000] [RX] [数据]",
       "timestampFmtOff": "[RX] [数据]"
+    },
+    "logWindow": {
+      "label": "日志显示行数上限",
+      "hint": "超出后会丢弃最旧的行；自动保存的文件不受影响",
+      "lines": "{count} 行"
+    },
+    "archiveLimit": {
+      "label": "会话归档大小上限",
+      "hint": "会话归档达到该大小后停止记录，已记录的内容保留；历史、筛选和导出到此为止，自动保存的文件不受影响",
+      "size": "{mib} MiB"
     },
     "hexPopup": {
       "titleHex": "十六进制视图",

--- a/src/stores/flash.test.ts
+++ b/src/stores/flash.test.ts
@@ -120,6 +120,7 @@ function makeSerialDebugTransportWithDeferredClose() {
     async readSessionPage() {
       return { totalLines: 0, start: 0, items: [] };
     },
+    async setArchiveLimit() {},
     onChunk() {
       return () => {};
     },
@@ -130,6 +131,9 @@ function makeSerialDebugTransportWithDeferredClose() {
       return () => {};
     },
     onFilterUpdated() {
+      return () => {};
+    },
+    onArchiveCapped() {
       return () => {};
     },
   };

--- a/src/stores/flash.test.ts
+++ b/src/stores/flash.test.ts
@@ -109,7 +109,9 @@ function makeSerialDebugTransportWithDeferredClose() {
     },
     async send() {},
     async clearSession() {},
-    async appendSysLine() {},
+    async appendSysLine() {
+      return null;
+    },
     async addFilter() {
       throw new Error("not implemented");
     },

--- a/src/stores/serial-debug-workspace.test.ts
+++ b/src/stores/serial-debug-workspace.test.ts
@@ -4,6 +4,14 @@ import {
   SD_WORKSPACE_VERSION,
   type SerialDebugWorkspaceSerialized,
 } from "./serial-debug-workspace";
+import {
+  DEFAULT_ARCHIVE_LIMIT_MIB,
+  DEFAULT_VISIBLE_LOG_WINDOW_LINES,
+  MAX_ARCHIVE_LIMIT_MIB,
+  MAX_VISIBLE_LOG_WINDOW_LINES,
+  MIN_ARCHIVE_LIMIT_MIB,
+  MIN_VISIBLE_LOG_WINDOW_LINES,
+} from "@/features/serial-debug/constants";
 
 /** A minimal valid record; callers spread a patch over it. */
 function base(): SerialDebugWorkspaceSerialized {
@@ -131,6 +139,64 @@ describe("parseSerialDebugWorkspace", () => {
     expect(w!.ansiEnabled).toBeUndefined();
     expect(w!.autoSave).toBeUndefined();
     expect(w!.autoSaveDir).toBeUndefined();
+  });
+
+  it("falls back to the default logWindowLines when absent or invalid", () => {
+    expect(parseSerialDebugWorkspace(base())!.logWindowLines).toBe(
+      DEFAULT_VISIBLE_LOG_WINDOW_LINES,
+    );
+    expect(
+      parseSerialDebugWorkspace({ ...base(), logWindowLines: "lots" })!
+        .logWindowLines,
+    ).toBe(DEFAULT_VISIBLE_LOG_WINDOW_LINES);
+    expect(
+      parseSerialDebugWorkspace({ ...base(), logWindowLines: Infinity })!
+        .logWindowLines,
+    ).toBe(DEFAULT_VISIBLE_LOG_WINDOW_LINES);
+  });
+
+  it("clamps an out-of-range logWindowLines into [MIN, MAX]", () => {
+    expect(
+      parseSerialDebugWorkspace({ ...base(), logWindowLines: 1 })!
+        .logWindowLines,
+    ).toBe(MIN_VISIBLE_LOG_WINDOW_LINES);
+    expect(
+      parseSerialDebugWorkspace({ ...base(), logWindowLines: 999999 })!
+        .logWindowLines,
+    ).toBe(MAX_VISIBLE_LOG_WINDOW_LINES);
+    expect(
+      parseSerialDebugWorkspace({ ...base(), logWindowLines: 3000 })!
+        .logWindowLines,
+    ).toBe(3000);
+  });
+
+  it("falls back to the default archiveLimitMib when absent or invalid", () => {
+    expect(parseSerialDebugWorkspace(base())!.archiveLimitMib).toBe(
+      DEFAULT_ARCHIVE_LIMIT_MIB,
+    );
+    expect(
+      parseSerialDebugWorkspace({ ...base(), archiveLimitMib: "big" })!
+        .archiveLimitMib,
+    ).toBe(DEFAULT_ARCHIVE_LIMIT_MIB);
+    expect(
+      parseSerialDebugWorkspace({ ...base(), archiveLimitMib: Infinity })!
+        .archiveLimitMib,
+    ).toBe(DEFAULT_ARCHIVE_LIMIT_MIB);
+  });
+
+  it("clamps an out-of-range archiveLimitMib into [MIN, MAX]", () => {
+    expect(
+      parseSerialDebugWorkspace({ ...base(), archiveLimitMib: 0 })!
+        .archiveLimitMib,
+    ).toBe(MIN_ARCHIVE_LIMIT_MIB);
+    expect(
+      parseSerialDebugWorkspace({ ...base(), archiveLimitMib: 999999 })!
+        .archiveLimitMib,
+    ).toBe(MAX_ARCHIVE_LIMIT_MIB);
+    expect(
+      parseSerialDebugWorkspace({ ...base(), archiveLimitMib: 512 })!
+        .archiveLimitMib,
+    ).toBe(512);
   });
 
   it("rejects a negative or non-finite customBaudRate", () => {

--- a/src/stores/serial-debug-workspace.ts
+++ b/src/stores/serial-debug-workspace.ts
@@ -7,11 +7,17 @@ import type {
 } from "@/features/serial-debug/types";
 import {
   COMMON_BAUD_RATES,
+  DEFAULT_ARCHIVE_LIMIT_MIB,
   DEFAULT_DATA_BITS,
   DEFAULT_HEX_BYTES_PER_ROW,
   DEFAULT_PARITY,
   DEFAULT_STOP_BITS,
+  DEFAULT_VISIBLE_LOG_WINDOW_LINES,
+  MAX_ARCHIVE_LIMIT_MIB,
   MAX_SEND_HISTORY,
+  MAX_VISIBLE_LOG_WINDOW_LINES,
+  MIN_ARCHIVE_LIMIT_MIB,
+  MIN_VISIBLE_LOG_WINDOW_LINES,
 } from "@/features/serial-debug/constants";
 import { isTauriRuntime } from "@/runtime";
 
@@ -53,6 +59,8 @@ export interface SerialDebugWorkspaceSerialized {
   sendHistory: string[];
   ansiEnabled?: boolean;
   logFontSize?: number;
+  logWindowLines?: number;
+  archiveLimitMib?: number;
   autoSave?: boolean;
   autoSaveDir?: string;
   autoSaveTimestamp?: boolean;
@@ -121,6 +129,22 @@ export function parseSerialDebugWorkspace(
       ? n
       : 12;
   })();
+  const logWindowLines = (() => {
+    const n = numOrNull(r.logWindowLines);
+    if (n === null) return DEFAULT_VISIBLE_LOG_WINDOW_LINES;
+    return Math.min(
+      MAX_VISIBLE_LOG_WINDOW_LINES,
+      Math.max(MIN_VISIBLE_LOG_WINDOW_LINES, Math.round(n)),
+    );
+  })();
+  const archiveLimitMib = (() => {
+    const n = numOrNull(r.archiveLimitMib);
+    if (n === null) return DEFAULT_ARCHIVE_LIMIT_MIB;
+    return Math.min(
+      MAX_ARCHIVE_LIMIT_MIB,
+      Math.max(MIN_ARCHIVE_LIMIT_MIB, Math.round(n)),
+    );
+  })();
 
   // Send history: must be an array of strings; cap length + drop non-strings.
   const sendHistory: string[] = Array.isArray(r.sendHistory)
@@ -146,6 +170,8 @@ export function parseSerialDebugWorkspace(
     ansiEnabled:
       r.ansiEnabled === undefined ? undefined : bool(r.ansiEnabled, true),
     logFontSize,
+    logWindowLines,
+    archiveLimitMib,
     autoSave: r.autoSave === undefined ? undefined : bool(r.autoSave),
     autoSaveDir: r.autoSaveDir === undefined ? undefined : str(r.autoSaveDir),
     autoSaveTimestamp:

--- a/src/stores/serial-debug.test.ts
+++ b/src/stores/serial-debug.test.ts
@@ -113,6 +113,9 @@ function fakeTransport(): SerialDebugTransport & {
     async clearSession() {},
     async appendSysLine(_tsMs, text) {
       sysLineWrites.push(text);
+      // No archive position: the store must then treat the line as one the
+      // archive never took, i.e. never discard it during an auto-save handoff.
+      return null;
     },
     async addFilter(keyword, useRegex, color) {
       const id = `filter-${nextFilterId++}`;
@@ -427,6 +430,67 @@ describe("useSerialDebugStore.appendChunk", () => {
       s.drainPendingAutoSaveLines(Infinity).map((line) => line.text),
     ).toEqual(["after-enable"]);
   });
+
+  it("discards exactly the queued lines the backfill already covered", () => {
+    const s = useSerialDebugStore();
+    s.sessionAutoSavePath = "/logs/COM1/serial-debug.txt";
+
+    // Archived as line 3 → inside a backfill that stopped at line 3.
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 1000,
+      bytes: [...Buffer.from("backfilled\n")],
+      archivedBefore: 2,
+    });
+    // Archived as line 4 → after the backfill, the live half's job.
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 1001,
+      bytes: [...Buffer.from("live\n")],
+      archivedBefore: 3,
+    });
+    // No position at all → never in the archive, so never discarded.
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 1002,
+      bytes: [...Buffer.from("unarchived\n")],
+    });
+
+    s.dropBackfilledAutoSaveLines(3);
+
+    expect(
+      s.drainPendingAutoSaveLines(Infinity).map((line) => line.text),
+    ).toEqual(["live", "unarchived"]);
+
+    // The event for a line archived before the snapshot can still be delivered
+    // after the discard pass; the same predicate has to catch it at enqueue.
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 1003,
+      bytes: [...Buffer.from("late\n")],
+      archivedBefore: 1,
+    });
+    expect(s.drainPendingAutoSaveLines(Infinity)).toEqual([]);
+  });
+
+  it("stops discarding once a session clear has renumbered the archive", async () => {
+    const s = useSerialDebugStore();
+    s.sessionAutoSavePath = "/logs/COM1/serial-debug.txt";
+    s.dropBackfilledAutoSaveLines(5);
+    await s.clear();
+
+    // The new session numbers from 1 again, so the old watermark would swallow
+    // every line of it.
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 2000,
+      bytes: [...Buffer.from("fresh\n")],
+      archivedBefore: 0,
+    });
+    expect(
+      s.drainPendingAutoSaveLines(Infinity).map((line) => line.text),
+    ).toEqual(["fresh"]);
+  });
 });
 
 describe("useSerialDebugStore.send", () => {
@@ -717,6 +781,74 @@ describe("useSerialDebugStore port-manager integration", () => {
       fake.emitChunksDropped(4096);
 
       expect(s.lines.length).toBe(before);
+    });
+  });
+
+  // Closing the port is the last moment the live view can catch up with what the
+  // device actually sent — nothing arrives after it, and nothing else ever cuts
+  // an unterminated line.
+  describe("closing the port", () => {
+    async function openedStore() {
+      const s = useSerialDebugStore();
+      s.port = "/dev/ttyUSB0";
+      s.baudRate = 115200;
+      await s.openPort();
+      return s;
+    }
+
+    it("flushes the chunks still queued in the last coalescing frame", async () => {
+      const s = await openedStore();
+      const before = s.lines.length;
+
+      // Deliberately no waitForChunkFrame(): the close lands *inside* the 16 ms
+      // coalescing window. Rust archived these bytes the moment they arrived, so
+      // discarding the queue here would make the live view disagree with the
+      // export and the auto-save file.
+      fake.emitChunk({
+        direction: "rx",
+        tsMs: 1000,
+        bytes: [...Buffer.from("last-gasp\n")],
+      });
+      await s.closePort();
+
+      const added = s.lines.slice(before).filter((l) => l.direction === "rx");
+      expect(added.map((l) => l.text)).toEqual(["last-gasp"]);
+    });
+
+    it("shows the tail the device never terminated with a newline", async () => {
+      const s = await openedStore();
+      fake.emitChunk({
+        direction: "rx",
+        tsMs: 1000,
+        bytes: [...Buffer.from("boot ok\nlogin: ")],
+      });
+      await waitForChunkFrame();
+      const before = s.lines.length;
+      expect(s.lines[before - 1].text).toBe("boot ok");
+
+      await s.closePort();
+
+      // A prompt, a progress bar, a bootloader banner: no trailing newline, so
+      // only the close path can turn it into a line at all.
+      const added = s.lines.slice(before).filter((l) => l.direction === "rx");
+      expect(added.map((l) => l.text)).toEqual(["login: "]);
+    });
+
+    it("adds no empty line when nothing was left unterminated", async () => {
+      const s = await openedStore();
+      fake.emitChunk({
+        direction: "rx",
+        tsMs: 1000,
+        bytes: [...Buffer.from("complete\n")],
+      });
+      await waitForChunkFrame();
+      const before = s.lines.length;
+
+      await s.closePort();
+
+      expect(s.lines.slice(before).filter((l) => l.direction === "rx")).toEqual(
+        [],
+      );
     });
   });
 
@@ -1396,7 +1528,9 @@ describe("useSerialDebugStore open/close/send lifecycle", () => {
         state.sent.push(b);
       },
       async clearSession() {},
-      async appendSysLine() {},
+      async appendSysLine() {
+        return null;
+      },
       async addFilter(keyword, useRegex, color) {
         return {
           def: { id: "filter-1", keyword, useRegex, color },

--- a/src/stores/serial-debug.test.ts
+++ b/src/stores/serial-debug.test.ts
@@ -13,8 +13,12 @@ import type {
 } from "@/features/serial-debug/types";
 import { useSerialDebugStore } from "./serial-debug";
 import { useFlashStore } from "./flash";
-import { nextTick } from "vue";
-import { MAX_PENDING_LINE_BYTES } from "@/features/serial-debug/constants";
+import { nextTick, watchEffect } from "vue";
+import {
+  DEFAULT_ARCHIVE_LIMIT_MIB,
+  DEFAULT_VISIBLE_LOG_WINDOW_LINES,
+  MAX_PENDING_LINE_BYTES,
+} from "@/features/serial-debug/constants";
 import { AUTH_ONLY_CHIP_ID } from "@/features/firmware-flash/constants";
 
 vi.mock("@/composables/confirmDialog", () => ({
@@ -32,6 +36,7 @@ function fakeTransport(): SerialDebugTransport & {
   emitChunkBatch: (chunks: DebugChunk[]) => void;
   emitDisconnect: (reason: string) => void;
   emitFilterUpdated: (payload: SerialDebugFilterUpdatePayload) => void;
+  emitArchiveCapped: (limitMib: number) => void;
   setFilterPage: (filterId: string, page: SerialDebugFilterPage) => void;
   readFilterMatchesCalls: Array<{
     filterId: string;
@@ -39,6 +44,8 @@ function fakeTransport(): SerialDebugTransport & {
     limit?: number;
   }>;
   sent: Uint8Array[];
+  archiveLimitCalls: number[];
+  sysLineWrites: string[];
   opened: boolean;
 } {
   const chunkListeners = new Set<(c: DebugChunk) => void>();
@@ -47,7 +54,10 @@ function fakeTransport(): SerialDebugTransport & {
   const filterListeners = new Set<
     (p: SerialDebugFilterUpdatePayload) => void
   >();
+  const archiveCappedListeners = new Set<(p: { limitMib: number }) => void>();
   const sent: Uint8Array[] = [];
+  const archiveLimitCalls: number[] = [];
+  const sysLineWrites: string[] = [];
   const readFilterMatchesCalls: Array<{
     filterId: string;
     start?: number;
@@ -65,6 +75,8 @@ function fakeTransport(): SerialDebugTransport & {
   >();
   return {
     sent,
+    archiveLimitCalls,
+    sysLineWrites,
     readFilterMatchesCalls,
     get opened() {
       return opened;
@@ -79,7 +91,9 @@ function fakeTransport(): SerialDebugTransport & {
       sent.push(b);
     },
     async clearSession() {},
-    async appendSysLine() {},
+    async appendSysLine(_tsMs, text) {
+      sysLineWrites.push(text);
+    },
     async addFilter(keyword, useRegex, color) {
       const id = `filter-${nextFilterId++}`;
       const payload: SerialDebugFilterUpdatePayload = {
@@ -121,6 +135,9 @@ function fakeTransport(): SerialDebugTransport & {
         items: [],
       };
     },
+    async setArchiveLimit(maxBytes: number) {
+      archiveLimitCalls.push(maxBytes);
+    },
     onChunk(cb) {
       chunkListeners.add(cb);
       return () => chunkListeners.delete(cb);
@@ -137,6 +154,10 @@ function fakeTransport(): SerialDebugTransport & {
       filterListeners.add(cb);
       return () => filterListeners.delete(cb);
     },
+    onArchiveCapped(cb) {
+      archiveCappedListeners.add(cb);
+      return () => archiveCappedListeners.delete(cb);
+    },
     emitChunk(c) {
       chunkListeners.forEach((l) => l(c));
     },
@@ -148,6 +169,9 @@ function fakeTransport(): SerialDebugTransport & {
     },
     emitFilterUpdated(payload) {
       filterListeners.forEach((l) => l(payload));
+    },
+    emitArchiveCapped(limitMib) {
+      archiveCappedListeners.forEach((l) => l({ limitMib }));
     },
     setFilterPage(filterId, page) {
       const entry = filters.get(filterId);
@@ -221,9 +245,11 @@ describe("useSerialDebugStore.appendChunk", () => {
     const s = useSerialDebugStore();
     // Simulate slightly more than the visible window arriving in one batch.
     const oneLine = "x\n";
-    const bytes = [...Buffer.from(oneLine.repeat(3505))];
+    const bytes = [
+      ...Buffer.from(oneLine.repeat(DEFAULT_VISIBLE_LOG_WINDOW_LINES + 505)),
+    ];
     s.appendChunk({ direction: "rx", tsMs: 1000, bytes });
-    expect(s.lines.length).toBe(3000);
+    expect(s.lines.length).toBe(DEFAULT_VISIBLE_LOG_WINDOW_LINES);
   });
 
   it("each line owns an independent rawBytes copy", () => {
@@ -235,6 +261,48 @@ describe("useSerialDebugStore.appendChunk", () => {
     });
     expect(s.lines.length).toBe(2);
     expect(s.lines[0].rawBytes).not.toBe(s.lines[1].rawBytes);
+  });
+
+  // `lines` is a shallowRef, so every in-place write has to publish itself via
+  // triggerRef. This guards all three writers: append, append-into-a-saturated
+  // window (length does not change), and the trim when the limit is lowered.
+  it("publishes every in-place lines write to reactive readers", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 2;
+    await nextTick();
+
+    const seen: string[] = [];
+    const stop = watchEffect(() => {
+      seen.push(s.lines.map((line) => line.text).join(","));
+    });
+    try {
+      s.appendChunk({
+        direction: "rx",
+        tsMs: 1000,
+        bytes: [...Buffer.from("a\n")],
+      });
+      await nextTick();
+      s.appendChunk({
+        direction: "rx",
+        tsMs: 1001,
+        bytes: [...Buffer.from("b\n")],
+      });
+      await nextTick();
+      // Window is full: the head is dropped for every append, so the array
+      // length stops changing while the content keeps moving.
+      s.appendChunk({
+        direction: "rx",
+        tsMs: 1002,
+        bytes: [...Buffer.from("c\n")],
+      });
+      await nextTick();
+      s.logWindowLines = 1;
+      await nextTick();
+
+      expect(seen).toEqual(["", "a", "a,b", "b,c", "c"]);
+    } finally {
+      stop();
+    }
   });
 
   it("reuses one TextDecoder while processing a chunk batch", () => {
@@ -265,6 +333,7 @@ describe("useSerialDebugStore.appendChunk", () => {
 
   it("drains auto-save lines in bounded lightweight batches", () => {
     const s = useSerialDebugStore();
+    s.sessionAutoSavePath = "/logs/COM1/serial-debug.txt";
     s.appendChunk({
       direction: "rx",
       tsMs: 1000,
@@ -284,6 +353,33 @@ describe("useSerialDebugStore.appendChunk", () => {
     const secondBatch = s.drainPendingAutoSaveLines(1);
     expect(secondBatch).toHaveLength(1);
     expect(secondBatch[0].text).toBe("second");
+  });
+
+  it("does not queue auto-save lines while no session file is active", () => {
+    const s = useSerialDebugStore();
+
+    for (let i = 0; i < 200; i += 1) {
+      s.appendChunk({
+        direction: "rx",
+        tsMs: 1000 + i,
+        bytes: [...Buffer.from(`line-${i}\n`)],
+      });
+    }
+
+    // Nothing drains the backlog while auto-save is off, so it must stay empty
+    // instead of retaining every line for the whole session.
+    expect(s.drainPendingAutoSaveLines(Infinity)).toEqual([]);
+
+    // Enabling auto-save starts capturing from that point on.
+    s.sessionAutoSavePath = "/logs/COM1/serial-debug.txt";
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 2000,
+      bytes: [...Buffer.from("after-enable\n")],
+    });
+    expect(
+      s.drainPendingAutoSaveLines(Infinity).map((line) => line.text),
+    ).toEqual(["after-enable"]);
   });
 });
 
@@ -422,6 +518,61 @@ describe("useSerialDebugStore port-manager integration", () => {
     ]);
   });
 
+  // The live view is fed by the raw chunk stream and never reads the archive,
+  // so the notice the archive wrote into itself can only reach the user through
+  // this event. Without it the log keeps scrolling while archiving has silently
+  // stopped.
+  describe("archive cap notice", () => {
+    // Mirrors serial_debug_archive_cap_sentinel in
+    // crates/tyutool-core/src/serial_debug.rs.
+    const SOH = String.fromCharCode(1);
+
+    it("puts a translated sys line into the live view", async () => {
+      const s = useSerialDebugStore();
+      s.port = "/dev/ttyUSB0";
+      s.baudRate = 115200;
+      await s.openPort();
+      const before = s.lines.length;
+
+      fake.emitArchiveCapped(256);
+
+      const added = s.lines.slice(before);
+      expect(added).toHaveLength(1);
+      expect(added[0].direction).toBe("sys");
+      expect(added[0].text).toContain("256 MiB");
+      // The sentinel is an internal marker — it must never reach the user.
+      expect(added[0].text).not.toContain(SOH);
+      expect(added[0].text).not.toContain("archive-capped");
+    });
+
+    it("does not write the notice back into the archive", async () => {
+      const s = useSerialDebugStore();
+      s.port = "/dev/ttyUSB0";
+      s.baudRate = 115200;
+      await s.openPort();
+      fake.sysLineWrites.length = 0;
+
+      fake.emitArchiveCapped(256);
+
+      // The archive already holds the sentinel; a write-back would record the
+      // same event twice (and be dropped, the archive being capped).
+      expect(fake.sysLineWrites).toEqual([]);
+    });
+
+    it("stops listening once the session is torn down", async () => {
+      const s = useSerialDebugStore();
+      s.port = "/dev/ttyUSB0";
+      s.baudRate = 115200;
+      await s.openPort();
+      await s.closePort();
+      const before = s.lines.length;
+
+      fake.emitArchiveCapped(256);
+
+      expect(s.lines.length).toBe(before);
+    });
+  });
+
   it("reuses one TextDecoder across queued chunks flushed in the same frame", async () => {
     const OriginalTextDecoder = globalThis.TextDecoder;
     let decoderConstructCount = 0;
@@ -507,6 +658,7 @@ describe("useSerialDebugStore port-manager integration", () => {
 
   it("clear() empties lines and pending buffer", async () => {
     const s = useSerialDebugStore();
+    s.sessionAutoSavePath = "/logs/COM1/serial-debug.txt";
     s.appendChunk({
       direction: "rx",
       tsMs: 1000,
@@ -764,7 +916,7 @@ describe("useSerialDebugStore watch chip management", () => {
 
     await s.setActiveChip(id);
 
-    const items = s.activeDisplayLines;
+    const items = s.activeDisplayLines();
     expect(items.map((line) => line.text)).toEqual([
       "ERR alpha",
       "ERR beta",
@@ -775,6 +927,35 @@ describe("useSerialDebugStore watch chip management", () => {
     // single filtered line shown repeatedly).
     expect(new Set(items.map((line) => line.id)).size).toBe(3);
     expect(items.every((line) => Number.isInteger(line.id))).toBe(true);
+  });
+
+  // A filter tab renders straight out of the archive, so it is the one live-view
+  // path that can meet the raw cap sentinel.
+  it("translates the archive cap sentinel in a filter page", async () => {
+    const s = useSerialDebugStore();
+    await s.addChip("tyutool", false);
+    const id = s.watchChips[0].id;
+    const SOH = String.fromCharCode(1);
+    fake.setFilterPage(id, {
+      filterId: id,
+      totalMatches: 1,
+      start: 0,
+      items: [
+        {
+          lineNo: 4,
+          tsMs: 1000,
+          direction: "sys",
+          text: `${SOH}tyutool:archive-capped:512${SOH}`,
+        },
+      ],
+    });
+
+    await s.setActiveChip(id);
+
+    const [line] = s.activeDisplayLines();
+    expect(line.text).toContain("512 MiB");
+    expect(line.text).not.toContain(SOH);
+    expect(line.text).not.toContain("archive-capped");
   });
 
   it("keeps display ids stable when the same filter page is reloaded", async () => {
@@ -792,9 +973,9 @@ describe("useSerialDebugStore watch chip management", () => {
     });
 
     await s.setActiveChip(id);
-    const firstIds = s.activeDisplayLines.map((line) => line.id);
+    const firstIds = s.activeDisplayLines().map((line) => line.id);
     await s.setActiveChip(id);
-    expect(s.activeDisplayLines.map((line) => line.id)).toEqual(firstIds);
+    expect(s.activeDisplayLines().map((line) => line.id)).toEqual(firstIds);
   });
 
   it("does not reuse display ids for archive line numbers of a new session", async () => {
@@ -808,7 +989,7 @@ describe("useSerialDebugStore watch chip management", () => {
       items: [{ lineNo: 1, tsMs: 1000, direction: "rx", text: "ERR old" }],
     });
     await s.setActiveChip(id);
-    const oldId = s.activeDisplayLines[0].id;
+    const oldId = s.activeDisplayLines()[0].id;
 
     await s.clear();
     fake.setFilterPage(id, {
@@ -819,8 +1000,8 @@ describe("useSerialDebugStore watch chip management", () => {
     });
     await s.setActiveChip(id);
 
-    expect(s.activeDisplayLines[0].text).toBe("ERR new");
-    expect(s.activeDisplayLines[0].id).not.toBe(oldId);
+    expect(s.activeDisplayLines()[0].text).toBe("ERR new");
+    expect(s.activeDisplayLines()[0].id).not.toBe(oldId);
   });
 
   it("throttles active filter tail reloads for repeated live updates", async () => {
@@ -1062,6 +1243,7 @@ describe("useSerialDebugStore open/close/send lifecycle", () => {
       async readSessionPage() {
         return { totalLines: 0, start: 0, items: [] };
       },
+      async setArchiveLimit() {},
       onChunk(cb) {
         chunkListeners.add(cb);
         return () => chunkListeners.delete(cb);
@@ -1077,6 +1259,9 @@ describe("useSerialDebugStore open/close/send lifecycle", () => {
       onFilterUpdated(cb) {
         filterListeners.add(cb);
         return () => filterListeners.delete(cb);
+      },
+      onArchiveCapped() {
+        return () => {};
       },
     };
     return {
@@ -1315,5 +1500,96 @@ describe("useSerialDebugStore baud-rate follows flash chip", () => {
     flash.selectedChipId = "esp32";
     await nextTick();
     expect(s.baudRate).toBe(9600);
+  });
+});
+
+describe("useSerialDebugStore visible log window", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  function appendLines(
+    s: ReturnType<typeof useSerialDebugStore>,
+    count: number,
+  ): void {
+    const text =
+      Array.from({ length: count }, (_, i) => `line${i}`).join("\n") + "\n";
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 1000,
+      bytes: [...Buffer.from(text)],
+    });
+  }
+
+  it("defaults the visible window to 5000 lines", () => {
+    const s = useSerialDebugStore();
+    expect(DEFAULT_VISIBLE_LOG_WINDOW_LINES).toBe(5000);
+    expect(s.logWindowLines).toBe(DEFAULT_VISIBLE_LOG_WINDOW_LINES);
+  });
+
+  it("trims already-buffered lines as soon as the limit is lowered", async () => {
+    const s = useSerialDebugStore();
+    appendLines(s, 20);
+    expect(s.lines.length).toBe(20);
+
+    s.logWindowLines = 5;
+    await nextTick();
+
+    expect(s.lines.length).toBe(5);
+    expect(s.lines[0].text).toBe("line15");
+    expect(s.lines[4].text).toBe("line19");
+  });
+
+  it("caps newly appended lines at the configured limit", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 3;
+    await nextTick();
+
+    appendLines(s, 10);
+
+    expect(s.lines.length).toBe(3);
+    expect(s.lines[0].text).toBe("line7");
+    expect(s.lines[2].text).toBe("line9");
+  });
+});
+
+describe("useSerialDebugStore session archive limit", () => {
+  let fake: ReturnType<typeof fakeTransport>;
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    fake = fakeTransport();
+    __setSerialDebugTransportForTest(fake);
+  });
+  afterEach(() => __setSerialDebugTransportForTest(null));
+
+  it("defaults to 256 MiB and pushes nothing until the value changes", () => {
+    const s = useSerialDebugStore();
+    expect(DEFAULT_ARCHIVE_LIMIT_MIB).toBe(256);
+    expect(s.archiveLimitMib).toBe(DEFAULT_ARCHIVE_LIMIT_MIB);
+    expect(fake.archiveLimitCalls).toEqual([]);
+  });
+
+  it("pushes the limit to Rust in bytes whenever it changes", async () => {
+    const s = useSerialDebugStore();
+    s.archiveLimitMib = 512;
+    await nextTick();
+    expect(fake.archiveLimitCalls).toEqual([512 * 1024 * 1024]);
+
+    s.archiveLimitMib = 64;
+    await nextTick();
+    expect(fake.archiveLimitCalls).toEqual([
+      512 * 1024 * 1024,
+      64 * 1024 * 1024,
+    ]);
+  });
+
+  it("swallows a transport failure — the Rust default cap still applies", async () => {
+    const s = useSerialDebugStore();
+    fake.setArchiveLimit = async () => {
+      throw new Error("archive not ready");
+    };
+    s.archiveLimitMib = 128;
+    await expect(nextTick()).resolves.toBeUndefined();
+    expect(s.archiveLimitMib).toBe(128);
   });
 });

--- a/src/stores/serial-debug.test.ts
+++ b/src/stores/serial-debug.test.ts
@@ -37,6 +37,7 @@ function fakeTransport(): SerialDebugTransport & {
   emitDisconnect: (reason: string) => void;
   emitFilterUpdated: (payload: SerialDebugFilterUpdatePayload) => void;
   emitArchiveCapped: (limitMib: number) => void;
+  emitChunksDropped: (droppedBytes: number) => void;
   setFilterPage: (filterId: string, page: SerialDebugFilterPage) => void;
   readFilterMatchesCalls: Array<{
     filterId: string;
@@ -55,6 +56,9 @@ function fakeTransport(): SerialDebugTransport & {
     (p: SerialDebugFilterUpdatePayload) => void
   >();
   const archiveCappedListeners = new Set<(p: { limitMib: number }) => void>();
+  const chunksDroppedListeners = new Set<
+    (p: { droppedBytes: number }) => void
+  >();
   const sent: Uint8Array[] = [];
   const archiveLimitCalls: number[] = [];
   const sysLineWrites: string[] = [];
@@ -158,6 +162,10 @@ function fakeTransport(): SerialDebugTransport & {
       archiveCappedListeners.add(cb);
       return () => archiveCappedListeners.delete(cb);
     },
+    onChunksDropped(cb) {
+      chunksDroppedListeners.add(cb);
+      return () => chunksDroppedListeners.delete(cb);
+    },
     emitChunk(c) {
       chunkListeners.forEach((l) => l(c));
     },
@@ -172,6 +180,9 @@ function fakeTransport(): SerialDebugTransport & {
     },
     emitArchiveCapped(limitMib) {
       archiveCappedListeners.forEach((l) => l({ limitMib }));
+    },
+    emitChunksDropped(droppedBytes) {
+      chunksDroppedListeners.forEach((l) => l({ droppedBytes }));
     },
     setFilterPage(filterId, page) {
       const entry = filters.get(filterId);
@@ -573,6 +584,107 @@ describe("useSerialDebugStore port-manager integration", () => {
     });
   });
 
+  // Dropping a chunk is bad; splicing the bytes either side of the gap into one
+  // line is worse — it fabricates a log line the device never printed, and the
+  // user has no way to tell. The gap has to become a line boundary.
+  describe("dropped chunk notice", () => {
+    const SOH = String.fromCharCode(1);
+
+    async function openedStore() {
+      const s = useSerialDebugStore();
+      s.port = "/dev/ttyUSB0";
+      s.baudRate = 115200;
+      await s.openPort();
+      return s;
+    }
+
+    it("closes the open line so the halves are never joined", async () => {
+      const s = await openedStore();
+      fake.emitChunk({
+        direction: "rx",
+        tsMs: 1000,
+        bytes: [...Buffer.from("before-gap")],
+      });
+      await waitForChunkFrame();
+      const before = s.lines.length;
+
+      fake.emitChunksDropped(4096);
+      fake.emitChunk({
+        direction: "rx",
+        tsMs: 1001,
+        bytes: [...Buffer.from("after-gap\n")],
+      });
+      await waitForChunkFrame();
+
+      const added = s.lines.slice(before);
+      expect(added.map((line) => line.direction)).toEqual(["rx", "sys", "rx"]);
+      expect(added[0].text).toBe("before-gap");
+      expect(added[2].text).toBe("after-gap");
+      expect(
+        added.every((line) => !line.text.includes("before-gapafter-gap")),
+      ).toBe(true);
+    });
+
+    it("emits queued pre-gap chunks before the notice, not after", async () => {
+      const s = await openedStore();
+      const before = s.lines.length;
+
+      // Still sitting in the 16 ms coalescing queue when the drop arrives.
+      fake.emitChunk({
+        direction: "rx",
+        tsMs: 1000,
+        bytes: [...Buffer.from("queued\n")],
+      });
+      fake.emitChunksDropped(512);
+      await waitForChunkFrame();
+
+      const added = s.lines.slice(before);
+      expect(added).toHaveLength(2);
+      // Order is the point: the queued chunk arrived before the gap, so the
+      // notice must land after it, not on top of it.
+      expect(added[0].direction).toBe("rx");
+      expect(added[0].text).toBe("queued");
+      expect(added[1].direction).toBe("sys");
+      expect(added[1].text).toContain("512");
+    });
+
+    it("shows a translated notice and never the raw sentinel", async () => {
+      const s = await openedStore();
+      const before = s.lines.length;
+
+      fake.emitChunksDropped(12288);
+
+      const added = s.lines.slice(before);
+      expect(added).toHaveLength(1);
+      expect(added[0].direction).toBe("sys");
+      expect(added[0].text).toContain("12288");
+      expect(added[0].text).not.toContain(SOH);
+      expect(added[0].text).not.toContain("chunks-dropped");
+    });
+
+    it("does not write the notice back into the archive", async () => {
+      const s = await openedStore();
+      fake.sysLineWrites.length = 0;
+
+      fake.emitChunksDropped(4096);
+
+      // Rust already wrote the sentinel into the archive at the gap; a write-back
+      // would record the same loss twice, in the wrong place.
+      expect(fake.sysLineWrites).toEqual([]);
+      expect(s.lines.length).toBeGreaterThan(0);
+    });
+
+    it("stops listening once the session is torn down", async () => {
+      const s = await openedStore();
+      await s.closePort();
+      const before = s.lines.length;
+
+      fake.emitChunksDropped(4096);
+
+      expect(s.lines.length).toBe(before);
+    });
+  });
+
   it("reuses one TextDecoder across queued chunks flushed in the same frame", async () => {
     const OriginalTextDecoder = globalThis.TextDecoder;
     let decoderConstructCount = 0;
@@ -956,6 +1068,33 @@ describe("useSerialDebugStore watch chip management", () => {
     expect(line.text).toContain("512 MiB");
     expect(line.text).not.toContain(SOH);
     expect(line.text).not.toContain("archive-capped");
+  });
+
+  it("translates the dropped-chunk sentinel in a filter page", async () => {
+    const s = useSerialDebugStore();
+    await s.addChip("tyutool", false);
+    const id = s.watchChips[0].id;
+    const SOH = String.fromCharCode(1);
+    fake.setFilterPage(id, {
+      filterId: id,
+      totalMatches: 1,
+      start: 0,
+      items: [
+        {
+          lineNo: 4,
+          tsMs: 1000,
+          direction: "sys",
+          text: `${SOH}tyutool:chunks-dropped:8192${SOH}`,
+        },
+      ],
+    });
+
+    await s.setActiveChip(id);
+
+    const [line] = s.activeDisplayLines();
+    expect(line.text).toContain("8192");
+    expect(line.text).not.toContain(SOH);
+    expect(line.text).not.toContain("chunks-dropped");
   });
 
   it("keeps display ids stable when the same filter page is reloaded", async () => {

--- a/src/stores/serial-debug.test.ts
+++ b/src/stores/serial-debug.test.ts
@@ -10,6 +10,7 @@ import type {
   DebugChunk,
   SerialDebugFilterPage,
   SerialDebugFilterUpdatePayload,
+  SerialDebugSessionPage,
 } from "@/features/serial-debug/types";
 import { useSerialDebugStore } from "./serial-debug";
 import { useFlashStore } from "./flash";
@@ -17,6 +18,9 @@ import { nextTick, watchEffect } from "vue";
 import {
   DEFAULT_ARCHIVE_LIMIT_MIB,
   DEFAULT_VISIBLE_LOG_WINDOW_LINES,
+  FILTER_PAGE_SIZE,
+  HISTORY_ENTRY_PAGES,
+  HISTORY_PAGE_SIZE,
   MAX_PENDING_LINE_BYTES,
 } from "@/features/serial-debug/constants";
 import { AUTH_ONLY_CHIP_ID } from "@/features/firmware-flash/constants";
@@ -39,6 +43,13 @@ function fakeTransport(): SerialDebugTransport & {
   emitArchiveCapped: (limitMib: number) => void;
   emitChunksDropped: (droppedBytes: number) => void;
   setFilterPage: (filterId: string, page: SerialDebugFilterPage) => void;
+  /** Pretend the Rust session archive holds `total` lines (`arch-1`…`arch-N`). */
+  setSessionArchive: (total: number) => void;
+  /** Take over `readSessionPage` entirely (gap / failure scenarios). */
+  setSessionPageResponder: (
+    fn: ((start: number, limit: number) => SerialDebugSessionPage) | null,
+  ) => void;
+  readSessionPageCalls: Array<{ start: number; limit: number }>;
   readFilterMatchesCalls: Array<{
     filterId: string;
     start?: number;
@@ -67,6 +78,11 @@ function fakeTransport(): SerialDebugTransport & {
     start?: number;
     limit?: number;
   }> = [];
+  const readSessionPageCalls: Array<{ start: number; limit: number }> = [];
+  let sessionArchiveTotal = 0;
+  let sessionPageResponder:
+    | ((start: number, limit: number) => SerialDebugSessionPage)
+    | null = null;
   let opened = false;
   let nextFilterId = 1;
   const filters = new Map<
@@ -132,11 +148,23 @@ function fakeTransport(): SerialDebugTransport & {
         }
       );
     },
-    async readSessionPage() {
+    async readSessionPage(start: number, limit: number) {
+      readSessionPageCalls.push({ start, limit });
+      if (sessionPageResponder) return sessionPageResponder(start, limit);
+      // Mirrors the Rust archive: dense 1-based `lineNo`, and an out-of-range
+      // `start` is silently clamped to `totalLines` (the clamped value is what
+      // comes back in `page.start`).
+      const clamped = Math.min(Math.max(start, 0), sessionArchiveTotal);
+      const end = Math.min(clamped + limit, sessionArchiveTotal);
       return {
-        totalLines: 0,
-        start: 0,
-        items: [],
+        totalLines: sessionArchiveTotal,
+        start: clamped,
+        items: Array.from({ length: Math.max(0, end - clamped) }, (_, i) => ({
+          lineNo: clamped + i + 1,
+          tsMs: 1_700_000_000_000 + clamped + i,
+          direction: "rx" as const,
+          text: `arch-${clamped + i + 1}`,
+        })),
       };
     },
     async setArchiveLimit(maxBytes: number) {
@@ -187,6 +215,13 @@ function fakeTransport(): SerialDebugTransport & {
     setFilterPage(filterId, page) {
       const entry = filters.get(filterId);
       if (entry) entry.page = page;
+    },
+    readSessionPageCalls,
+    setSessionArchive(total) {
+      sessionArchiveTotal = total;
+    },
+    setSessionPageResponder(fn) {
+      sessionPageResponder = fn;
     },
   };
 }
@@ -1730,5 +1765,286 @@ describe("useSerialDebugStore session archive limit", () => {
     s.archiveLimitMib = 128;
     await expect(nextTick()).resolves.toBeUndefined();
     expect(s.archiveLimitMib).toBe(128);
+  });
+});
+
+describe("useSerialDebugStore full-session history window", () => {
+  const ENTRY_LINES = HISTORY_PAGE_SIZE * HISTORY_ENTRY_PAGES;
+  let fake: ReturnType<typeof fakeTransport>;
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    fake = fakeTransport();
+    __setSerialDebugTransportForTest(fake);
+  });
+  afterEach(() => __setSerialDebugTransportForTest(null));
+
+  it("pages the archive tail into the window and shows it instead of the live buffer", async () => {
+    const s = useSerialDebugStore();
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 1000,
+      bytes: [...Buffer.from("live-a\nlive-b\n")],
+    });
+    fake.setSessionArchive(2000);
+
+    expect(await s.enterHistoryMode(s.lines.length)).toBe(true);
+
+    expect(s.historyMode).toBe(true);
+    expect(s.historyLines.length).toBe(ENTRY_LINES);
+    expect(s.historyStartLineNo).toBe(2000 - ENTRY_LINES + 1);
+    expect(s.historyEndLineNo).toBe(2000);
+    expect(s.historyTotalLines).toBe(2000);
+    expect(s.historyAtArchiveEnd).toBe(true);
+    expect(s.historyAtSessionStart).toBe(false);
+    expect(s.activeDisplayLines()).toBe(s.historyLines);
+    expect(s.activeDisplayLines()[0].text).toBe(
+      `arch-${2000 - ENTRY_LINES + 1}`,
+    );
+    // Never one big request: `readSessionPage` holds the Rust archive lock for
+    // the whole range, so a long read stalls the serial writer.
+    expect(
+      fake.readSessionPageCalls.every((c) => c.limit <= HISTORY_PAGE_SIZE),
+    ).toBe(true);
+    // Positioned so the viewport starts roughly where the live buffer did.
+    expect(s.historyEntryOffsetLines).toBe(ENTRY_LINES - s.lines.length);
+  });
+
+  it("keeps filling the live buffer while history mode is on, without displaying it", async () => {
+    const s = useSerialDebugStore();
+    fake.setSessionArchive(1000);
+    await s.enterHistoryMode(0);
+
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 2000,
+      bytes: [...Buffer.from("still-live\n")],
+    });
+
+    expect(s.lines[s.lines.length - 1].text).toBe("still-live");
+    expect(s.activeDisplayLines()).toBe(s.historyLines);
+    expect(s.activeDisplayLines().some((l) => l.text === "still-live")).toBe(
+      false,
+    );
+  });
+
+  it("returns the number of lines it prepended and keeps the window within budget", async () => {
+    const s = useSerialDebugStore();
+    const budget = ENTRY_LINES + 2 * HISTORY_PAGE_SIZE;
+    s.logWindowLines = budget;
+    await nextTick();
+    fake.setSessionArchive(5000);
+    await s.enterHistoryMode(50);
+    expect(s.historyStartLineNo).toBe(5000 - ENTRY_LINES + 1);
+
+    // Steps that still fit inside the budget leave the window's tail alone.
+    for (let i = 1; i <= 2; i += 1) {
+      expect(await s.loadOlderHistory()).toEqual({
+        prepended: HISTORY_PAGE_SIZE,
+        reanchored: false,
+      });
+      expect(s.historyLines.length).toBe(ENTRY_LINES + i * HISTORY_PAGE_SIZE);
+      expect(s.historyAtArchiveEnd).toBe(true);
+    }
+
+    // The step that overflows trims the *tail*, which sits below the viewport,
+    // so nothing the user is looking at moves.
+    expect((await s.loadOlderHistory()).prepended).toBe(HISTORY_PAGE_SIZE);
+    expect(s.historyLines.length).toBe(budget);
+    expect(s.historyAtArchiveEnd).toBe(false);
+    expect(s.historyStartLineNo).toBe(
+      5000 - ENTRY_LINES + 1 - 3 * HISTORY_PAGE_SIZE,
+    );
+    expect(s.historyLines[0].text).toBe(`arch-${s.historyStartLineNo}`);
+
+    for (let i = 0; i < 10; i += 1) await s.loadOlderHistory();
+    expect(s.historyLines.length).toBe(budget);
+  });
+
+  it("stops at the session start, detected from lineNo 1 rather than page.start", async () => {
+    const s = useSerialDebugStore();
+    fake.setSessionArchive(ENTRY_LINES + 250);
+    await s.enterHistoryMode(10);
+    expect(s.historyAtSessionStart).toBe(false);
+
+    expect((await s.loadOlderHistory()).prepended).toBe(250);
+    expect(s.historyStartLineNo).toBe(1);
+    expect(s.historyAtSessionStart).toBe(true);
+
+    fake.readSessionPageCalls.length = 0;
+    expect(await s.loadOlderHistory()).toEqual({
+      prepended: 0,
+      reanchored: false,
+    });
+    expect(fake.readSessionPageCalls).toEqual([]);
+  });
+
+  it("re-anchors on the archive tail instead of splicing a non-contiguous page", async () => {
+    const s = useSerialDebugStore();
+    fake.setSessionArchive(2000);
+    await s.enterHistoryMode(50);
+    const firstLineNo = s.historyStartLineNo;
+
+    // A head-dropping archive policy would answer the "give me the 400 lines
+    // before firstLineNo" request with renumbered lines. Splicing them on would
+    // silently show the wrong content, so the self-check must refuse.
+    const badStart = firstLineNo - 1 - HISTORY_PAGE_SIZE;
+    fake.setSessionPageResponder((start, limit) => ({
+      totalLines: 2000,
+      start,
+      items: Array.from({ length: Math.min(limit, 2000 - start) }, (_, i) => ({
+        lineNo: start + i + 1 + (start === badStart ? 25 : 0),
+        tsMs: 0,
+        direction: "rx" as const,
+        text: `arch-${start + i + 1}`,
+      })),
+    }));
+
+    expect(await s.loadOlderHistory()).toEqual({
+      prepended: 0,
+      reanchored: true,
+    });
+    expect(s.historyMode).toBe(true);
+    expect(s.historyStartLineNo).toBe(firstLineNo);
+    expect(s.historyLines.length).toBe(ENTRY_LINES);
+  });
+
+  it("pages forward again and drops from the head to stay within budget", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 1500;
+    await nextTick();
+    fake.setSessionArchive(5000);
+    await s.enterHistoryMode(50);
+    expect(await s.jumpToSessionStart()).toBe(true);
+    expect(s.historyStartLineNo).toBe(1);
+    expect(s.historyAtSessionStart).toBe(true);
+    expect(s.historyAtArchiveEnd).toBe(false);
+
+    const dropped = await s.loadNewerHistory();
+
+    expect(dropped).toBe(ENTRY_LINES + HISTORY_PAGE_SIZE - 1500);
+    expect(s.historyLines.length).toBe(1500);
+    expect(s.historyStartLineNo).toBe(1 + dropped);
+    expect(s.historyAtSessionStart).toBe(false);
+    expect(s.historyAtArchiveEnd).toBe(false);
+  });
+
+  it("reports being at the archive end once a short page comes back", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 20000;
+    await nextTick();
+    fake.setSessionArchive(ENTRY_LINES + 100);
+    await s.enterHistoryMode(10);
+    await s.jumpToSessionStart();
+    expect(s.historyAtArchiveEnd).toBe(false);
+
+    expect(await s.loadNewerHistory()).toBe(0);
+
+    expect(s.historyAtArchiveEnd).toBe(true);
+    expect(s.historyEndLineNo).toBe(ENTRY_LINES + 100);
+  });
+
+  it("leaves history mode on clear — the new session renumbers from 1", async () => {
+    const s = useSerialDebugStore();
+    fake.setSessionArchive(2000);
+    await s.enterHistoryMode(10);
+    expect(s.historyMode).toBe(true);
+
+    await s.clear();
+
+    expect(s.historyMode).toBe(false);
+    expect(s.historyLines).toEqual([]);
+    expect(s.historyStartLineNo).toBe(0);
+    expect(s.activeDisplayLines()).toBe(s.lines);
+  });
+
+  it("does not let a read that resolves after a clear resurrect the window", async () => {
+    const s = useSerialDebugStore();
+    fake.setSessionArchive(2000);
+    await s.enterHistoryMode(10);
+    let release: (() => void) | null = null;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const passthrough = fake.readSessionPage.bind(fake);
+    fake.readSessionPage = async (start: number, limit: number) => {
+      await gate;
+      return passthrough(start, limit);
+    };
+
+    const pending = s.loadOlderHistory();
+    await s.clear();
+    release!();
+    expect(await pending).toEqual({ prepended: 0, reanchored: false });
+
+    expect(s.historyMode).toBe(false);
+    expect(s.historyLines).toEqual([]);
+  });
+
+  it("falls back to the live view and says why when the archive read fails", async () => {
+    const s = useSerialDebugStore();
+    fake.setSessionArchive(2000);
+    await s.enterHistoryMode(10);
+    fake.setSessionPageResponder(() => {
+      throw new Error("archive gone");
+    });
+
+    expect((await s.loadOlderHistory()).prepended).toBe(0);
+
+    expect(s.historyMode).toBe(false);
+    expect(s.historyLines).toEqual([]);
+    expect(s.lines[s.lines.length - 1].text).toContain("archive gone");
+  });
+
+  it("does not enter history mode when the archive is empty", async () => {
+    const s = useSerialDebugStore();
+    fake.setSessionArchive(0);
+    expect(await s.enterHistoryMode(10)).toBe(false);
+    expect(s.historyMode).toBe(false);
+    expect(s.activeDisplayLines()).toBe(s.lines);
+  });
+
+  it("bounds how many filter matches the older-matches button accumulates", async () => {
+    const s = useSerialDebugStore();
+    s.logWindowLines = 1000;
+    await nextTick();
+    fake.readFilterMatches = async (
+      filterId: string,
+      start: number,
+      limit: number,
+    ) => ({
+      filterId,
+      totalMatches: 10_000,
+      start,
+      items: Array.from({ length: limit }, (_, i) => ({
+        lineNo: start + i + 1,
+        tsMs: 0,
+        direction: "rx" as const,
+        text: `m-${start + i + 1}`,
+      })),
+    });
+    s.watchChips = [{ id: "f1", keyword: "m", useRegex: false, color: "#000" }];
+    s.filterStatsById = {
+      f1: {
+        filterId: "f1",
+        status: "complete",
+        scannedUntilLineNo: 0,
+        totalLinesSnapshot: 0,
+        totalMatches: 10_000,
+        error: null,
+      },
+    };
+    await s.setActiveChip("f1");
+    expect(s.filterPagesById.f1.items.length).toBe(FILTER_PAGE_SIZE);
+
+    for (let i = 0; i < 5; i += 1) {
+      expect(await s.loadOlderActiveFilterMatches()).toBe(FILTER_PAGE_SIZE);
+    }
+
+    // Bounded, and trimmed from the tail so the scroll position is unaffected.
+    expect(s.filterPagesById.f1.items.length).toBe(1000);
+    expect(s.filterPagesById.f1.start).toBe(10_000 - 6 * FILTER_PAGE_SIZE);
+    expect(s.filterPagesById.f1.items[0].text).toBe(
+      `m-${10_000 - 6 * FILTER_PAGE_SIZE + 1}`,
+    );
   });
 });

--- a/src/stores/serial-debug.ts
+++ b/src/stores/serial-debug.ts
@@ -210,7 +210,17 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     "direction" | "tsMs" | "text"
   > & {
     estimatedChars: number;
+    /**
+     * Archive lines that existed before this line's own archive write; see
+     * `DebugChunk.archivedBefore`. `UNARCHIVED` means the line is not in the
+     * archive at all (or its position is unknown), so the backfill can never
+     * contain it and it must never be discarded.
+     */
+    archivedBefore: number;
   };
+  const UNARCHIVED = Number.POSITIVE_INFINITY;
+  /** A display line together with the archive position it was written at. */
+  type PreparedLine = { line: DebugLogLine; archivedBefore: number };
   // Only filled while an auto-save session file exists (sessionAutoSavePath).
   // Without that gate nothing ever drains it when auto-save is off, so it grows
   // for the whole session (~11 MiB/min at 921600). This queue is therefore only
@@ -218,6 +228,24 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
   // backfilled from the Rust-side session archive by
   // `useSerialAutoSave.backfillFromArchive`, which is the full record.
   const pendingAutoSaveLines: PendingAutoSaveLine[] = [];
+  // Where the backfilled half of the current auto-save file ends: the archive
+  // snapshot the backfill was capped at, or null while it is not known yet.
+  // Everything at or after it is the live queue's job, everything before it has
+  // already been written — that split is what makes the handoff exact.
+  let autoSaveBackfilledUntil: number | null = null;
+  // Sys-line archive writes still in flight. The backfill awaits them before
+  // discarding, so no queued line can still be missing its position by then.
+  const pendingSysArchiveWrites = new Set<Promise<void>>();
+  // The watermark is a position in *one* session file's backfill; a new (or
+  // closed) file invalidates it. `flush: 'sync'` so this can never be queued
+  // behind — and then clobber — a snapshot the backfill has already published.
+  watch(
+    sessionAutoSavePath,
+    () => {
+      autoSaveBackfilledUntil = null;
+    },
+    { flush: "sync" },
+  );
 
   let nextLineId = 1;
   // Display id per archive line number, so reloading a filter page keeps the
@@ -427,12 +455,44 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     void applyArchiveLimit();
   });
 
+  /**
+   * Queue one line for the auto-save file, unless it is already in the
+   * backfilled half. Returns the queued entry so a caller that only learns the
+   * archive position later (`appendSysLine`) can fill it in.
+   */
+  function enqueueAutoSaveLine(
+    line: DebugLogLine,
+    archivedBefore: number,
+  ): PendingAutoSaveLine | null {
+    if (sessionAutoSavePath.value === null) return null;
+    // The backfill's own discard pass only sees what is queued when it runs; a
+    // line archived before the snapshot can still be delivered after it (the
+    // event and the snapshot read are separate round trips), so the same
+    // predicate has to guard the enqueue.
+    if (
+      autoSaveBackfilledUntil !== null &&
+      archivedBefore < autoSaveBackfilledUntil
+    ) {
+      return null;
+    }
+    const entry: PendingAutoSaveLine = {
+      direction: line.direction,
+      tsMs: line.tsMs,
+      text: line.text,
+      estimatedChars: line.text.length + 48,
+      archivedBefore,
+    };
+    pendingAutoSaveLines.push(entry);
+    return entry;
+  }
+
   function pushLine(
     direction: DebugLogLine["direction"],
     tsMs: number,
     text: string,
     rawBytes?: Uint8Array,
-  ): void {
+    archivedBefore: number = UNARCHIVED,
+  ): PendingAutoSaveLine | null {
     const line: DebugLogLine = {
       id: nextLineId++,
       direction,
@@ -441,30 +501,21 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
       rawBytes,
     };
     lines.value.push(line);
-    if (sessionAutoSavePath.value !== null) {
-      pendingAutoSaveLines.push({
-        direction: line.direction,
-        tsMs: line.tsMs,
-        text: line.text,
-        estimatedChars: line.text.length + 48,
-      });
-    }
+    const entry = enqueueAutoSaveLine(line, archivedBefore);
     trimVisibleLines();
     triggerRef(lines);
+    return entry;
   }
 
-  function pushPreparedLines(batch: DebugLogLine[]): void {
+  function pushPreparedLines(batch: PreparedLine[]): void {
     if (batch.length === 0) return;
-    lines.value.push(...batch);
+    // One bulk push per frame — a per-line push would re-enter the reactive
+    // array once per line.
+    lines.value.push(...batch.map((prepared) => prepared.line));
     if (sessionAutoSavePath.value !== null) {
-      pendingAutoSaveLines.push(
-        ...batch.map((line) => ({
-          direction: line.direction,
-          tsMs: line.tsMs,
-          text: line.text,
-          estimatedChars: line.text.length + 48,
-        })),
-      );
+      for (const prepared of batch) {
+        enqueueAutoSaveLine(prepared.line, prepared.archivedBefore);
+      }
     }
     trimVisibleLines();
     triggerRef(lines);
@@ -472,13 +523,29 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
 
   async function appendSysLine(text: string): Promise<void> {
     const tsMs = Date.now();
-    pushLine("sys", tsMs, text);
+    // Pushed before it is archived, so its position is not known yet — the
+    // entry is patched in place below rather than queued late, which keeps the
+    // file in the same order as the live view.
+    const entry = pushLine("sys", tsMs, text);
+    const write = (async () => {
+      try {
+        const lineNo = await transport.appendSysLine(tsMs, text);
+        // `null` = not archived (capped archive, or web mode): leave it
+        // UNARCHIVED, because a line the archive never took cannot be
+        // backfilled and so must never be discarded.
+        if (entry !== null && lineNo !== null)
+          entry.archivedBefore = lineNo - 1;
+      } catch (e) {
+        rLog.warn(
+          `[SerialDebug] append sys line failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    })();
+    pendingSysArchiveWrites.add(write);
     try {
-      await transport.appendSysLine(tsMs, text);
-    } catch (e) {
-      rLog.warn(
-        `[SerialDebug] append sys line failed: ${e instanceof Error ? e.message : String(e)}`,
-      );
+      await write;
+    } finally {
+      pendingSysArchiveWrites.delete(write);
     }
   }
 
@@ -488,9 +555,14 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
 
   function prepareLinesFromChunks(
     chunks: readonly DebugChunk[],
-  ): DebugLogLine[] {
-    const completedLines: DebugLogLine[] = [];
+  ): PreparedLine[] {
+    const completedLines: PreparedLine[] = [];
     for (const chunk of chunks) {
+      // The archive splits lines exactly as this loop does (same `\n` rule, same
+      // MAX_PENDING_LINE_BYTES), so a line completed by this chunk is a line the
+      // archive completed while appending this chunk — inside
+      // (archivedBefore, archivedBefore + appended].
+      const archivedBefore = chunk.archivedBefore ?? UNARCHIVED;
       const dir = chunk.direction as "tx" | "rx";
       const p = pending[dir];
       appendPendingBytes(p, chunk.bytes);
@@ -505,11 +577,14 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
         if (!lineBytes) break;
         const text = decodeLossy(trimTrailingLineEnding(lineBytes));
         completedLines.push({
-          id: nextLineId++,
-          direction: dir,
-          tsMs: chunk.tsMs,
-          text,
-          rawBytes: lineBytes,
+          line: {
+            id: nextLineId++,
+            direction: dir,
+            tsMs: chunk.tsMs,
+            text,
+            rawBytes: lineBytes,
+          },
+          archivedBefore,
         });
       }
     }
@@ -523,21 +598,26 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
 
   /**
    * Close the line currently being assembled for `dir` and show it as its own
-   * line. Used at a gap in the chunk stream: `prepareLinesFromChunks` only cuts
-   * on `\n`, so without this the bytes before the gap and the bytes after it
-   * would be joined into one line the device never printed.
+   * line. Used at a gap in the chunk stream and when the session closes:
+   * `prepareLinesFromChunks` only cuts on `\n`, so without this the bytes
+   * before the gap and the bytes after it would be joined into one line the
+   * device never printed, and whatever the device printed last without a
+   * newline would never be shown at all.
    */
-  function finalizePendingLine(dir: "tx" | "rx"): void {
+  function finalizePendingLine(dir: "tx" | "rx", archivedBefore: number): void {
     const p = pending[dir];
     if (p.totalBytes === 0) return;
     const lineBytes = takePendingBytes(p, p.totalBytes);
     pushPreparedLines([
       {
-        id: nextLineId++,
-        direction: dir,
-        tsMs: Date.now(),
-        text: decodeLossy(trimTrailingLineEnding(lineBytes)),
-        rawBytes: lineBytes,
+        line: {
+          id: nextLineId++,
+          direction: dir,
+          tsMs: Date.now(),
+          text: decodeLossy(trimTrailingLineEnding(lineBytes)),
+          rawBytes: lineBytes,
+        },
+        archivedBefore,
       },
     ]);
   }
@@ -551,13 +631,24 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
    * Only `rx` is finalized — the bounded backend queue only carries the serial
    * reader's Rx chunks, the Tx path writes straight through.
    */
-  function handleChunksDropped(droppedBytes: number): void {
+  function handleChunksDropped(
+    droppedBytes: number,
+    archivedBefore: number,
+  ): void {
     if (chunkFlushTimer !== null) {
       clearTimeout(chunkFlushTimer);
     }
     flushQueuedChunks();
-    finalizePendingLine("rx");
-    pushLine("sys", Date.now(), chunksDroppedNoticeText(droppedBytes));
+    // Both lines come from one `append_gap` call under one archive lock, so they
+    // share the position that call was made at.
+    finalizePendingLine("rx", archivedBefore);
+    pushLine(
+      "sys",
+      Date.now(),
+      chunksDroppedNoticeText(droppedBytes),
+      undefined,
+      archivedBefore,
+    );
   }
 
   async function clear(): Promise<void> {
@@ -573,6 +664,9 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
       chunkFlushTimer = null;
     }
     pendingAutoSaveLines.length = 0;
+    // The archive restarts at line 1, so the backfill watermark now points at
+    // nothing; keeping it would discard every line of the new session.
+    autoSaveBackfilledUntil = null;
     cancelActiveFilterRefresh();
     filterStatsById.value = Object.fromEntries(
       Object.entries(filterStatsById.value).map(([id, stats]) => [
@@ -597,6 +691,43 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
       const msg = e instanceof Error ? e.message : String(e);
       await appendSysLine(t("serialDebug.err.sendFailed", { msg }));
     }
+  }
+
+  /**
+   * Settle every sys-line archive write that is already in flight, so the
+   * discard pass below cannot run while a queued line's position is still
+   * unknown. Writes started *after* this resolves need no wait: their archive
+   * append necessarily happens after the snapshot read that preceded the call,
+   * so they can only land after the backfilled half.
+   */
+  async function settleAutoSaveMarkers(): Promise<void> {
+    if (pendingSysArchiveWrites.size === 0) return;
+    await Promise.all([...pendingSysArchiveWrites]);
+  }
+
+  /**
+   * The backfill has written archive lines 1..`untilLineNo` to the auto-save
+   * file. Drop the queued live lines that are inside that range, and remember
+   * the watermark so later arrivals from before it are dropped at enqueue time.
+   *
+   * Exact in both directions. No duplicate: a queued line is discarded exactly
+   * when its archive counterpart is <= `untilLineNo`, because a snapshot can
+   * never land inside one archive write (`DebugChunk.archivedBefore`). No gap:
+   * everything at or after the snapshot is kept, and lines the archive never
+   * took are UNARCHIVED and therefore never discarded.
+   */
+  function dropBackfilledAutoSaveLines(untilLineNo: number): void {
+    autoSaveBackfilledUntil = untilLineNo;
+    // Compacted in place: the queue can hold a whole backfill's worth of live
+    // output, and a copy would be a second allocation of it.
+    let kept = 0;
+    for (const entry of pendingAutoSaveLines) {
+      if (entry.archivedBefore >= untilLineNo) {
+        pendingAutoSaveLines[kept] = entry;
+        kept += 1;
+      }
+    }
+    pendingAutoSaveLines.length = kept;
   }
 
   function drainPendingAutoSaveLines(
@@ -698,11 +829,19 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     unsubscribeFilterUpdated = null;
     unsubscribeArchiveCapped = null;
     unsubscribeChunksDropped = null;
-    queuedChunks.length = 0;
+    // Everything still in flight has to become a line before the port goes:
+    // the chunks queued in the last coalescing frame (dropping them would erase
+    // output the archive already has), and then the bytes the device left
+    // unterminated — a `login: ` prompt, a progress bar — which nothing else
+    // ever cuts. The two tail lines go in as UNARCHIVED: the store never learns
+    // the archive position of a line it closed itself, and a line whose position
+    // is unknown must never be discarded by the auto-save handoff.
     if (chunkFlushTimer !== null) {
       clearTimeout(chunkFlushTimer);
-      chunkFlushTimer = null;
     }
+    flushQueuedChunks();
+    finalizePendingLine("tx", UNARCHIVED);
+    finalizePendingLine("rx", UNARCHIVED);
     cancelActiveFilterRefresh();
     try {
       await transport.close();
@@ -795,14 +934,22 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     // holds the sentinel this line is the translation of, and writing it back
     // would record the same event twice (and be dropped anyway, the archive
     // being capped).
-    unsubscribeArchiveCapped = transport.onArchiveCapped(({ limitMib }) => {
-      pushLine("sys", Date.now(), archiveCapNoticeText(limitMib));
-    });
+    unsubscribeArchiveCapped = transport.onArchiveCapped(
+      ({ limitMib, archivedBefore }) => {
+        pushLine(
+          "sys",
+          Date.now(),
+          archiveCapNoticeText(limitMib),
+          undefined,
+          archivedBefore ?? UNARCHIVED,
+        );
+      },
+    );
     // Live view only, same as the cap notice: the archive already holds the
     // dropped-chunk sentinel this line is the translation of.
     unsubscribeChunksDropped =
-      transport.onChunksDropped?.(({ droppedBytes }) => {
-        handleChunksDropped(droppedBytes);
+      transport.onChunksDropped?.(({ droppedBytes, archivedBefore }) => {
+        handleChunksDropped(droppedBytes, archivedBefore ?? UNARCHIVED);
       }) ?? null;
     unsubscribeFilterUpdated = transport.onFilterUpdated((payload) => {
       filterStatsById.value = {
@@ -1314,6 +1461,8 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     clear,
     appendChunk,
     drainPendingAutoSaveLines,
+    settleAutoSaveMarkers,
+    dropBackfilledAutoSaveLines,
     showHexPopup,
     closeHexPopup,
     appendSysLine,

--- a/src/stores/serial-debug.ts
+++ b/src/stores/serial-debug.ts
@@ -28,6 +28,7 @@ import { parseHexInput } from "@/features/serial-debug/hex-format";
 import { archiveLineToLogLine } from "@/features/serial-debug/utils";
 import {
   archiveCapNoticeText,
+  chunksDroppedNoticeText,
   localizeArchiveLineText,
 } from "@/features/serial-debug/archive-line-text";
 import { serialDebugTransport } from "@/features/serial-debug/transport";
@@ -257,6 +258,7 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
   let unsubscribeDisconnect: (() => void) | null = null;
   let unsubscribeFilterUpdated: (() => void) | null = null;
   let unsubscribeArchiveCapped: (() => void) | null = null;
+  let unsubscribeChunksDropped: (() => void) | null = null;
   let resumeAfterFlashRelease = false;
 
   const resumePortManager = usePortManagerStore();
@@ -482,6 +484,45 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     pushPreparedLines(completedLines);
   }
 
+  /**
+   * Close the line currently being assembled for `dir` and show it as its own
+   * line. Used at a gap in the chunk stream: `prepareLinesFromChunks` only cuts
+   * on `\n`, so without this the bytes before the gap and the bytes after it
+   * would be joined into one line the device never printed.
+   */
+  function finalizePendingLine(dir: "tx" | "rx"): void {
+    const p = pending[dir];
+    if (p.totalBytes === 0) return;
+    const lineBytes = takePendingBytes(p, p.totalBytes);
+    pushPreparedLines([
+      {
+        id: nextLineId++,
+        direction: dir,
+        tsMs: Date.now(),
+        text: decodeLossy(trimTrailingLineEnding(lineBytes)),
+        rawBytes: lineBytes,
+      },
+    ]);
+  }
+
+  /**
+   * Device output was dropped between two chunks. Ordered carefully: everything
+   * already queued arrived *before* the gap, so it has to be turned into lines
+   * first; then the open line is closed; only then does the notice go in, where
+   * the loss actually happened.
+   *
+   * Only `rx` is finalized — the bounded backend queue only carries the serial
+   * reader's Rx chunks, the Tx path writes straight through.
+   */
+  function handleChunksDropped(droppedBytes: number): void {
+    if (chunkFlushTimer !== null) {
+      clearTimeout(chunkFlushTimer);
+    }
+    flushQueuedChunks();
+    finalizePendingLine("rx");
+    pushLine("sys", Date.now(), chunksDroppedNoticeText(droppedBytes));
+  }
+
   async function clear(): Promise<void> {
     lines.value = [];
     resetPendingBuffer(pending.tx);
@@ -606,10 +647,12 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     unsubscribeDisconnect?.();
     unsubscribeFilterUpdated?.();
     unsubscribeArchiveCapped?.();
+    unsubscribeChunksDropped?.();
     unsubscribeChunk = null;
     unsubscribeDisconnect = null;
     unsubscribeFilterUpdated = null;
     unsubscribeArchiveCapped = null;
+    unsubscribeChunksDropped = null;
     queuedChunks.length = 0;
     if (chunkFlushTimer !== null) {
       clearTimeout(chunkFlushTimer);
@@ -710,6 +753,12 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     unsubscribeArchiveCapped = transport.onArchiveCapped(({ limitMib }) => {
       pushLine("sys", Date.now(), archiveCapNoticeText(limitMib));
     });
+    // Live view only, same as the cap notice: the archive already holds the
+    // dropped-chunk sentinel this line is the translation of.
+    unsubscribeChunksDropped =
+      transport.onChunksDropped?.(({ droppedBytes }) => {
+        handleChunksDropped(droppedBytes);
+      }) ?? null;
     unsubscribeFilterUpdated = transport.onFilterUpdated((payload) => {
       filterStatsById.value = {
         ...filterStatsById.value,
@@ -739,10 +788,12 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
       unsubscribeDisconnect?.();
       unsubscribeFilterUpdated?.();
       unsubscribeArchiveCapped?.();
+      unsubscribeChunksDropped?.();
       unsubscribeChunk = null;
       unsubscribeDisconnect = null;
       unsubscribeFilterUpdated = null;
       unsubscribeArchiveCapped = null;
+      unsubscribeChunksDropped = null;
     } finally {
       opening.value = false;
     }

--- a/src/stores/serial-debug.ts
+++ b/src/stores/serial-debug.ts
@@ -12,9 +12,11 @@ import {
   FILTER_PAGE_SIZE,
   MAX_PENDING_LINE_BYTES,
   MAX_SEND_HISTORY,
+  MAX_VISIBLE_LOG_WINDOW_LINES,
   DEFAULT_VISIBLE_LOG_WINDOW_LINES,
   DEFAULT_ARCHIVE_LIMIT_MIB,
 } from "@/features/serial-debug/constants";
+import { useSerialDebugHistory } from "@/features/serial-debug/useSerialDebugHistory";
 import {
   chipManifest,
   rustPluginIdForChip,
@@ -222,7 +224,14 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
   // ids of lines that are already on screen (the log renderers cache parsed
   // lines by id). Reset on session clear, because archive line numbers restart.
   let archiveLineIds = new Map<number, number>();
-  const MAX_ARCHIVE_LINE_IDS = 20000;
+  // Sized for the largest set of archive-backed lines that can be on screen at
+  // once, because dropping the memo costs every one of them a fresh id (renderer
+  // caches invalidated, and the follow-tail watcher sees "the last line changed"
+  // where nothing did). Two archive-backed buffers are each bounded by
+  // `logWindowLines` — the history window and the active filter tab's page — and
+  // the remaining filter tabs each keep their last loaded page.
+  const MAX_ARCHIVE_LINE_IDS =
+    2 * MAX_VISIBLE_LOG_WINDOW_LINES + 4 * FILTER_PAGE_SIZE;
   const pending = {
     tx: createPendingBuffer(),
     rx: createPendingBuffer(),
@@ -260,6 +269,34 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
   let unsubscribeArchiveCapped: (() => void) | null = null;
   let unsubscribeChunksDropped: (() => void) | null = null;
   let resumeAfterFlashRelease = false;
+
+  // Full-session scrollback for the "All" tab. Owns its own buffer over the Rust
+  // session archive; see the composable's header for why it must never be
+  // spliced into `lines`. Destructured back into local bindings so the public
+  // API below stays one flat `return {}`.
+  const {
+    historyMode,
+    historyLines,
+    historyStartLineNo,
+    historyEndLineNo,
+    historyTotalLines,
+    historyLoading,
+    historyAtSessionStart,
+    historyAtArchiveEnd,
+    historyEntryOffsetLines,
+    enterHistoryMode,
+    loadOlderHistory,
+    loadNewerHistory,
+    jumpToSessionStart,
+    exitHistoryMode,
+  } = useSerialDebugHistory({
+    readSessionPage: (start, limit) => transport.readSessionPage(start, limit),
+    archiveLineId: (lineNo) => archiveLineId(lineNo),
+    historyBudget: () => logWindowLines.value,
+    reportError: (msg) => {
+      void appendSysLine(t("serialDebug.log.historyLoadFailed", { msg }));
+    },
+  });
 
   const resumePortManager = usePortManagerStore();
   watch(
@@ -525,6 +562,9 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
 
   async function clear(): Promise<void> {
     lines.value = [];
+    // A clear starts a new archive session whose line numbers restart at 1, so
+    // every anchor the history window holds points at the wrong lines.
+    exitHistoryMode();
     resetPendingBuffer(pending.tx);
     resetPendingBuffer(pending.rx);
     queuedChunks.length = 0;
@@ -588,11 +628,16 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
   // A plain getter, not a computed: on the "All" tab this returns `lines.value`
   // unchanged, and Vue only notifies a computed's subscribers when the
   // computed's *result* changes — an identity-stable array would swallow every
-  // triggerRef. As a getter, callers depend on `lines` / `filterPagesById`
-  // directly and are notified.
+  // triggerRef. As a getter, callers depend on `lines` / `filterPagesById` /
+  // `historyMode` / `historyLines` directly and are notified.
   function activeDisplayLines(): DebugLogLine[] {
-    if (activeChipId.value === null) return lines.value;
-    return filterPagesById.value[activeChipId.value]?.items ?? [];
+    if (activeChipId.value !== null) {
+      return filterPagesById.value[activeChipId.value]?.items ?? [];
+    }
+    // History mode swaps the buffer rather than concatenating: live lines keep
+    // flowing into `lines` (and into the auto-save queue) the whole time, they
+    // are just not what is on screen.
+    return historyMode.value ? historyLines.value : lines.value;
   }
 
   function flushQueuedChunks(): void {
@@ -1011,28 +1056,38 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     }
   }
 
-  async function loadOlderActiveFilterMatches(): Promise<void> {
+  /** @returns how many matches were prepended, for the caller's scroll compensation. */
+  async function loadOlderActiveFilterMatches(): Promise<number> {
     const id = activeChipId.value;
-    if (!id) return;
+    if (!id) return 0;
     const existing = filterPagesById.value[id];
     if (!existing || existing.start === 0) {
       activeFilterFullyLoaded.value = true;
-      return;
+      return 0;
     }
     activeFilterLoading.value = true;
     try {
       const start = Math.max(0, existing.start - FILTER_PAGE_SIZE);
       const page = await loadFilterPage(id, start, existing.start - start);
+      const items = [...page.items, ...existing.items];
+      // Bounded like the live buffer and the history window: without this,
+      // holding the button down pulls every match of the whole session into
+      // memory. Trimmed from the tail, which sits below the viewport, so the
+      // scroll position is unaffected; `loadActiveFilterTail` (tab switch, live
+      // refresh) puts the newest matches back.
+      const max = Math.max(logWindowLines.value, FILTER_PAGE_SIZE);
+      if (items.length > max) items.length = max;
       filterPagesById.value = {
         ...filterPagesById.value,
         [id]: {
           ...existing,
           start: page.start,
           totalMatches: page.totalMatches,
-          items: [...page.items, ...existing.items],
+          items,
         },
       };
       activeFilterFullyLoaded.value = start === 0;
+      return page.items.length;
     } finally {
       activeFilterLoading.value = false;
     }
@@ -1227,6 +1282,15 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     filterPagesById,
     activeFilterLoading,
     activeFilterFullyLoaded,
+    historyMode,
+    historyLines,
+    historyStartLineNo,
+    historyEndLineNo,
+    historyTotalLines,
+    historyLoading,
+    historyAtSessionStart,
+    historyAtArchiveEnd,
+    historyEntryOffsetLines,
     sendMode,
     sendAppendCrlf,
     sendInput,
@@ -1258,6 +1322,11 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     setActiveChip,
     loadActiveFilterTail,
     loadOlderActiveFilterMatches,
+    enterHistoryMode,
+    loadOlderHistory,
+    loadNewerHistory,
+    jumpToSessionStart,
+    exitHistoryMode,
     increaseFontSize,
     decreaseFontSize,
     loadWorkspace,

--- a/src/stores/serial-debug.ts
+++ b/src/stores/serial-debug.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { computed, ref, watch } from "vue";
+import { computed, ref, shallowRef, triggerRef, watch } from "vue";
 import {
   CHIP_COLORS,
   COMMON_BAUD_RATES,
@@ -12,7 +12,8 @@ import {
   FILTER_PAGE_SIZE,
   MAX_PENDING_LINE_BYTES,
   MAX_SEND_HISTORY,
-  VISIBLE_LOG_WINDOW_LINES,
+  DEFAULT_VISIBLE_LOG_WINDOW_LINES,
+  DEFAULT_ARCHIVE_LIMIT_MIB,
 } from "@/features/serial-debug/constants";
 import {
   chipManifest,
@@ -25,6 +26,10 @@ import {
 import { useFlashStore } from "@/stores/flash";
 import { parseHexInput } from "@/features/serial-debug/hex-format";
 import { archiveLineToLogLine } from "@/features/serial-debug/utils";
+import {
+  archiveCapNoticeText,
+  localizeArchiveLineText,
+} from "@/features/serial-debug/archive-line-text";
 import { serialDebugTransport } from "@/features/serial-debug/transport";
 import { wsTransport } from "@/transport/ws-transport";
 import type {
@@ -170,11 +175,21 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
   const rebootChipId = ref("");
 
   // ── display ──────────────────────────────────────────────────────────
-  const lines = ref<DebugLogLine[]>([]);
+  // shallowRef: a deep ref would proxy every element, so the per-frame
+  // splice(0, n) that keeps the window at logWindowLines would re-run the
+  // Proxy traps over the whole window (~8 ms per flush at 5000 lines, ~35 ms
+  // at 20000). DebugLogLine objects are never mutated after creation, so deep
+  // reactivity buys nothing. In-place writers must call triggerRef(lines).
+  const lines = shallowRef<DebugLogLine[]>([]);
   const hexView = ref(false);
   const hexBytesPerRow = ref<HexBytesPerRow>(DEFAULT_HEX_BYTES_PER_ROW);
   const ansiEnabled = ref(true);
   const logFontSize = ref(12);
+  const logWindowLines = ref(DEFAULT_VISIBLE_LOG_WINDOW_LINES);
+  // Cap for the Rust-side session archive, in MiB. Unrelated to
+  // logWindowLines: that bounds what the UI keeps in memory, this bounds what
+  // is written to disk.
+  const archiveLimitMib = ref(DEFAULT_ARCHIVE_LIMIT_MIB);
   const showTimestamp = ref(true);
   const showDirBadge = ref(true);
   const filterStatsById = ref<Record<string, SerialDebugFilterStats>>({});
@@ -193,6 +208,12 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
   > & {
     estimatedChars: number;
   };
+  // Only filled while an auto-save session file exists (sessionAutoSavePath).
+  // Without that gate nothing ever drains it when auto-save is off, so it grows
+  // for the whole session (~11 MiB/min at 921600). This queue is therefore only
+  // the *live* half of the auto-save file; lines from before the toggle are
+  // backfilled from the Rust-side session archive by
+  // `useSerialAutoSave.backfillFromArchive`, which is the full record.
   const pendingAutoSaveLines: PendingAutoSaveLine[] = [];
 
   let nextLineId = 1;
@@ -235,6 +256,7 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
   let unsubscribeChunk: (() => void) | null = null;
   let unsubscribeDisconnect: (() => void) | null = null;
   let unsubscribeFilterUpdated: (() => void) | null = null;
+  let unsubscribeArchiveCapped: (() => void) | null = null;
   let resumeAfterFlashRelease = false;
 
   const resumePortManager = usePortManagerStore();
@@ -334,6 +356,38 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     };
   }
 
+  // Does not publish the change: the push paths below trim as their last step
+  // and then trigger once, so the trim never needs its own notification.
+  function trimVisibleLines(): void {
+    if (lines.value.length > logWindowLines.value) {
+      lines.value.splice(0, lines.value.length - logWindowLines.value);
+    }
+  }
+
+  // Lowering the limit must take effect immediately, not on the next batch.
+  watch(logWindowLines, () => {
+    trimVisibleLines();
+    triggerRef(lines);
+  });
+
+  // Same shape as settings.applyLogLevel: a setting the frontend owns, pushed
+  // to Rust on load and on change. Best-effort — the archive may not be ready
+  // yet (or the backend may be a version without the command), and a failed
+  // push only means the compile-time default cap stays in force.
+  async function applyArchiveLimit(): Promise<void> {
+    try {
+      await serialDebugTransport().setArchiveLimit(
+        archiveLimitMib.value * 1024 * 1024,
+      );
+    } catch (e) {
+      rLog.warn(`[serial-debug] failed to apply archive limit: ${String(e)}`);
+    }
+  }
+
+  watch(archiveLimitMib, () => {
+    void applyArchiveLimit();
+  });
+
   function pushLine(
     direction: DebugLogLine["direction"],
     tsMs: number,
@@ -348,31 +402,33 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
       rawBytes,
     };
     lines.value.push(line);
-    pendingAutoSaveLines.push({
-      direction: line.direction,
-      tsMs: line.tsMs,
-      text: line.text,
-      estimatedChars: line.text.length + 48,
-    });
-    if (lines.value.length > VISIBLE_LOG_WINDOW_LINES) {
-      lines.value.splice(0, lines.value.length - VISIBLE_LOG_WINDOW_LINES);
+    if (sessionAutoSavePath.value !== null) {
+      pendingAutoSaveLines.push({
+        direction: line.direction,
+        tsMs: line.tsMs,
+        text: line.text,
+        estimatedChars: line.text.length + 48,
+      });
     }
+    trimVisibleLines();
+    triggerRef(lines);
   }
 
   function pushPreparedLines(batch: DebugLogLine[]): void {
     if (batch.length === 0) return;
     lines.value.push(...batch);
-    pendingAutoSaveLines.push(
-      ...batch.map((line) => ({
-        direction: line.direction,
-        tsMs: line.tsMs,
-        text: line.text,
-        estimatedChars: line.text.length + 48,
-      })),
-    );
-    if (lines.value.length > VISIBLE_LOG_WINDOW_LINES) {
-      lines.value.splice(0, lines.value.length - VISIBLE_LOG_WINDOW_LINES);
+    if (sessionAutoSavePath.value !== null) {
+      pendingAutoSaveLines.push(
+        ...batch.map((line) => ({
+          direction: line.direction,
+          tsMs: line.tsMs,
+          text: line.text,
+          estimatedChars: line.text.length + 48,
+        })),
+      );
     }
+    trimVisibleLines();
+    triggerRef(lines);
   }
 
   async function appendSysLine(text: string): Promise<void> {
@@ -488,10 +544,15 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     return pendingAutoSaveLines.splice(0, count);
   }
 
-  const activeDisplayLines = computed<DebugLogLine[]>(() => {
+  // A plain getter, not a computed: on the "All" tab this returns `lines.value`
+  // unchanged, and Vue only notifies a computed's subscribers when the
+  // computed's *result* changes — an identity-stable array would swallow every
+  // triggerRef. As a getter, callers depend on `lines` / `filterPagesById`
+  // directly and are notified.
+  function activeDisplayLines(): DebugLogLine[] {
     if (activeChipId.value === null) return lines.value;
     return filterPagesById.value[activeChipId.value]?.items ?? [];
-  });
+  }
 
   function flushQueuedChunks(): void {
     chunkFlushTimer = null;
@@ -544,9 +605,11 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     unsubscribeChunk?.();
     unsubscribeDisconnect?.();
     unsubscribeFilterUpdated?.();
+    unsubscribeArchiveCapped?.();
     unsubscribeChunk = null;
     unsubscribeDisconnect = null;
     unsubscribeFilterUpdated = null;
+    unsubscribeArchiveCapped = null;
     queuedChunks.length = 0;
     if (chunkFlushTimer !== null) {
       clearTimeout(chunkFlushTimer);
@@ -640,6 +703,13 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
       );
       pm.notifyUnplugged(port.value);
     });
+    // Live view only — deliberately not appendSysLine(): the archive already
+    // holds the sentinel this line is the translation of, and writing it back
+    // would record the same event twice (and be dropped anyway, the archive
+    // being capped).
+    unsubscribeArchiveCapped = transport.onArchiveCapped(({ limitMib }) => {
+      pushLine("sys", Date.now(), archiveCapNoticeText(limitMib));
+    });
     unsubscribeFilterUpdated = transport.onFilterUpdated((payload) => {
       filterStatsById.value = {
         ...filterStatsById.value,
@@ -668,9 +738,11 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
       unsubscribeChunk?.();
       unsubscribeDisconnect?.();
       unsubscribeFilterUpdated?.();
+      unsubscribeArchiveCapped?.();
       unsubscribeChunk = null;
       unsubscribeDisconnect = null;
       unsubscribeFilterUpdated = null;
+      unsubscribeArchiveCapped = null;
     } finally {
       opening.value = false;
     }
@@ -857,8 +929,17 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
       filterId: page.filterId,
       totalMatches: page.totalMatches,
       start: page.start,
+      // A filter tab renders straight out of the archive, so this is the third
+      // place the cap sentinel could surface — same helper as the export and
+      // the auto-save file.
       items: page.items.map((line) =>
-        archiveLineToLogLine(line, archiveLineId(line.lineNo)),
+        archiveLineToLogLine(
+          {
+            ...line,
+            text: localizeArchiveLineText(line.direction, line.text),
+          },
+          archiveLineId(line.lineNo),
+        ),
       ),
     };
   }
@@ -962,6 +1043,9 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     hexBytesPerRow.value = data.hexBytesPerRow;
     ansiEnabled.value = data.ansiEnabled ?? true;
     logFontSize.value = data.logFontSize ?? 12;
+    logWindowLines.value =
+      data.logWindowLines ?? DEFAULT_VISIBLE_LOG_WINDOW_LINES;
+    archiveLimitMib.value = data.archiveLimitMib ?? DEFAULT_ARCHIVE_LIMIT_MIB;
     autoSave.value = data.autoSave ?? false;
     autoSaveDir.value = data.autoSaveDir ?? "";
     // Re-authorize the restored auto-save directory so writes work after a
@@ -980,6 +1064,10 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     sendMode.value = data.sendMode;
     sendAppendCrlf.value = data.sendAppendCrlf;
     sendHistory.value = data.sendHistory;
+    // The archive is created at app start with the compile-time default, so the
+    // restored value has to be pushed down once the workspace is known. The
+    // watch above only fires when the value actually changes.
+    await applyArchiveLimit();
   }
 
   function startWorkspacePersistence(): void {
@@ -1001,6 +1089,8 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
             hexBytesPerRow: hexBytesPerRow.value,
             ansiEnabled: ansiEnabled.value,
             logFontSize: logFontSize.value,
+            logWindowLines: logWindowLines.value,
+            archiveLimitMib: archiveLimitMib.value,
             autoSave: autoSave.value,
             autoSaveDir: autoSaveDir.value,
             autoSaveTimestamp: autoSaveTimestamp.value,
@@ -1024,6 +1114,8 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
             hexBytesPerRow.value,
             ansiEnabled.value,
             logFontSize.value,
+            logWindowLines.value,
+            archiveLimitMib.value,
             sendMode.value,
             sendAppendCrlf.value,
             autoSave.value,
@@ -1072,11 +1164,12 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     rebootControlPort,
     rebootChipId,
     lines,
-    activeDisplayLines,
     hexView,
     hexBytesPerRow,
     ansiEnabled,
     logFontSize,
+    logWindowLines,
+    archiveLimitMib,
     showTimestamp,
     showDirBadge,
     filterStatsById,
@@ -1095,6 +1188,7 @@ export const useSerialDebugStore = defineStore("serial-debug", () => {
     autoSaveTimestamp,
     sessionAutoSavePath,
     // actions
+    activeDisplayLines,
     openPort,
     closePort,
     deviceReset,

--- a/src/transport/ws-transport.test.ts
+++ b/src/transport/ws-transport.test.ts
@@ -611,6 +611,7 @@ describe("serialDebugOpen / send / close", () => {
       (batch) => chunkBatches.push(batch),
       (r) => disconnects.push(r),
       () => {},
+      () => {},
     );
     await flush();
     const ws = latest();
@@ -640,6 +641,7 @@ describe("serialDebugOpen / send / close", () => {
       (batch) => chunkBatches.push(batch),
       () => {},
       () => {},
+      () => {},
     );
     await flush();
     const ws = latest();
@@ -665,10 +667,37 @@ describe("serialDebugOpen / send / close", () => {
     ]);
   });
 
+  it("routes serial_debug_archive_capped and maps limit_mib to limitMib", async () => {
+    const t = new WsTransport();
+    const capped: unknown[] = [];
+    const p = t.serialDebugOpen(
+      { port: "x" } as never,
+      () => {},
+      () => {},
+      () => {},
+      () => {},
+      (payload) => capped.push(payload),
+    );
+    await flush();
+    const ws = latest();
+    ws.open();
+    await flush();
+    ws.recv({ type: "serial_debug_opened" });
+    await p;
+
+    ws.recv({ type: "serial_debug_archive_capped", limit_mib: 256 });
+    expect(capped).toEqual([{ limitMib: 256 }]);
+
+    // A malformed frame must not synthesise a NaN notice.
+    ws.recv({ type: "serial_debug_archive_capped" });
+    expect(capped).toHaveLength(1);
+  });
+
   it("rejects serialDebugOpen on an error frame", async () => {
     const t = new WsTransport();
     const p = t.serialDebugOpen(
       { port: "x" } as never,
+      () => {},
       () => {},
       () => {},
       () => {},
@@ -701,6 +730,7 @@ describe("serialDebugOpen / send / close", () => {
     const p = t.serialDebugOpen(
       { port: "x" } as never,
       (c) => chunks.push(c),
+      () => {},
       () => {},
       () => {},
       () => {},

--- a/src/transport/ws-transport.ts
+++ b/src/transport/ws-transport.ts
@@ -380,6 +380,9 @@ export class WsTransport {
     onArchiveCapped: (
       payload: import("@/features/serial-debug/types").ArchiveCappedPayload,
     ) => void,
+    onChunksDropped?: (
+      payload: import("@/features/serial-debug/types").ChunksDroppedPayload,
+    ) => void,
   ): Promise<void> {
     const ws = await this.connect();
     return new Promise((resolve, reject) => {
@@ -418,6 +421,7 @@ export class WsTransport {
             stats?: SerialDebugFilterUpdatePayload["stats"];
             // snake_case on the wire like every other ServerMessage field.
             limit_mib?: number;
+            dropped_bytes?: number;
           };
           if (m.type === "serial_debug_chunk" && m.chunk) onChunk(m.chunk);
           else if (m.type === "serial_debug_chunk_batch" && m.chunks)
@@ -431,6 +435,11 @@ export class WsTransport {
             typeof m.limit_mib === "number"
           )
             onArchiveCapped({ limitMib: m.limit_mib });
+          else if (
+            m.type === "serial_debug_chunks_dropped" &&
+            typeof m.dropped_bytes === "number"
+          )
+            onChunksDropped?.({ droppedBytes: m.dropped_bytes });
         } catch {
           /* ignore */
         }

--- a/src/transport/ws-transport.ts
+++ b/src/transport/ws-transport.ts
@@ -420,8 +420,11 @@ export class WsTransport {
             def?: SerialDebugFilterUpdatePayload["def"];
             stats?: SerialDebugFilterUpdatePayload["stats"];
             // snake_case on the wire like every other ServerMessage field.
+            // (`archivedBefore` inside `chunk`/`chunks` is the exception: it is
+            // flattened into the chunk object, which is camelCase already.)
             limit_mib?: number;
             dropped_bytes?: number;
+            archived_before?: number;
           };
           if (m.type === "serial_debug_chunk" && m.chunk) onChunk(m.chunk);
           else if (m.type === "serial_debug_chunk_batch" && m.chunks)
@@ -434,12 +437,18 @@ export class WsTransport {
             m.type === "serial_debug_archive_capped" &&
             typeof m.limit_mib === "number"
           )
-            onArchiveCapped({ limitMib: m.limit_mib });
+            onArchiveCapped({
+              limitMib: m.limit_mib,
+              archivedBefore: m.archived_before,
+            });
           else if (
             m.type === "serial_debug_chunks_dropped" &&
             typeof m.dropped_bytes === "number"
           )
-            onChunksDropped?.({ droppedBytes: m.dropped_bytes });
+            onChunksDropped?.({
+              droppedBytes: m.dropped_bytes,
+              archivedBefore: m.archived_before,
+            });
         } catch {
           /* ignore */
         }

--- a/src/transport/ws-transport.ts
+++ b/src/transport/ws-transport.ts
@@ -377,6 +377,9 @@ export class WsTransport {
     ) => void,
     onDisconnect: (reason: string) => void,
     onFilterUpdated: (payload: SerialDebugFilterUpdatePayload) => void,
+    onArchiveCapped: (
+      payload: import("@/features/serial-debug/types").ArchiveCappedPayload,
+    ) => void,
   ): Promise<void> {
     const ws = await this.connect();
     return new Promise((resolve, reject) => {
@@ -413,6 +416,8 @@ export class WsTransport {
             reason?: string;
             def?: SerialDebugFilterUpdatePayload["def"];
             stats?: SerialDebugFilterUpdatePayload["stats"];
+            // snake_case on the wire like every other ServerMessage field.
+            limit_mib?: number;
           };
           if (m.type === "serial_debug_chunk" && m.chunk) onChunk(m.chunk);
           else if (m.type === "serial_debug_chunk_batch" && m.chunks)
@@ -421,6 +426,11 @@ export class WsTransport {
             onDisconnect(m.reason ?? "");
           else if (m.type === "serial_debug_filter_updated" && m.def && m.stats)
             onFilterUpdated({ def: m.def, stats: m.stats });
+          else if (
+            m.type === "serial_debug_archive_capped" &&
+            typeof m.limit_mib === "number"
+          )
+            onArchiveCapped({ limitMib: m.limit_mib });
         } catch {
           /* ignore */
         }
@@ -454,6 +464,16 @@ export class WsTransport {
   async serialDebugSessionClear(): Promise<void> {
     const ws = await this.connect();
     ws.send(JSON.stringify({ type: "serial_debug_session_clear" }));
+  }
+
+  async serialDebugSetArchiveLimit(maxBytes: number): Promise<void> {
+    const ws = await this.connect();
+    ws.send(
+      JSON.stringify({
+        type: "serial_debug_set_archive_limit",
+        max_bytes: maxBytes,
+      }),
+    );
   }
 
   async serialDebugAppendSysLine(tsMs: number, text: string): Promise<void> {


### PR DESCRIPTION
## 背景

设备高频输出时 GUI 日志刷新明显卡顿。调研发现瓶颈不在 IPC 也不在 ANSI 解析，而是两处 O(总行数) 的每帧开销；顺带查出若干数据完整性与无界增长问题。共 6 个 commit。

## 性能

### `8e6a398` 让日志视图在满速端口下保持流畅

- **自动滚动跟随失效**：跟随逻辑监听数组长度，而可见窗口饱和后长度不再变化，watcher 永久失聪。改为跟踪最新行 id。
- **可见行数上限可配置**：默认 3000 → 5000，设置页可选 1000–20000，随工作区持久化。
- **`lines` 改 `shallowRef` + `triggerRef`**：每帧的 `splice` 不再穿透整个窗口的响应式代理（5000 行下 8.1ms → 0.003ms）。直通型 computed 降级为普通 getter——返回值不变的 computed 会吞掉 `triggerRef`。
- **自动保存两个缺陷**：关闭时仍无条件入队（约 11 MiB/分钟且无人消费）；周期性 flush 每 5s 只写一次 128 KiB，只跟上约 17% 的行速率。
- **ASCII 视口虚拟化**：只渲染视口 + overscan，搜索匹配仍覆盖整个缓冲区。
- **会话归档加上限**（默认 256 MiB 可调）+ 跨会话 prune + 不再存 `rawBytes`（同上限多留约 3 倍历史）。

### `76a930c` hex 视图虚拟化

hex 面板每 16ms 把整个缓冲区重建成一个字符串塞进单个 `<pre>`——20000 行下每帧替换 3.4 MB 文本，使可配置的行数上限在 hex 模式下形同虚设。

hex 的行是字节区间而非日志行，因此渲染器维护 chunk 长度前缀和，二分查找覆盖可见行的日志行。窗口是完整 dump 的逐字符切片，对 8/16/32 三种每行字节数、在头/中/尾/越界处均有断言。

## 数据完整性

### `09f91a4` 不再静默丢弃串口字节

桥接队列用的是阻塞 `send`，消费端变慢会卡住串口读线程——而它是唯一排空 OS 接收缓冲区的线程。端口以 `FlowControl::None` 打开，所以阻塞**不对设备产生任何背压**：驱动层直接溢出丢弃，位置在我们最低观测点之下，无计数、无报错。

改用 `try_send` 并对丢弃计数。丢一个 chunk 会把缺口两侧的字节拼成一条设备从未打印过、但看起来完全正常的日志行——归档和实时 store 都会先收尾当前方向的未完成行，再报告缺口。突发按"静默 250ms 或每 2s"合并上报。

### `7e6542c` 归档交接精确化 + 不再丢失尾部输出

- **自动保存回填交接从"可能重复"改为精确**。chunk 事件现在携带"本 chunk 归档前的归档行数"。`append_chunk` 在一把锁内原子归档整个 chunk，所以快照不可能落在 chunk 中间，于是"某条实时行是否已被回填覆盖"有了精确判据。sys 行经带 ack 的写入拿到位置；归档拒收的行保留"永不丢弃"标记，使残余方向是"保留"而非"丢失"。`clear()` 重置水位线（归档会从 1 重新编号）。
- **关闭端口时未换行的尾部输出不再丢失**。分行只在换行或 4096 字节强制断行时发生，而关闭路径两侧都不收口 pending——设备最后的提示符（`login: `、`>`、进度条）既不在实时视图也不在归档，因而导出、自动保存、筛选、历史页全都看不到。两个宿主现在在关闭时收口两个方向，store 也在拆会话前冲刷排队 chunk 并收口自己的 pending 行，顺带找回了以前被丢弃的最后 16ms 一批。
- **归档分页读取优化**：`read_page` 原本逐行走索引和日志，每行 5 次 syscall 且全程持有归档锁。ndjson 是追加写的，所以连续一页占一段连续区间——索引一次 seek+read，正文一次 seek+read，然后在内存里切片。400 行一页从 2002 次 syscall 降到 6 次。缓冲区有界（索引 16 KiB、正文 4 MiB，必要时分批），API 契约不变。
- 顺带删除 `SerialDebugArchiveMeta` / `meta()` / 再导出 / TS 镜像这条零调用点的死垂直切片。

## 功能

### `3bb5377` "All" 标签页全会话回滚

归档本来就存着整个会话，但 All 页只能看到实时环形缓冲，滚到顶会话就没了。滚过顶部进入历史模式：归档上的有界窗口，按 `lineNo` 锚定，每次 400 行，带加载更早/更新、跳到会话开头和返回实时。

**刻意不与实时缓冲拼接**：前端行序号与归档行号已经在三种情况下分歧——桥接处丢弃的 chunk 进了归档却从未送达前端；归档封顶后 `total_lines()` 冻结而实时视图继续涨；归档永不含未终结的尾行。模式切换绕开全部三种，连续性自校验在假设被打破时重锚而非错拼。

同时修掉筛选标签页"加载更早"的两个缺陷：缺少滚动补偿（虚拟化前由浏览器 scroll anchoring 兜底，组件接管 `scrollTop` 后点一次视口就跳）、匹配列表无上限增长。

### `84de1d5` 滚动模型跟随 DOM + 清理死参数

`applyScrollTop` 存的是**请求值**，而 DOM 会把写入 clamp 到 `[0, scrollHeight - clientHeight]`；模型持有未 clamp 的值就会算出滚动条并不在的窗口。上一个 commit 靠"在每个调用点 clamp"绕过，而 `onActivated` 恰好漏了。现在改为写入后回读——这本身就是对的，且不额外付出代价（给 `scrollTop` 赋值本来就要解析布局才能 clamp）。

## 效果

每帧渲染成本从 O(缓冲区大小) 变为 O(视口)：

| | 改前 | 改后 |
|---|---|---|
| ASCII 5000 行 | 622 ms | 6.5 ms |
| ASCII 20000 行 | 5339 ms | 8.9 ms |
| hex 20000 行 | 42.8 ms | 0.57 ms |
| 交给 DOM 的 hex 文本 | 3.4 MB | 3.9 KB |
| 归档翻页 syscall（400 行） | 2002 | 6 |

**渲染数字出自 node/happy-dom，只覆盖 JS 开销**——浏览器的样式重算、reflow、paint 不在其中。真实收益应更大，但本 PR 不对此作量化承诺。

## 验证

```
cargo test -p tyutool-core     252 passed
cargo test -p tyutool-serve     29 passed
cargo test -p tyutool_gui       77 passed
cargo fmt --check              clean
pnpm exec vitest run           62 files / 908 tests passed
pnpm run lint / vue-tsc        clean
```

## 需要评审注意的可见变更

1. **长行不再自动换行**。定高虚拟化要求行高固定，`.text` 由 `pre-wrap` 改为 `pre`，超长行改为横向滚动（终端行为）。
2. **跨视口选中会被截断到已挂载的行**。视口内选中、右键复制/转 hex/转 ascii 均正常；完整日志的出口是「另存日志」，走后端分页不受影响。
3. **中途开启自动保存不再补写"内存里那部分"**，改为从归档回填整个会话，交接精确（不重不漏）。
4. **hex 视图下的搜索跳转**改为映射到该行首字节所在的 hex 行（此前按日志行序号计算，在字节行模型下无意义）。
5. **`serial_debug_close` 增加了 `app: AppHandle` 参数**（Tauri 自动注入，前端 `invoke` 调用不变）。

## 尚未完成 / 已知残留

- **真机验证**。所有性能数字与滚动行为都在无布局引擎的环境下测得，`rowHeight` 在测试中是打桩的。进入历史模式时的视口补偿是否真的不跳，需要接真设备在 `tauri:dev` 下确认。20000 档预设是否保留也建议届时再定。
- **Tauri 侧关闭收口有一个 ≤12ms 窗口**：serve 的 bridge `shutdown()` 是带 ack 的 rendezvous，最后一次冲刷必定先于收口；Tauri 的 bridge 靠句柄析构后 `Disconnected` 退出，没有 ack，所以极小概率最后一次冲刷落在收口之后，该片段留待下次收口。这是那个窗口的原有行为，不是本 PR 引入的回归。给 Tauri bridge 加一个带 ack 的 `Shutdown` 消息即可闭合，适合作为独立后续。
- **`read_page` 的整块读仍在锁内**。函数收到的 `&self` 借自调用方持有的 `MutexGuard`，无法在函数内释放；要移出锁外需改 `src-tauri` 与 `tyutool-serve` 两个调用点改用 `snapshot_reader()`。当前锁内工作量已降约 300 倍，优先级不高。
