### PR TITLE
fix(serial-debug): stop auto-save dying when its write grant lapses

### DIFF
--- a/crates/tyutool-bridge/src/tray_glyph.rs
+++ b/crates/tyutool-bridge/src/tray_glyph.rs
@@ -119,7 +119,9 @@ mod tests {
     fn visible_pixels(glyph: &Glyph) -> Vec<[u8; 4]> {
         glyph
             .rgba
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .filter(|px| px[3] > 0)
             .map(|px| [px[0], px[1], px[2], px[3]])
             .collect()

--- a/crates/tyutool-bridge/tests/ws_server.rs
+++ b/crates/tyutool-bridge/tests/ws_server.rs
@@ -44,10 +44,13 @@ async fn start_server() -> SocketAddr {
     addr
 }
 
+// The error is boxed because the bare tungstenite::Error is large enough to trip
+// clippy::result_large_err; no caller inspects it, only is_ok/is_err/expect.
 async fn connect_with_origin(
     addr: &SocketAddr,
     origin: &str,
-) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, tokio_tungstenite::tungstenite::Error> {
+) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, Box<tokio_tungstenite::tungstenite::Error>>
+{
     let mut request = format!("ws://{addr}/")
         .into_client_request()
         .expect("build client request");
@@ -58,6 +61,7 @@ async fn connect_with_origin(
     tokio_tungstenite::connect_async(request)
         .await
         .map(|(ws, _resp)| ws)
+        .map_err(Box::new)
 }
 
 #[tokio::test]

--- a/crates/tyutool-core/src/serial_debug.rs
+++ b/crates/tyutool-core/src/serial_debug.rs
@@ -1033,7 +1033,9 @@ fn read_line_run(
         idx_file.read_exact(&mut idx_buf)?;
 
         let entries = idx_buf
-            .chunks_exact(ARCHIVE_INDEX_ENTRY_BYTES as usize)
+            .as_chunks::<{ ARCHIVE_INDEX_ENTRY_BYTES as usize }>()
+            .0
+            .iter()
             .map(|entry| {
                 let mut offset = [0u8; 8];
                 let mut len = [0u8; 8];

--- a/src-tauri/src/logs.rs
+++ b/src-tauri/src/logs.rs
@@ -30,13 +30,15 @@ use crate::{detect_install_type, SESSION_ID};
 /// dialog-chosen path here; the write commands then refuse any path that is not
 /// the registered path itself or a descendant of a registered directory.
 ///
-/// Entries are TTL-bounded (a write is allowed within `TTL` of registration) so
-/// a leaked/old entry cannot be reused later. The map is capped to bound memory.
+/// Entries are TTL-bounded (a write is allowed within `TTL` of the last
+/// authorized write to that entry) so a leaked/idle entry cannot be reused
+/// later. The map is capped to bound memory.
 pub(crate) struct DialogPathRegistry {
     entries: StdMutex<Vec<(std::path::PathBuf, std::time::Instant)>>,
 }
 
-/// How long a registered path stays authorized for writes.
+/// How long a registered path stays authorized for writes, counted from the
+/// last authorized write to it (not from registration) — see `is_authorized`.
 const DIALOG_PATH_TTL: Duration = Duration::from_secs(600); // 10 min
 
 /// Maximum number of registered paths kept at once (LRU eviction on insert).
@@ -77,6 +79,13 @@ impl DialogPathRegistry {
     /// Returns true if `path` may be written: it equals a registered path, or it
     /// lives beneath a registered directory, within the TTL. Expired entries are
     /// pruned as a side effect.
+    ///
+    /// The TTL slides: an authorized write refreshes the entry it matched, so a
+    /// grant that is actively being written to cannot expire mid-session
+    /// (serial-debug auto-save appends every 5 s for as long as the port stays
+    /// open). A leaked/idle entry still expires 10 min after its last write, and
+    /// the path was user-chosen via a dialog either way, so the refresh does not
+    /// widen what the renderer may reach.
     fn is_authorized(&self, path: &std::path::Path) -> bool {
         let now = std::time::Instant::now();
         let mut entries = match self.entries.lock() {
@@ -84,14 +93,21 @@ impl DialogPathRegistry {
             Err(p) => p.into_inner(),
         };
         Self::prune_locked(&mut entries, now);
-        entries.iter().any(|(registered, ts)| {
+        let hit = entries.iter().position(|(registered, ts)| {
             if now.duration_since(*ts) > DIALOG_PATH_TTL {
                 return false;
             }
             // Authorized if the write target is the registered path itself, or a
             // descendant of a registered directory.
             path == registered || path.starts_with(registered)
-        })
+        });
+        match hit {
+            Some(idx) => {
+                entries[idx].1 = now;
+                true
+            }
+            None => false,
+        }
     }
 
     fn prune_locked(
@@ -1375,6 +1391,7 @@ mod log_tools_tests {
 mod dialog_path_registry_tests {
     use super::DialogPathRegistry;
     use std::path::Path;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn rejects_unregistered_path() {
@@ -1411,6 +1428,53 @@ mod dialog_path_registry_tests {
         assert!(reg.is_authorized(Path::new("/tmp/export.txt")));
     }
 
+    /// A grant that keeps being written to must not expire mid-session. The age
+    /// is injected through the (same-module) private `entries` vec instead of
+    /// sleeping out the 10 minute TTL.
+    #[test]
+    fn authorized_write_slides_the_ttl_forward() {
+        let reg = DialogPathRegistry::new();
+        reg.register(Path::new("/tmp/serial-debug"));
+        let target = Path::new("/tmp/serial-debug/ttyUSB0/log.txt");
+
+        // Age the entry to just inside the TTL, as a 9½-minute-old session would be.
+        let almost_expired = super::DIALOG_PATH_TTL - Duration::from_secs(30);
+        age_entry(&reg, almost_expired);
+        let before = entry_ts(&reg);
+
+        assert!(reg.is_authorized(target));
+        assert!(
+            entry_ts(&reg) > before,
+            "an authorized write must refresh its own grant"
+        );
+
+        // The refreshed grant survives another almost-TTL gap; a registration-only
+        // TTL would have expired by now.
+        age_entry(&reg, almost_expired);
+        assert!(reg.is_authorized(target));
+    }
+
+    /// The other half of the sliding TTL: an entry nothing writes to still dies.
+    #[test]
+    fn idle_entry_still_expires() {
+        let reg = DialogPathRegistry::new();
+        reg.register(Path::new("/tmp/serial-debug"));
+        age_entry(&reg, super::DIALOG_PATH_TTL + Duration::from_secs(1));
+        assert!(!reg.is_authorized(Path::new("/tmp/serial-debug/ttyUSB0/log.txt")));
+    }
+
+    /// Backdate the single registered entry by `age`.
+    fn age_entry(reg: &DialogPathRegistry, age: Duration) {
+        let mut entries = reg.entries.lock().expect("poisoned");
+        entries[0].1 = Instant::now()
+            .checked_sub(age)
+            .expect("test clock too close to boot");
+    }
+
+    fn entry_ts(reg: &DialogPathRegistry) -> Instant {
+        reg.entries.lock().expect("poisoned")[0].1
+    }
+
     #[test]
     fn evicts_oldest_when_at_capacity() {
         let reg = DialogPathRegistry::new();
@@ -1418,7 +1482,8 @@ mod dialog_path_registry_tests {
         for i in 0..super::DIALOG_PATH_MAX_ENTRIES {
             reg.register(Path::new(&format!("/tmp/file-{i}.txt")));
         }
-        assert!(reg.is_authorized(Path::new("/tmp/file-0.txt")));
+        // No probing file-0 first: an authorized write slides its timestamp
+        // forward, which would make it the newest entry rather than the oldest.
         // Adding one more evicts the oldest (file-0 was registered first).
         reg.register(Path::new("/tmp/extra.txt"));
         assert!(reg.is_authorized(Path::new("/tmp/extra.txt")));

--- a/src/features/serial-debug/useSerialAutoSave.test.ts
+++ b/src/features/serial-debug/useSerialAutoSave.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { createPinia, setActivePinia } from "pinia";
-import { createApp, defineComponent, nextTick } from "vue";
+import { createApp, defineComponent, h, KeepAlive, nextTick, ref } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SerialDebugTransport } from "./transport";
 import { __setSerialDebugTransportForTest } from "./transport";
@@ -179,8 +179,61 @@ describe("useSerialAutoSave", () => {
     app.mount(host);
   }
 
+  /**
+   * Same composable, but inside a `<KeepAlive>` so that navigating away from and
+   * back to the page runs the real `onDeactivated` / `onActivated` hooks.
+   */
+  function mountKeptAlive(s: ReturnType<typeof useSerialDebugStore>): {
+    deactivate: () => Promise<void>;
+    activate: () => Promise<void>;
+  } {
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    const shown = ref(true);
+    const Page = defineComponent({
+      setup() {
+        useSerialAutoSave(s);
+        return () => null;
+      },
+    });
+    app = createApp(
+      defineComponent({
+        setup() {
+          return () => h(KeepAlive, null, [shown.value ? h(Page) : h("div")]);
+        },
+      }),
+    );
+    app.mount(host);
+    return {
+      async deactivate() {
+        shown.value = false;
+        await nextTick();
+      },
+      async activate() {
+        shown.value = true;
+        await nextTick();
+      },
+    };
+  }
+
+  /**
+   * The file-writing invokes only — starting a session also invokes
+   * `register_dialog_path` to renew the write authorization.
+   */
+  function appendCalls(): unknown[][] {
+    return invokeSpy.mock.calls.filter(
+      (call) => call[0] === "append_text_file",
+    );
+  }
+
+  function registerCalls(): unknown[][] {
+    return invokeSpy.mock.calls.filter(
+      (call) => call[0] === "register_dialog_path",
+    );
+  }
+
   function writtenContents(): string[] {
-    return invokeSpy.mock.calls.map(
+    return appendCalls().map(
       (call) => (call[1] as { content: string }).content,
     );
   }
@@ -204,6 +257,9 @@ describe("useSerialAutoSave", () => {
     s.autoSaveDir = "/logs";
     s.open = true;
     await nextTick();
+    // Let the session-start authorization renewal land before the per-call
+    // mocks below, so they apply to the file writes.
+    await settle();
     expect(s.sessionAutoSavePath).not.toBeNull();
 
     s.appendChunk({
@@ -223,7 +279,7 @@ describe("useSerialAutoSave", () => {
       .mockResolvedValueOnce(undefined);
 
     await vi.advanceTimersByTimeAsync(5000);
-    expect(invokeSpy).toHaveBeenCalledTimes(1);
+    expect(appendCalls()).toHaveLength(1);
 
     s.appendChunk({
       direction: "rx",
@@ -238,7 +294,7 @@ describe("useSerialAutoSave", () => {
     (releaseFirstWrite as (() => void) | null)?.();
     await flushMicrotasks();
 
-    expect(invokeSpy).toHaveBeenCalledTimes(2);
+    expect(appendCalls()).toHaveLength(2);
     expect(s.sessionAutoSavePath).toBeNull();
   });
 
@@ -278,9 +334,9 @@ describe("useSerialAutoSave", () => {
     // than a couple of microtask rounds.
     await settle();
 
-    expect(invokeSpy.mock.calls.length).toBeGreaterThan(1);
+    expect(appendCalls().length).toBeGreaterThan(1);
     expect(s.sessionAutoSavePath).toBeNull();
-    for (const call of invokeSpy.mock.calls) {
+    for (const call of appendCalls()) {
       expect((call[1] as { content: string }).content.length).toBeLessThan(
         AUTO_SAVE_FLUSH_MAX_CHARS * 2,
       );
@@ -314,7 +370,7 @@ describe("useSerialAutoSave", () => {
     await flushMicrotasks();
 
     // A single append per tick would leave most of this behind forever.
-    expect(invokeSpy.mock.calls.length).toBeGreaterThanOrEqual(5);
+    expect(appendCalls().length).toBeGreaterThanOrEqual(5);
     expect(s.drainPendingAutoSaveLines(Infinity)).toEqual([]);
   });
 
@@ -345,13 +401,13 @@ describe("useSerialAutoSave", () => {
     await flushMicrotasks();
 
     // 20 batches of backlog, capped at 16 appends for this tick.
-    const firstTickAppends = invokeSpy.mock.calls.length;
+    const firstTickAppends = appendCalls().length;
     expect(firstTickAppends).toBe(16);
 
     await vi.advanceTimersByTimeAsync(5000);
     await flushMicrotasks();
 
-    expect(invokeSpy.mock.calls.length).toBeGreaterThan(firstTickAppends);
+    expect(appendCalls().length).toBeGreaterThan(firstTickAppends);
     expect(s.drainPendingAutoSaveLines(Infinity)).toEqual([]);
   });
 
@@ -386,7 +442,7 @@ describe("useSerialAutoSave", () => {
     await settle();
 
     expect(s.sessionAutoSavePath).not.toBeNull();
-    expect(invokeSpy).toHaveBeenCalledTimes(1);
+    expect(appendCalls()).toHaveLength(1);
     expect(invokeSpy).toHaveBeenCalledWith("append_text_file", {
       path: s.sessionAutoSavePath,
       content:
@@ -529,7 +585,7 @@ describe("useSerialAutoSave", () => {
     await settle();
 
     // The periodic flush fired but must not overtake the pending backfill.
-    expect(invokeSpy).not.toHaveBeenCalled();
+    expect(appendCalls()).toHaveLength(0);
 
     (releasePage as ((page: SerialDebugSessionPage) => void) | null)?.({
       totalLines: 1,
@@ -820,7 +876,7 @@ describe("useSerialAutoSave", () => {
     await settle();
 
     expect(s.sessionAutoSavePath).not.toBeNull();
-    expect(invokeSpy).not.toHaveBeenCalled();
+    expect(appendCalls()).toHaveLength(0);
     expect(
       s.lines.some((line) =>
         line.text.startsWith("serialDebug.autoSave.errWrite"),
@@ -837,5 +893,129 @@ describe("useSerialAutoSave", () => {
     await settle();
 
     expect(writtenContents()).toEqual([`[${formatTs(1000)}] [RX ] live\n`]);
+  });
+
+  /**
+   * The Rust-side dialog-path grant expires 10 min after the last authorized
+   * write, and is otherwise only handed out when the user picks the directory.
+   * A session starting after a long idle gap must renew it, or every append is
+   * refused and auto-save shuts itself down mid-session.
+   */
+  it("renews the write authorization for the auto-save dir on session start", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+    invokeSpy.mockResolvedValue(undefined);
+
+    s.port = "/dev/ttyUSB0";
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    s.open = true;
+    await nextTick();
+    await settle();
+
+    expect(invokeSpy).toHaveBeenCalledWith("register_dialog_path", {
+      path: "/logs",
+    });
+    expect(registerCalls()).toHaveLength(1);
+
+    // Closed and reopened later — by then the previous grant may be long gone.
+    s.open = false;
+    await nextTick();
+    await settle();
+    s.open = true;
+    await nextTick();
+    await settle();
+
+    expect(registerCalls()).toHaveLength(2);
+  });
+
+  it("keeps recording when the authorization renewal fails", async () => {
+    const s = useSerialDebugStore();
+    mountAutoSave(s);
+    invokeSpy.mockImplementation(async (cmd: string) => {
+      if (cmd === "register_dialog_path") throw new Error("nope");
+    });
+
+    s.port = "/dev/ttyUSB0";
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    s.open = true;
+    await nextTick();
+    await settle();
+
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 1000,
+      bytes: [...Buffer.from("live\n")],
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    expect(writtenContents()).toEqual([`[${formatTs(1000)}] [RX ] live\n`]);
+    expect(
+      s.lines.some((line) =>
+        line.text.startsWith("serialDebug.autoSave.errWrite"),
+      ),
+    ).toBe(false);
+  });
+
+  /**
+   * Navigating away keeps the session file (the port is still open) but stops
+   * the flush interval, so nothing renews the grant while the user is gone —
+   * ten minutes on another page is enough for it to lapse. Coming back resumes
+   * the interval on the same path, so the renewal has to land before the first
+   * append or every later write is refused.
+   */
+  it("renews the write authorization when the page is reactivated with the port open", async () => {
+    const s = useSerialDebugStore();
+    const page = mountKeptAlive(s);
+    invokeSpy.mockResolvedValue(undefined);
+
+    s.port = "/dev/ttyUSB0";
+    s.autoSave = true;
+    s.autoSaveDir = "/logs";
+    s.open = true;
+    await nextTick();
+    await settle();
+
+    expect(registerCalls()).toHaveLength(1);
+    const sessionPath = s.sessionAutoSavePath;
+    expect(sessionPath).not.toBeNull();
+
+    await page.deactivate();
+    await settle();
+    // The port is still open, so the session file survives the navigation.
+    expect(s.sessionAutoSavePath).toBe(sessionPath);
+
+    // Hold the renewal open, to prove nothing is appended before it lands.
+    let releaseRenewal: (() => void) | null = null;
+    invokeSpy.mockImplementation(async (cmd: string) => {
+      if (cmd === "register_dialog_path") {
+        await new Promise<void>((resolve) => {
+          releaseRenewal = resolve;
+        });
+      }
+    });
+
+    await page.activate();
+    await settle();
+
+    expect(registerCalls()).toHaveLength(2);
+
+    s.appendChunk({
+      direction: "rx",
+      tsMs: 3000,
+      bytes: [...Buffer.from("back\n")],
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+    await settle();
+
+    // The resumed interval ticked while the renewal was still pending.
+    expect(appendCalls()).toHaveLength(0);
+
+    (releaseRenewal as (() => void) | null)?.();
+    await settle();
+
+    expect(writtenContents()).toEqual([`[${formatTs(3000)}] [RX ] back\n`]);
   });
 });

--- a/src/features/serial-debug/useSerialAutoSave.ts
+++ b/src/features/serial-debug/useSerialAutoSave.ts
@@ -200,6 +200,28 @@ export function useSerialAutoSave(s: SerialDebugStore): void {
     await currentFlushPromise;
   }
 
+  /**
+   * Renew the write authorization for the auto-save directory.
+   *
+   * The Rust-side `DialogPathRegistry` only authorizes writes for 10 min after
+   * the last write to a registered path, and the dir is otherwise registered
+   * only when the user picks it (or when the workspace is restored). Never
+   * rejects: a failed renewal is not itself actionable, and the first append
+   * will surface the refusal through `serialDebug.autoSave.errWrite`.
+   */
+  async function registerAutoSaveDir(dir: string): Promise<void> {
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      await invoke("register_dialog_path", { path: dir });
+    } catch (e) {
+      rLog.warn(
+        `[SerialDebug] auto-save dir re-register failed: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+    }
+  }
+
   function startAutoSave(): void {
     if (!s.autoSave || !s.autoSaveDir) return;
     // Idempotent: when autoSave, autoSaveDir and open all flip in one tick both
@@ -208,12 +230,19 @@ export function useSerialAutoSave(s: SerialDebugStore): void {
     // backfill whose bookkeeping races the first one's.
     if (s.sessionAutoSavePath !== null) return;
     stopInterval();
+    const dir = s.autoSaveDir;
     const portDir = sanitizePortName(s.port);
     const filename = `serial-debug-${makeStamp()}.txt`;
     // path separator: Tauri on all platforms accepts forward slash
-    const path = `${s.autoSaveDir}/${portDir}/${filename}`;
+    const path = `${dir}/${portDir}/${filename}`;
     s.sessionAutoSavePath = path;
-    backfillPromise = backfillFromArchive(path)
+    // The dialog-path grant that authorizes writes under the auto-save dir
+    // expires 10 min after the last authorized write, so a session started
+    // after a long idle gap (port closed, reopened much later) needs a fresh
+    // grant before the first append. Everything that writes goes through
+    // backfillPromise first, so chaining here is enough to order it.
+    backfillPromise = registerAutoSaveDir(dir)
+      .then(() => backfillFromArchive(path))
       .catch((e) => {
         // No archive yet (port never opened) or an unreadable one must not stop
         // auto-save: the live half still records from here on. Developer-only
@@ -243,6 +272,21 @@ export function useSerialAutoSave(s: SerialDebugStore): void {
   onActivated(() => {
     if (s.open && s.sessionAutoSavePath) {
       stopInterval();
+      // Leaving the page stops the flush interval but keeps the session file
+      // while the port stays open, so nothing writes while the user is away and
+      // the dialog-path grant can expire before they come back. Renew it before
+      // the resumed interval appends anything: `flush` awaits `backfillPromise`
+      // first, so parking the renewal there reuses the ordering channel that
+      // already exists. When a start-time backfill is still in flight we skip
+      // the renewal instead of chaining onto it — that chain renewed the grant
+      // itself and is still writing, so the grant cannot have expired, and
+      // replacing the promise would drop the backfill's own ordering guarantee.
+      const dir = s.autoSaveDir;
+      if (dir && !backfillPromise) {
+        backfillPromise = registerAutoSaveDir(dir).finally(() => {
+          backfillPromise = null;
+        });
+      }
       autoSaveInterval = setInterval(() => {
         void flush();
       }, 5000);


### PR DESCRIPTION
## Problem

Serial-debug auto-save dies mid-session with `自动保存失败: path is not authorized for writing` / `Auto-save failed: path is not authorized for writing`, roughly ten minutes in:

```
10:05:34  SYS  自动保存失败: path is not authorized for writing
```

`DialogPathRegistry` (`src-tauri/src/logs.rs`) gates the renderer-reachable arbitrary-path write primitives (`write_text_file` / `append_text_file`) to dialog-chosen paths, with a 10 minute TTL counted **from registration**. The auto-save directory is registered only when the user picks it (`pickAutoSaveDir`) or when the workspace is restored at startup (`loadWorkspace`), but auto-save appends every 5 s for as long as the port stays open. Nothing ever refreshed the grant, so ten minutes after the last registration every append was refused.

It also did not recover: the `flush` catch-block calls `stopInterval()` and clears `sessionAutoSavePath`, and toggling auto-save off/on does not re-register (the directory is already set, so `pickAutoSaveDir` is never reached). Only re-picking the directory or restarting the app brought it back.

## Fix

**Slide the TTL** — `DialogPathRegistry::is_authorized` now refreshes the entry it matched. A grant that is actively being written to cannot expire mid-session; an idle or leaked entry still dies 10 min after its last write. The path was dialog-chosen either way, so the refresh does not widen what the renderer may reach. Side effect worth noting: because the timestamp now means *last write* rather than *registration*, the capacity eviction in `register` becomes true LRU instead of FIFO — an actively-written auto-save dir can no longer be squeezed out by 32 other entries.

**Renew explicitly on the two paths that have no write to slide:**

| Path | Why the grant lapses | Fix |
|---|---|---|
| `startAutoSave()` | Port closed for >10 min, then reopened | Re-register before the first append |
| `onActivated()` resume branch | Navigating away stops the flush interval but keeps the session file (port still open) — >10 min on another page and nothing slid the grant | Re-register before the resumed interval appends |

Both park the renewal on `backfillPromise`, which `flush()` already awaits before its first write, so no append can overtake the renewal — no new synchronisation flag. `onActivated` skips the renewal when a start-time backfill is still in flight: that chain renewed the grant itself and is actively appending, so the grant cannot have expired, and reassigning `backfillPromise` there would drop the backfill's own ordering guarantee.

A failed renewal is non-fatal (`rLog.warn` only) — the first append still surfaces a real refusal through `serialDebug.autoSave.errWrite`.

## Scope

No change to error surfacing, no retry logic, no UI or i18n changes, no CLI change (so no `docs/cli.md` update needed).

## Tests

**Rust** (`cargo test -p tyutool_gui`, 7 registry tests, all pass):

- `authorized_write_slides_the_ttl_forward` — backdates the entry to just inside the TTL via the same-module private `entries` vec, asserts the timestamp advanced, then backdates again and asserts it is still authorized. A registration-only TTL would have expired.
- `idle_entry_still_expires` — the security half of the contract.
- `evicts_oldest_when_at_capacity` dropped one precondition probe: `is_authorized` now slides the probed entry to newest, which would invert the eviction assertion. A comment explains why.

**Frontend** (`useSerialAutoSave.test.ts`, 18 tests, all pass):

- `register_dialog_path` is invoked once per session start, and again across a close→reopen cycle.
- A failing renewal still records, with no `errWrite` line.
- Reactivation with the port open renews, and **no append lands while the renewal is held pending** — released, the line reaches the file. Needed a new `mountKeptAlive` harness: no prior test exercised `onActivated`/`onDeactivated` at all.
- Negative control: with the `onActivated` renewal stripped, exactly that test fails on the renewal assertion.
- Existing count assertions moved from total `invokeSpy` calls to an `append_text_file` filter, since session start now also invokes `register_dialog_path`.

`pnpm run lint`, `prettier --check`, `vue-tsc --noEmit` and `cargo fmt --check` all clean.

## Not verified

End-to-end behaviour against the real `DialogPathRegistry` after a genuine >10 min idle was not exercised on hardware — only the frontend contract (that `register_dialog_path` is invoked and ordered ahead of the first append) and the Rust TTL logic are under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
