### PR TITLE
fix(firmware-flash): point T5AI/T1/T3 erase presets at their real KV …

### DIFF
--- a/src/features/firmware-flash/chip-manifests.test.ts
+++ b/src/features/firmware-flash/chip-manifests.test.ts
@@ -47,6 +47,24 @@ describe("CHIP_MANIFEST", () => {
     }
   });
 
+  it("erase presets stay inside the chip's own flash map", () => {
+    for (const id of CHIP_IDS) {
+      const m = CHIP_MANIFEST[id];
+      const size = Number(m.flashSize);
+      for (const preset of Object.values(m.erasePresets)) {
+        if (!preset) continue;
+        expect(Number(preset.start)).toBeLessThan(size);
+        expect(Number(preset.end)).toBeLessThanOrEqual(size);
+      }
+      const auth = m.erasePresets.authInfo;
+      if (!auth) continue;
+      // The KV / authorization partition always sits at the very top of flash
+      // (last 8 KiB reserved for RF + net params). A preset copied from a
+      // smaller chip's map would land mid-application and erase nothing useful.
+      expect(Number(auth.end)).toBeGreaterThanOrEqual(size - 0x2000 - 1);
+    }
+  });
+
   it("erase presets have valid hex addresses", () => {
     for (const id of CHIP_IDS) {
       const m = CHIP_MANIFEST[id];

--- a/src/features/firmware-flash/chip-manifests.ts
+++ b/src/features/firmware-flash/chip-manifests.ts
@@ -88,8 +88,13 @@ export const CHIP_MANIFEST: Record<ChipId, ChipManifest> = {
     flashSize: "0x00800000", // 8 MiB
     eraseRequires4KAlignment: true,
     erasePresets: {
-      authInfo: { start: "0x001EE000", end: "0x001FFFFF" },
-      fullChipNoRf: { start: "0x00000000", end: "0x001EDFFF" },
+      // TuyaOpen platform/T5AI/tuyaos/tuyaos_adapter/src/driver/tkl_flash.c:
+      // the tuya_data partition 0x7CD000 (196 KiB) holds KV_PROTECTED / USER1 /
+      // KV / UF / KV_KEY — i.e. both the authorization data and the network
+      // provisioning data. sys_rf (0x7FE000) and sys_net (0x7FF000) are the
+      // last 8 KiB and are preserved by both presets.
+      authInfo: { start: "0x007CD000", end: "0x007FDFFF" },
+      fullChipNoRf: { start: "0x00000000", end: "0x007FDFFF" },
     },
   },
   t1: {
@@ -100,8 +105,8 @@ export const CHIP_MANIFEST: Record<ChipId, ChipManifest> = {
     flashSize: "0x00800000", // 8 MiB — same layout as T5AI
     eraseRequires4KAlignment: true,
     erasePresets: {
-      authInfo: { start: "0x001EE000", end: "0x001FFFFF" },
-      fullChipNoRf: { start: "0x00000000", end: "0x001EDFFF" },
+      authInfo: { start: "0x007CD000", end: "0x007FDFFF" },
+      fullChipNoRf: { start: "0x00000000", end: "0x007FDFFF" },
     },
   },
   t3: {
@@ -112,7 +117,11 @@ export const CHIP_MANIFEST: Record<ChipId, ChipManifest> = {
     flashSize: "0x00400000", // 4 MiB
     eraseRequires4KAlignment: true,
     erasePresets: {
-      authInfo: { start: "0x001EE000", end: "0x001FFFFF" },
+      // TuyaOpen platform/T3/tuyaos/tuyaos_adapter/src/driver/tkl_flash.c:
+      // the usr_config partition 0x3C9000 (212 KiB) holds KV_PROTECTED / RES1 /
+      // KV_KEY / KV / UF / RES2. The RF calibration (0x3FE000) and fast-connect
+      // (0x3FF000) blocks are the last 8 KiB and are preserved by both presets.
+      authInfo: { start: "0x003C9000", end: "0x003FDFFF" },
       fullChipNoRf: { start: "0x00000000", end: "0x003FDFFF" },
     },
   },

--- a/src/stores/flash.test.ts
+++ b/src/stores/flash.test.ts
@@ -501,8 +501,8 @@ describe("flash store", () => {
       const store = useFlashStore();
       store.selectedChipId = "t5ai"; // switch to a Beken chip that has authInfo
       store.applyErasePreset("authInfo");
-      expect(store.eraseStartAddr).toBe("0x001EE000");
-      expect(store.eraseEndAddr).toBe("0x001FFFFF");
+      expect(store.eraseStartAddr).toBe("0x007CD000");
+      expect(store.eraseEndAddr).toBe("0x007FDFFF");
     });
 
     it("sets erase address range from fullChipNoRf preset (Beken chip)", () => {
@@ -510,7 +510,7 @@ describe("flash store", () => {
       store.selectedChipId = "t5ai";
       store.applyErasePreset("fullChipNoRf");
       expect(store.eraseStartAddr).toBe("0x00000000");
-      expect(store.eraseEndAddr).toBe("0x001EDFFF");
+      expect(store.eraseEndAddr).toBe("0x007FDFFF");
     });
 
     it("sets erase address range from fullChip preset (ESP chip)", () => {


### PR DESCRIPTION
…region

The T5AI, T1 and T3 erase presets carried the 2 MiB BK7231N/T2 addresses. On T5AI (8 MiB) that put "erase authorization data" at 0x1EE000, which sits inside primary_ap_app, and capped "full chip erase" at 0x1EDFFF -- neither touches tuya_data at 0x7CD000, where the KV store holding the authorization and network provisioning data lives. Re-flashing QIO.bin only writes up to 0x25B800, so the provisioning data survived erase + re-flash.

Addresses come from the TuyaOpen partition maps:
  T5AI  tkl_flash.c  tuya_data   0x7CD000 (196 KiB), sys_rf/sys_net last 8 KiB
  T3    tkl_flash.c  usr_config  0x3C9000 (212 KiB), rf/fast-connect last 8 KiB

T1 follows T5AI per the layout note already in the manifest. T2 and BK7231N were checked against platform/T2 tkl_flash.c (KV_KEY 0x1EE000 / KV 0x1EF000 / KV_SWAP 0x1FD000) and are correct as-is, so they are left alone.

Batch flashing is unaffected: batch-flash-auth reads fullChipNoRf for flashStartHex/flashEndHex, but flash mode derives its erase range from base_addr + firmware.len() and ignores the end field.

Adds a regression test asserting every preset stays inside its own chip's flash and that authInfo reaches the tail of it.