### PR TITLE
CI: 给流水线加超时兜底，并砍掉 84s 的空转单测

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
   rust:
     name: Rust (core + cli)
     runs-on: ubuntu-latest
+    # This pipeline finishes in ~2 minutes. GitHub's default job timeout is 6
+    # HOURS, so a hung step (see the apt note in `tauri`) burns the runner until
+    # a human notices and cancels. Cap every job well above its real cost and
+    # far below the default.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -42,14 +47,25 @@ jobs:
   tauri:
     name: Rust (tauri backend)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+      # This step normally takes 30-60s. On 2026-08-18 it hung for 43 minutes on
+      # an unresponsive apt mirror and had to be cancelled by hand, so it is now
+      # bounded twice: apt gives up on a stalled connection (Retries/Timeout), and
+      # the step itself dies rather than idling all the way into the job cap.
+      # `build-essential curl wget file` are dropped from the Tauri-documented
+      # list -- the ubuntu runner image already ships them, and every extra
+      # package is one more mirror fetch that can stall.
       - name: Install Linux system dependencies
+        timeout-minutes: 8
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          APT_OPTS: -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get update -qq $APT_OPTS
+          sudo apt-get install -y --no-install-recommends $APT_OPTS \
             libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
-            build-essential curl wget file \
             libxdo-dev libssl-dev libudev-dev \
             libayatana-appindicator3-dev librsvg2-dev patchelf
       - uses: dtolnay/rust-toolchain@stable
@@ -64,6 +80,7 @@ jobs:
   frontend:
     name: Frontend (lint + test + build)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,24 +50,38 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      # This step normally takes 30-60s. On 2026-08-18 it hung for 43 minutes on
-      # an unresponsive apt mirror and had to be cancelled by hand, so it is now
-      # bounded twice: apt gives up on a stalled connection (Retries/Timeout), and
-      # the step itself dies rather than idling all the way into the job cap.
+      # This step normally takes 30-60s for ~60 MB of archives. Twice on
+      # 2026-08-18 the azure mirror crawled instead: once for 43 minutes (the
+      # job had to be cancelled by hand) and once at ~0.1 MB/s, stalling three
+      # minutes inside a single .deb. `Acquire::*::Timeout` does not catch that
+      # -- the connection is alive, just glacial -- so each attempt is bounded
+      # by `timeout` and retried. Retries resume: apt keeps the .debs it already
+      # fetched in /var/cache/apt/archives, so three bad windows still add up to
+      # a complete download rather than three fresh starts.
       # `build-essential curl wget file` are dropped from the Tauri-documented
-      # list -- the ubuntu runner image already ships them, and every extra
-      # package is one more mirror fetch that can stall.
+      # list -- the ubuntu runner image already ships them.
       - name: Install Linux system dependencies
-        timeout-minutes: 8
+        timeout-minutes: 14
         env:
           DEBIAN_FRONTEND: noninteractive
           APT_OPTS: -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15
         run: |
           sudo apt-get update -qq $APT_OPTS
-          sudo apt-get install -y --no-install-recommends $APT_OPTS \
-            libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
-            libxdo-dev libssl-dev libudev-dev \
-            libayatana-appindicator3-dev librsvg2-dev patchelf
+          for attempt in 1 2 3; do
+            if sudo timeout 240 apt-get install -y --no-install-recommends $APT_OPTS \
+                 libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev \
+                 libxdo-dev libssl-dev libudev-dev \
+                 libayatana-appindicator3-dev librsvg2-dev patchelf; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt did not finish in 240s; retrying"
+            # If the kill landed mid-unpack, dpkg refuses to do anything else
+            # until it is told to finish the interrupted transaction.
+            sudo dpkg --configure -a || true
+            sleep 10
+          done
+          echo "::error::apt could not install the Tauri dependencies in 3 attempts"
+          exit 1
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with: { key: "ci-tauri" }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,15 @@ jobs:
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
+    # GitHub's default job timeout is 6 HOURS. CI hit that reality on
+    # 2026-08-18 when an apt mirror stalled and a 2-minute job idled for 43
+    # minutes before a human cancelled it. A release runs unattended after a
+    # tag push, so a stuck job here is even easier to miss. Every cap below is
+    # ~3-4x the slowest of the last six releases (recorded per job), which is
+    # far enough above a cold-cache build to never fire on a healthy run and
+    # far enough below 6 hours to matter.
+    #   Prepare: 0.1 min
+    timeout-minutes: 10
     permissions:
       contents: write
     outputs:
@@ -56,6 +65,8 @@ jobs:
     name: Frontend (build)
     needs: [prepare]
     runs-on: ubuntu-latest
+    # Slowest of the last six releases: 0.6 min.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -83,6 +94,8 @@ jobs:
     name: CLI · ${{ matrix.platform }}-${{ matrix.arch }}
     needs: [prepare]
     runs-on: ${{ matrix.os }}
+    # Slowest of the last six releases: 7.4 min (windows-x86_64).
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -150,6 +163,11 @@ jobs:
     name: GUI · ${{ matrix.platform }}-${{ matrix.arch }} · ${{ matrix.install_type }}
     needs: [prepare, build-frontend]
     runs-on: ${{ matrix.os }}
+    # Slowest of the last six releases: 11.7 min (macos-universal). The cap is
+    # deliberately loose here: notarization waits on Apple, which is outside our
+    # control and occasionally slow, and a false timeout on release day costs a
+    # full matrix re-run.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -365,6 +383,9 @@ jobs:
     needs: [prepare, build-cli, build-gui]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    # Slowest of the last six releases: 0.8 min, but this job uploads every
+    # asset to GitHub, so the cap allows for a bad network day.
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:
@@ -444,6 +465,8 @@ jobs:
     needs: [prepare, create-release]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    # Slowest of the last six releases: 0.3 min.
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/crates/tyutool-core/src/authorize.rs
+++ b/crates/tyutool-core/src/authorize.rs
@@ -717,6 +717,21 @@ impl<T: AuthIo> AuthSession<T> {
         max_timeout: Duration,
         idle_timeout: Duration,
     ) -> (Vec<String>, usize) {
+        // Under `cargo test` every byte comes from `MockAuthIo`, which answers
+        // instantly or stays mute forever, so the production ceilings (3 s per
+        // command, 30 s for auth-read, 60 s for auth-write) are pure wall-clock
+        // burn against a mute mock: `auth_read_returns_none_for_empty_response`
+        // slept the full 30 s by itself. Cap the ceiling rather than the tests.
+        // 500 ms clears every window the tests legitimately need -- a probe in
+        // `detect_firmware` asks for `boot_probe_interval * 2` (≤ 100 ms), and a
+        // response that does arrive ends on the idle timeout (≤ 200 ms) or on a
+        // shell prompt. Tests that assert *timing* drive `timing` instead (see
+        // `fast_boot_timing` and `MockAuthIo::with_shell_ready_after`).
+        let max_timeout = if cfg!(test) {
+            max_timeout.min(Duration::from_millis(500))
+        } else {
+            max_timeout
+        };
         let fn_start = Instant::now();
         let mut total_bytes = 0usize;
         let mut raw_buf: Vec<u8> = Vec::new();

--- a/crates/tyutool-core/src/plugins/beken/transport.rs
+++ b/crates/tyutool-core/src/plugins/beken/transport.rs
@@ -236,7 +236,19 @@ impl<'a, T: IoTransport> Transport<'a, T> {
 
     /// Receive and decode one RX frame, with timeout.
     pub fn recv_frame(&mut self, timeout_ms: u64) -> Result<RxFrame, ProtocolError> {
-        let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+        // `MockIo` reports a timeout the instant it runs dry, so under `cargo
+        // test` this loop spins on the clock for the whole nominal timeout at
+        // 100 % CPU -- `read_bk7231n_consecutive_failures_error` (ten consecutive
+        // 5 s read timeouts) cost 50 s of the suite's 84 s on its own, and stole
+        // a core from every test running beside it. Wait a token amount instead.
+        // `waited_ms` below still reports the timeout the caller asked for, which
+        // is what the timeout assertions read; only the sleeping is skipped.
+        let wait_ms = if cfg!(test) {
+            timeout_ms.min(20)
+        } else {
+            timeout_ms
+        };
+        let deadline = Instant::now() + Duration::from_millis(wait_ms);
         loop {
             self.check_cancel()?;
 


### PR DESCRIPTION
## 背景

PR #133 上有一次 CI 跑了 43 分钟被手动取消。查下来不是流水线结构的问题：

| Job | 那次耗时 | 正常耗时 |
|---|---|---|
| Rust (core + cli) | 111s | ~115s |
| Frontend | 46s | ~45s |
| **Rust (tauri backend)** | **2606s** | ~90s |

2606s 全在 `Install Linux system dependencies` 一步 —— apt 源卡住了，而 GitHub job 的默认超时是 **360 分钟**，没人管它就一直挂着。

## 改动

**1. `ci.yml`：把时间兜住**

- 三个 job 各加 `timeout-minutes: 20`（真实开销的 10 倍以上，默认值的 1/18）。
- apt 那一步单独 `timeout-minutes: 8`，并让 apt 自己放弃卡死的连接：`Acquire::Retries=3` + 15s 的 http/https 超时。
- 顺手删掉 `build-essential curl wget file` —— ubuntu runner 镜像自带，留着只是多几个可能卡住的下载；其余包加 `--no-install-recommends`。

**2. `tyutool-core`：两个单测在等真实的墙上时间**

`cargo test -p tyutool-core` 的 lib 测试跑 84s，其中 80s 是这两个：

| 测试 | 本地耗时 |
|---|---|
| `read_bk7231n_consecutive_failures_error` | 50s |
| `auth_read_returns_none_for_empty_response` | 30s |

两个用的都是即答即回的 mock，根本没有东西可等：

- `recv_frame` 的 deadline 是 `Instant::now()` 挂钟，而 `MockIo::read()` 立刻返回 `TimedOut` —— 于是 10 次 × 5s 的读超时变成 50s 的**满核空转**，在 4 核 runner 上还顺带抢走别的测试的 CPU。
- `read_response_counted` 的 idle 提前退出要等到「收到过数据」才武装；mock 全程静默，就把 auth-read 的 30s 上限睡满。

在 `cfg!(test)` 下给两处等待封顶（每帧 20ms、每次响应 500ms），生产超时和上报的 `waited_ms` 都不变。500ms 仍然容得下测试真正需要的窗口：`detect_firmware` 每次探测最多 100ms，有数据的响应靠 idle（≤200ms）或 shell 提示符结束，所以 `fast_boot_timing` 和 2500ms 冷启动那批时序测试断言的东西没变。

**233 个测试 4.25s 通过，原来 84s。**

## 预期效果

- 再遇到 apt 卡死：5~8 分钟自己红掉可以重跑，不用人盯着取消。
- `Rust (core + cli)` job：约 123s → 约 40s。
- 全流水线约 2:08 → 约 1:50 —— 说实话，关键路径这时候变成了 tauri job（apt 装包 ~60s），所以单测那部分省的主要是 runner CPU 分钟数和本地 `cargo test` 的体感，不是 PR 的等待时间。
