### PR TITLE
refactor(serial-debug): share the chunk bridge between both hosts

### DIFF
--- a/crates/tyutool-core/src/lib.rs
+++ b/crates/tyutool-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod plugins;
 mod registry;
 mod serial;
 mod serial_debug;
+mod serial_debug_bridge;
 mod tuya_dev_usb;
 mod usb_port_survey;
 
@@ -39,5 +40,11 @@ pub use serial_debug::{
     SerialDebugDropReport, SerialDebugFilterBackfillSnapshot, SerialDebugFilterDefinition,
     SerialDebugFilterIndex, SerialDebugFilterPage, SerialDebugFilterStats, SerialDebugFilterStatus,
     SerialDebugGeneration, SerialDebugLine, SerialDebugSession, SerialDebugSessionPage, StopBits,
+};
+pub use serial_debug_bridge::{
+    serial_debug_finalize_pending, serial_debug_flush_chunks, serial_debug_ingest_lines,
+    serial_debug_report_drops, serial_debug_spawn_chunk_bridge, ArchivedChunk,
+    SerialDebugChunkBridgeHandle, SerialDebugSink, SERIAL_DEBUG_CHUNK_FLUSH_BYTES,
+    SERIAL_DEBUG_CHUNK_FLUSH_MS, SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY,
 };
 pub use usb_port_survey::{usb_port_survey, UsbPortSurveyEntry, UsbPortSurveyUsb};

--- a/crates/tyutool-core/src/serial_debug_bridge.rs
+++ b/crates/tyutool-core/src/serial_debug_bridge.rs
@@ -1,0 +1,699 @@
+//! The chunk bridge that carries serial-debug output from the reader thread to a
+//! UI, shared by every host that has one.
+//!
+//! Device output arrives line-by-line but must reach the UI in coalesced batches
+//! (`SERIAL_DEBUG_CHUNK_FLUSH_*`) so a chatty device cannot flood the transport.
+//! That batching, the bounded queue in front of it, the archive bookkeeping and
+//! the three notices the user has to see (batch, dropped, capped) are host
+//! independent — only the *sink* differs: `src-tauri` emits Tauri events to the
+//! webview, `tyutool-serve` sends `ServerMessage`s down a WebSocket.
+//!
+//! Both hosts previously carried their own copy of all of it. The copies had
+//! already drifted (one grew a parameter it only passed to `let _ =`), and the
+//! drop-report and archive-cap paths are exactly the kind of rare,
+//! hard-to-reproduce behaviour where a fix landing in one copy and not the other
+//! stays invisible until a user hits it. Implement [`SerialDebugSink`] and the
+//! two hosts behave identically by construction.
+
+use std::sync::mpsc::{self, RecvTimeoutError, SyncSender, TrySendError};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde::Serialize;
+
+use crate::serial_debug::{
+    serial_debug_archive_cap_limit_mib, serial_debug_now_ms, DebugChunk, Direction,
+    SerialDebugArchive, SerialDebugChunkBatchBuffer, SerialDebugDropCounter, SerialDebugDropReport,
+    SerialDebugFilterDefinition, SerialDebugFilterIndex, SerialDebugFilterStats,
+    SerialDebugGeneration, SerialDebugLine,
+};
+
+/// How long a partially-filled batch may wait before it is flushed anyway. Also
+/// the bridge thread's poll interval, so the drop check runs at least this often
+/// even on a silent port.
+pub const SERIAL_DEBUG_CHUNK_FLUSH_MS: u64 = 12;
+/// Flush early once a batch reaches this many bytes, so a fast device gets
+/// throughput instead of 12 ms of latency per 32 KiB.
+pub const SERIAL_DEBUG_CHUNK_FLUSH_BYTES: usize = 32 * 1024;
+/// Bound the bridge queue so sustained ingress can't grow process memory without
+/// limit when archive/filter/UI consumption temporarily lags behind the serial
+/// reader.
+pub const SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY: usize = 256;
+
+/// One chunk on its way to the UI, plus the number of lines the session archive
+/// held *before* this chunk was appended to it.
+///
+/// That number is what lets the frontend switch auto-save on mid-session without
+/// either duplicating or losing a line. Auto-save enables in two halves — the
+/// archive is paged into the file up to a snapshot `N`, the live queue continues
+/// after it — and the frontend cannot otherwise tell which half a live line
+/// belongs to: its own line counter and the archive's `line_no` diverge (the
+/// archive freezes its numbering once capped, and never holds an unterminated
+/// trailing line).
+///
+/// `archived_before` closes that gap exactly, because `append_chunk` archives a
+/// whole chunk under one lock: no snapshot can land *inside* a chunk, so every
+/// line the chunk produced is either wholly inside `N` or wholly after it.
+/// A live line is therefore already in the backfilled half iff
+/// `archived_before < N` — see `dropBackfilledAutoSaveLines` in
+/// `src/stores/serial-debug.ts`.
+///
+/// Read under the same lock guard as the `append_chunk` it precedes; reading it
+/// outside the guard would let another writer slip in between and make the
+/// number a lie.
+///
+/// Flattened into the `chunk` object, which already serialises camelCase
+/// (`tsMs`), so the field reaches the frontend as `archivedBefore` with no
+/// mapping at either transport boundary.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchivedChunk {
+    #[serde(flatten)]
+    pub chunk: DebugChunk,
+    pub archived_before: u64,
+}
+
+/// Where a host's serial-debug output goes. One implementation per transport.
+///
+/// Every method is fire-and-forget: a closed webview or a dropped WebSocket is
+/// normal teardown, not something the bridge can act on, and the bridge thread
+/// must not stall on it either way. Implementations must therefore neither block
+/// nor panic. `Send + 'static` because the bridge owns one on its own thread.
+pub trait SerialDebugSink: Send + 'static {
+    /// One coalesced batch of device output, in arrival order.
+    fn chunk_batch(&self, chunks: Vec<ArchivedChunk>);
+    /// Device output the bounded queue could not accept. `archived_before` is the
+    /// position of the gap lines this notice belongs to.
+    fn chunks_dropped(&self, dropped_bytes: u64, archived_before: u64);
+    /// The session archive hit its size cap and stopped recording.
+    fn archive_capped(&self, limit_mib: u64, archived_before: u64);
+    /// A filter's match count moved.
+    fn filter_updated(&self, def: SerialDebugFilterDefinition, stats: SerialDebugFilterStats);
+}
+
+enum SerialDebugChunkBridgeMessage {
+    Chunk {
+        generation: u64,
+        chunk: DebugChunk,
+    },
+    Reset {
+        generation: u64,
+        ack: SyncSender<()>,
+    },
+    /// Drain and stop, acknowledged. Hosts that tear the bridge down by dropping
+    /// every handle get the same drain via `Disconnected` instead and never send
+    /// this.
+    Shutdown {
+        ack: SyncSender<()>,
+    },
+}
+
+#[derive(Clone)]
+pub struct SerialDebugChunkBridgeHandle {
+    generation: Arc<SerialDebugGeneration>,
+    send_lock: Arc<Mutex<()>>,
+    tx: SyncSender<SerialDebugChunkBridgeMessage>,
+    drops: Arc<SerialDebugDropCounter>,
+}
+
+impl SerialDebugChunkBridgeHandle {
+    /// Hand one chunk to the bridge, or account for it as lost.
+    ///
+    /// `try_send`, never `send`: this runs on the serial reader thread, which is
+    /// the only thread draining the OS/driver receive buffer, and the port runs
+    /// without flow control. Blocking here therefore applies no backpressure to
+    /// the *device* — it just stops the buffer being drained until the driver
+    /// overflows and discards bytes we never saw, with no count, no error and
+    /// nothing to show the user. Dropping the chunk here instead keeps the reader
+    /// draining and moves the loss to a boundary we own: we know how many bytes
+    /// went, we can close the archive line so the halves cannot be spliced, and
+    /// we can tell the user (who can lower the baud rate or quieten the device).
+    pub fn send_chunk(&self, chunk: DebugChunk) {
+        let _guard = self.send_lock.lock().unwrap();
+        let bytes = chunk.bytes.len();
+        match self.tx.try_send(SerialDebugChunkBridgeMessage::Chunk {
+            generation: self.generation.current(),
+            chunk,
+        }) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => self.drops.record(bytes, serial_debug_now_ms()),
+            // The bridge thread is gone; the session is being torn down.
+            Err(TrySendError::Disconnected(_)) => {}
+        }
+    }
+
+    /// Discard everything in flight and start a new generation, so output from
+    /// the log the user just cleared cannot land in the new one.
+    pub fn reset(&self) -> Result<u64, String> {
+        let _guard = self.send_lock.lock().unwrap();
+        let generation = self.generation.advance();
+        let (ack_tx, ack_rx) = mpsc::sync_channel(0);
+        self.tx
+            .send(SerialDebugChunkBridgeMessage::Reset {
+                generation,
+                ack: ack_tx,
+            })
+            .map_err(|e| e.to_string())?;
+        ack_rx.recv().map_err(|e| e.to_string())?;
+        Ok(generation)
+    }
+
+    /// Flush, report any last drops, and stop — waiting until the thread has done
+    /// so.
+    pub fn shutdown(self) -> Result<(), String> {
+        let _guard = self.send_lock.lock().unwrap();
+        let (ack_tx, ack_rx) = mpsc::sync_channel(0);
+        self.tx
+            .send(SerialDebugChunkBridgeMessage::Shutdown { ack: ack_tx })
+            .map_err(|e| e.to_string())?;
+        ack_rx.recv().map_err(|e| e.to_string())?;
+        Ok(())
+    }
+}
+
+/// Every line the archive accepts passes through [`serial_debug_ingest_lines`],
+/// which makes it the one place that can spot the archive-cap sentinel. The live
+/// view never sees archived lines — it re-splits the raw chunk payloads itself —
+/// so without this notice the cap would only ever exist in the archive file and
+/// the user would watch the log keep scrolling with no hint that recording had
+/// stopped.
+fn emit_archive_cap_notice(sink: &impl SerialDebugSink, lines: &[SerialDebugLine]) {
+    if let Some((limit_mib, line_no)) = lines
+        .iter()
+        .find_map(|line| serial_debug_archive_cap_limit_mib(line).map(|mib| (mib, line.line_no)))
+    {
+        // The sentinel is an archive line like any other, so its own position is
+        // exactly `line_no - 1`.
+        sink.archive_capped(limit_mib, line_no.saturating_sub(1));
+    }
+}
+
+/// Feed newly-archived lines to the filter index and announce whatever moved.
+pub fn serial_debug_ingest_lines(
+    sink: &impl SerialDebugSink,
+    filters: &Arc<Mutex<SerialDebugFilterIndex>>,
+    lines: &[SerialDebugLine],
+) {
+    if lines.is_empty() {
+        return;
+    }
+    emit_archive_cap_notice(sink, lines);
+    // One lock acquisition, not two: this runs per flushed batch (every 12 ms on
+    // a busy port), and taking the lock again to look the definitions up would
+    // also let a `filter_remove` land in between and silently swallow the update.
+    let updates = {
+        let mut guard = match filters.lock() {
+            Ok(guard) => guard,
+            Err(_) => return,
+        };
+        let moved = guard.ingest_completed_lines(lines).unwrap_or_default();
+        moved
+            .into_iter()
+            .filter_map(|stats| guard.definition(&stats.filter_id).map(|def| (def, stats)))
+            .collect::<Vec<_>>()
+    };
+    // Emitted outside the guard: a sink must not be able to hold the filter index
+    // for as long as its transport takes.
+    for (def, stats) in updates {
+        sink.filter_updated(def, stats);
+    }
+}
+
+/// Archive one batch of chunks and hand it to the sink.
+pub fn serial_debug_flush_chunks(
+    sink: &impl SerialDebugSink,
+    archive: &Arc<Mutex<SerialDebugArchive>>,
+    filters: &Arc<Mutex<SerialDebugFilterIndex>>,
+    chunks: Vec<DebugChunk>,
+) {
+    if chunks.is_empty() {
+        return;
+    }
+    let (completed, archived) = {
+        let mut guard = match archive.lock() {
+            Ok(guard) => guard,
+            Err(_) => return,
+        };
+        let mut completed = Vec::new();
+        let mut archived = Vec::with_capacity(chunks.len());
+        // One `archived_before` per chunk, not one per batch: per-chunk only
+        // needs `append_chunk` to be atomic, which the archive guarantees on its
+        // own, whereas a per-batch number would additionally rely on this loop
+        // holding the lock for the whole batch.
+        for chunk in chunks {
+            let archived_before = guard.total_lines();
+            completed.extend(guard.append_chunk(&chunk).unwrap_or_default());
+            archived.push(ArchivedChunk {
+                chunk,
+                archived_before,
+            });
+        }
+        (completed, archived)
+    };
+    serial_debug_ingest_lines(sink, filters, &completed);
+    sink.chunk_batch(archived);
+}
+
+/// Surface one coalesced burst of dropped chunks: a `log::warn!` for the
+/// developer, a gap in the archive and a notice for the user.
+///
+/// Whatever is buffered is flushed first — those chunks arrived before the gap,
+/// and emitting them afterwards would put the notice in the wrong place in the
+/// live view.
+pub fn serial_debug_report_drops(
+    sink: &impl SerialDebugSink,
+    archive: &Arc<Mutex<SerialDebugArchive>>,
+    filters: &Arc<Mutex<SerialDebugFilterIndex>>,
+    pending: &mut SerialDebugChunkBatchBuffer,
+    report: SerialDebugDropReport,
+) {
+    serial_debug_flush_chunks(sink, archive, filters, pending.take());
+    log::warn!(
+        "[serial-debug] chunk bridge queue full (capacity {}): dropped {} chunk(s) / {} byte(s) \
+         of device output",
+        SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY,
+        report.chunks,
+        report.bytes
+    );
+    // Only the reader thread's Rx chunks travel the bounded queue: the Tx path
+    // writes straight to the archive.
+    let (lines, archived_before) = {
+        let mut guard = match archive.lock() {
+            Ok(guard) => guard,
+            Err(_) => return,
+        };
+        // `append_gap` writes the cut-off partial line and the sentinel under one
+        // lock, so one number covers both frontend lines — see [`ArchivedChunk`].
+        let archived_before = guard.total_lines();
+        (
+            guard
+                .append_gap(Direction::Rx, serial_debug_now_ms(), report.bytes)
+                .unwrap_or_default(),
+            archived_before,
+        )
+    };
+    serial_debug_ingest_lines(sink, filters, &lines);
+    sink.chunks_dropped(report.bytes, archived_before);
+}
+
+/// Cut the tail the device never terminated into the archive, at the end of a
+/// session. Returns the lines written (empty when nothing was buffered) so the
+/// caller can ingest them like any other archive line.
+///
+/// Nothing else closes that buffer: `append_chunk` only cuts on a newline and
+/// `append_gap` only runs when a chunk is dropped, so a prompt or a progress bar
+/// — output the device deliberately leaves unterminated — would go down with the
+/// port and appear in neither the live view nor the archive.
+pub fn serial_debug_finalize_pending(
+    archive: &Arc<Mutex<SerialDebugArchive>>,
+) -> Vec<SerialDebugLine> {
+    let mut guard = match archive.lock() {
+        Ok(guard) => guard,
+        Err(_) => return Vec::new(),
+    };
+    guard
+        .finalize_pending_lines(serial_debug_now_ms())
+        .unwrap_or_default()
+}
+
+/// Start the bridge thread and return the handle the reader thread pushes into.
+pub fn serial_debug_spawn_chunk_bridge<S: SerialDebugSink>(
+    sink: S,
+    archive: Arc<Mutex<SerialDebugArchive>>,
+    filters: Arc<Mutex<SerialDebugFilterIndex>>,
+    generation: Arc<SerialDebugGeneration>,
+) -> SerialDebugChunkBridgeHandle {
+    let (tx, rx) =
+        mpsc::sync_channel::<SerialDebugChunkBridgeMessage>(SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY);
+    let drops = Arc::new(SerialDebugDropCounter::default());
+    let handle = SerialDebugChunkBridgeHandle {
+        generation: Arc::clone(&generation),
+        send_lock: Arc::new(Mutex::new(())),
+        tx,
+        drops: Arc::clone(&drops),
+    };
+    std::thread::spawn(move || {
+        let mut pending = SerialDebugChunkBatchBuffer::new();
+        let mut active_generation = generation.current();
+        loop {
+            // Before every receive, so `recv_timeout`'s own tick is the poll
+            // clock and no `continue` below can skip the check.
+            if let Some(report) = drops.take_report(serial_debug_now_ms()) {
+                serial_debug_report_drops(&sink, &archive, &filters, &mut pending, report);
+            }
+            match rx.recv_timeout(Duration::from_millis(SERIAL_DEBUG_CHUNK_FLUSH_MS)) {
+                Ok(SerialDebugChunkBridgeMessage::Chunk { generation, chunk }) => {
+                    if generation != active_generation {
+                        if generation < active_generation {
+                            continue;
+                        }
+                        let _ = pending.take();
+                        active_generation = generation;
+                    }
+                    pending.push(chunk);
+                    if pending.should_flush_bytes(SERIAL_DEBUG_CHUNK_FLUSH_BYTES) {
+                        serial_debug_flush_chunks(&sink, &archive, &filters, pending.take());
+                    }
+                }
+                Ok(SerialDebugChunkBridgeMessage::Reset { generation, ack }) => {
+                    let _ = pending.take();
+                    // Drops from the cleared session belong to the log the user
+                    // just discarded; reporting them into the new one would be a
+                    // notice about a gap that is no longer there.
+                    let _ = drops.take_pending();
+                    active_generation = generation;
+                    let _ = ack.send(());
+                }
+                Ok(SerialDebugChunkBridgeMessage::Shutdown { ack }) => {
+                    serial_debug_flush_chunks(&sink, &archive, &filters, pending.take());
+                    if let Some(report) = drops.take_pending() {
+                        serial_debug_report_drops(&sink, &archive, &filters, &mut pending, report);
+                    }
+                    let _ = ack.send(());
+                    return;
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    if pending
+                        .should_flush_elapsed(Duration::from_millis(SERIAL_DEBUG_CHUNK_FLUSH_MS))
+                    {
+                        serial_debug_flush_chunks(&sink, &archive, &filters, pending.take());
+                    }
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    serial_debug_flush_chunks(&sink, &archive, &filters, pending.take());
+                    // A burst still aggregating at teardown is reported anyway —
+                    // it is the last thing the user needs to know about the log
+                    // they are about to read.
+                    if let Some(report) = drops.take_pending() {
+                        serial_debug_report_drops(&sink, &archive, &filters, &mut pending, report);
+                    }
+                    return;
+                }
+            }
+        }
+    });
+    handle
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serial_debug::{
+        serial_debug_archive_cap_sentinel, serial_debug_chunk_drop_sentinel, LogDirection,
+    };
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// One temp dir per test, unique even when two land in the same millisecond.
+    fn scratch_dir(tag: &str) -> std::path::PathBuf {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        std::env::temp_dir().join(format!(
+            "tyutool-bridge-{tag}-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[derive(Default)]
+    struct Recorded {
+        batches: Vec<Vec<ArchivedChunk>>,
+        dropped: Vec<(u64, u64)>,
+        capped: Vec<(u64, u64)>,
+        filters: Vec<(String, u64)>,
+    }
+
+    #[derive(Clone, Default)]
+    struct TestSink(Arc<Mutex<Recorded>>);
+
+    impl TestSink {
+        fn recorded(&self) -> std::sync::MutexGuard<'_, Recorded> {
+            self.0.lock().unwrap()
+        }
+    }
+
+    impl SerialDebugSink for TestSink {
+        fn chunk_batch(&self, chunks: Vec<ArchivedChunk>) {
+            self.recorded().batches.push(chunks);
+        }
+        fn chunks_dropped(&self, dropped_bytes: u64, archived_before: u64) {
+            self.recorded()
+                .dropped
+                .push((dropped_bytes, archived_before));
+        }
+        fn archive_capped(&self, limit_mib: u64, archived_before: u64) {
+            self.recorded().capped.push((limit_mib, archived_before));
+        }
+        fn filter_updated(&self, def: SerialDebugFilterDefinition, stats: SerialDebugFilterStats) {
+            self.recorded()
+                .filters
+                .push((def.keyword, stats.total_matches));
+        }
+    }
+
+    fn rx(bytes: &[u8]) -> DebugChunk {
+        DebugChunk {
+            direction: Direction::Rx,
+            ts_ms: 1,
+            bytes: bytes.to_vec(),
+        }
+    }
+
+    /// Closing the port is the last moment the bytes the device printed without a
+    /// trailing newline can be saved — a `login: ` prompt, a progress bar.
+    /// Nothing else in the archive ever cuts them.
+    ///
+    /// Both hosts used to carry their own copy of this test against their own copy
+    /// of the function; there is one of each now.
+    #[test]
+    fn closing_a_session_archives_the_unterminated_tail() {
+        let dir = scratch_dir("close-tail");
+        let archive = Arc::new(Mutex::new(SerialDebugArchive::create(&dir).unwrap()));
+        archive
+            .lock()
+            .unwrap()
+            .append_chunk(&rx(b"login: "))
+            .unwrap();
+        assert_eq!(archive.lock().unwrap().total_lines(), 0, "no newline yet");
+
+        let lines = serial_debug_finalize_pending(&archive);
+
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].text, "login: ");
+        assert_eq!(
+            archive
+                .lock()
+                .unwrap()
+                .read_line_range(1, 10)
+                .unwrap()
+                .iter()
+                .map(|l| l.text.clone())
+                .collect::<Vec<_>>(),
+            vec!["login: ".to_string()]
+        );
+        // Closing again has nothing left to cut: no empty line.
+        assert!(serial_debug_finalize_pending(&archive).is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A full queue must cost us the chunk, not the reader thread.
+    ///
+    /// This test would hang rather than fail if `send_chunk` went back to a
+    /// blocking `send`: nothing drains the receiver, so the third call would park
+    /// forever — which is exactly what stalls the serial reader in production and
+    /// lets the OS receive buffer overflow behind our back.
+    #[test]
+    fn full_bridge_queue_drops_chunks_instead_of_blocking_the_reader() {
+        let (tx, receiver) = mpsc::sync_channel::<SerialDebugChunkBridgeMessage>(1);
+        let handle = SerialDebugChunkBridgeHandle {
+            generation: Arc::new(SerialDebugGeneration::default()),
+            send_lock: Arc::new(Mutex::new(())),
+            tx,
+            drops: Arc::new(SerialDebugDropCounter::default()),
+        };
+        let chunk = |bytes: usize| rx(&vec![b'x'; bytes]);
+
+        handle.send_chunk(chunk(4)); // fits the capacity-1 queue
+        handle.send_chunk(chunk(8)); // dropped
+        handle.send_chunk(chunk(16)); // dropped
+
+        // One report for the whole burst, carrying the total loss.
+        let report = handle.drops.take_pending().unwrap();
+        assert_eq!(report.chunks, 2);
+        assert_eq!(report.bytes, 24);
+        assert!(handle.drops.take_pending().is_none());
+
+        drop(receiver);
+        // A disconnected queue is a closing session, not a data loss.
+        handle.send_chunk(chunk(32));
+        assert!(handle.drops.take_pending().is_none());
+    }
+
+    /// `archived_before` is per chunk, not per batch — it is what lets the
+    /// frontend enable auto-save mid-session without duplicating or losing a line,
+    /// so a batch-wide number would be wrong for every chunk but the first.
+    #[test]
+    fn flush_reports_the_archive_position_of_each_chunk() {
+        let dir = scratch_dir("flush-positions");
+        let archive = Arc::new(Mutex::new(SerialDebugArchive::create(&dir).unwrap()));
+        let filters = Arc::new(Mutex::new(SerialDebugFilterIndex::create(&dir).unwrap()));
+        let sink = TestSink::default();
+
+        serial_debug_flush_chunks(
+            &sink,
+            &archive,
+            &filters,
+            vec![rx(b"first\n"), rx(b"second\n")],
+        );
+
+        let recorded = sink.recorded();
+        assert_eq!(recorded.batches.len(), 1, "one batch, not one per chunk");
+        let positions: Vec<u64> = recorded.batches[0]
+            .iter()
+            .map(|c| c.archived_before)
+            .collect();
+        assert_eq!(positions, vec![0, 1]);
+        drop(recorded);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An empty batch is not a notice: the bridge flushes on a timer, so most
+    /// ticks on a quiet port have nothing to say.
+    #[test]
+    fn flushing_nothing_tells_the_sink_nothing() {
+        let dir = scratch_dir("flush-empty");
+        let archive = Arc::new(Mutex::new(SerialDebugArchive::create(&dir).unwrap()));
+        let filters = Arc::new(Mutex::new(SerialDebugFilterIndex::create(&dir).unwrap()));
+        let sink = TestSink::default();
+
+        serial_debug_flush_chunks(&sink, &archive, &filters, Vec::new());
+
+        assert!(sink.recorded().batches.is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Dropping device output must cut the open archive line before the sentinel,
+    /// or the bytes either side of the gap get concatenated into a line the device
+    /// never printed. The notice then has to point at the gap it belongs to.
+    #[test]
+    fn reporting_drops_cuts_the_open_line_and_announces_the_gap() {
+        let dir = scratch_dir("drop-report");
+        let archive = Arc::new(Mutex::new(SerialDebugArchive::create(&dir).unwrap()));
+        let filters = Arc::new(Mutex::new(SerialDebugFilterIndex::create(&dir).unwrap()));
+        let sink = TestSink::default();
+        let mut pending = SerialDebugChunkBatchBuffer::new();
+
+        // A line still being received when the queue overflowed.
+        archive
+            .lock()
+            .unwrap()
+            .append_chunk(&rx(b"before-gap"))
+            .unwrap();
+        assert_eq!(archive.lock().unwrap().total_lines(), 0, "still open");
+
+        serial_debug_report_drops(
+            &sink,
+            &archive,
+            &filters,
+            &mut pending,
+            SerialDebugDropReport {
+                chunks: 2,
+                bytes: 4096,
+            },
+        );
+
+        let texts: Vec<String> = archive
+            .lock()
+            .unwrap()
+            .read_line_range(1, 10)
+            .unwrap()
+            .iter()
+            .map(|l| l.text.clone())
+            .collect();
+        assert_eq!(texts.len(), 2, "the cut line, then the sentinel: {texts:?}");
+        assert_eq!(texts[0], "before-gap");
+        assert_eq!(texts[1], serial_debug_chunk_drop_sentinel(4096));
+
+        // Both lines were written under one lock, so one position covers both.
+        assert_eq!(sink.recorded().dropped, vec![(4096, 0)]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The live view is fed raw chunks and never reads the archive, so this notice
+    /// is the only way the user learns recording stopped. It keys off the
+    /// sentinel, which only the archive itself emits — identical text arriving
+    /// from the device must not trigger it.
+    #[test]
+    fn the_archive_cap_sentinel_reaches_the_sink_but_device_output_does_not() {
+        let dir = scratch_dir("cap-notice");
+        let filters = Arc::new(Mutex::new(SerialDebugFilterIndex::create(&dir).unwrap()));
+        let sink = TestSink::default();
+        let line = |direction, text: String| SerialDebugLine {
+            line_no: 7,
+            ts_ms: 1,
+            direction,
+            text,
+            raw_bytes: None,
+        };
+
+        serial_debug_ingest_lines(
+            &sink,
+            &filters,
+            &[line(
+                LogDirection::Sys,
+                serial_debug_archive_cap_sentinel(64),
+            )],
+        );
+        // The sentinel sits at line 7, so it is inside a backfill snapshot iff
+        // that snapshot is >= 7, i.e. iff `archived_before` (6) < snapshot.
+        assert_eq!(sink.recorded().capped, vec![(64, 6)]);
+
+        serial_debug_ingest_lines(
+            &sink,
+            &filters,
+            &[line(
+                LogDirection::Rx,
+                serial_debug_archive_cap_sentinel(64),
+            )],
+        );
+        assert_eq!(
+            sink.recorded().capped.len(),
+            1,
+            "device output must not count"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Filter counts move as lines are archived, and the sink hears about it —
+    /// under a single lock acquisition, so a concurrent `filter_remove` cannot
+    /// land between the ingest and the definition lookup and swallow the update.
+    #[test]
+    fn ingesting_lines_announces_the_filters_that_moved() {
+        let dir = scratch_dir("filter-updates");
+        let archive = Arc::new(Mutex::new(SerialDebugArchive::create(&dir).unwrap()));
+        let filters = Arc::new(Mutex::new(SerialDebugFilterIndex::create(&dir).unwrap()));
+        let sink = TestSink::default();
+        filters
+            .lock()
+            .unwrap()
+            .add_filter("boot".to_string(), false, "#f00".to_string(), 0)
+            .unwrap();
+
+        serial_debug_flush_chunks(
+            &sink,
+            &archive,
+            &filters,
+            vec![rx(b"boot ok\n"), rx(b"idle\n"), rx(b"boot again\n")],
+        );
+
+        assert_eq!(
+            sink.recorded().filters,
+            vec![("boot".to_string(), 2)],
+            "one update carrying the final count, not one per matching line"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/tyutool-serve/src/lib.rs
+++ b/crates/tyutool-serve/src/lib.rs
@@ -6,7 +6,6 @@
 
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, RecvTimeoutError, SyncSender, TrySendError};
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -27,17 +26,13 @@ use tokio_tungstenite::{
 };
 use tyutool_core::{
     device_reset_dtr_rts, list_serial_ports, run_job, serial_debug_fail_backfill_if_current,
-    serial_debug_finish_backfill_if_current, serial_debug_now_ms, serial_debug_scan_filter_matches,
-    DebugChunk, DebugConfig, Direction, FlashJob, SerialDebugArchive, SerialDebugArchiveReader,
-    SerialDebugChunkBatchBuffer, SerialDebugDropCounter, SerialDebugDropReport,
-    SerialDebugFilterBackfillSnapshot, SerialDebugFilterDefinition, SerialDebugFilterIndex,
-    SerialDebugFilterPage, SerialDebugFilterStats, SerialDebugGeneration, SerialDebugLine,
-    SerialDebugSession, SerialDebugSessionPage, SerialPortEntry,
+    serial_debug_finalize_pending, serial_debug_finish_backfill_if_current,
+    serial_debug_ingest_lines, serial_debug_scan_filter_matches, serial_debug_spawn_chunk_bridge,
+    ArchivedChunk, DebugChunk, DebugConfig, FlashJob, SerialDebugArchive, SerialDebugArchiveReader,
+    SerialDebugChunkBridgeHandle, SerialDebugFilterBackfillSnapshot, SerialDebugFilterDefinition,
+    SerialDebugFilterIndex, SerialDebugFilterPage, SerialDebugFilterStats, SerialDebugGeneration,
+    SerialDebugSession, SerialDebugSessionPage, SerialDebugSink, SerialPortEntry,
 };
-
-const SERIAL_DEBUG_CHUNK_FLUSH_MS: u64 = 12;
-const SERIAL_DEBUG_CHUNK_FLUSH_BYTES: usize = 32 * 1024;
-const SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY: usize = 256;
 
 // ── Client → Server ──────────────────────────────────────────────────────────
 
@@ -184,88 +179,43 @@ pub enum ServerMessage {
     },
 }
 
-/// One chunk on its way to the browser, plus the number of lines the session
-/// archive held *before* this chunk was appended to it. Twin of `ArchivedChunk`
-/// in `src-tauri/src/serial_debug.rs`, which carries the full rationale: it is
-/// what lets the frontend enable auto-save mid-session without duplicating or
-/// losing a line, and it is exact because `append_chunk` archives a whole chunk
-/// under one lock, so no snapshot can land inside a chunk.
+/// Turns everything the shared chunk bridge produces into `ServerMessage`s.
 ///
-/// Flattened into the `chunk` object, which already serialises camelCase
-/// (`tsMs`), so the field reaches the frontend as `archivedBefore` with no
-/// mapping in `ws-transport.ts`.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ArchivedChunk {
-    #[serde(flatten)]
-    pub chunk: DebugChunk,
-    pub archived_before: u64,
-}
-
-enum SerialDebugChunkBridgeMessage {
-    Chunk {
-        generation: u64,
-        chunk: DebugChunk,
-    },
-    Reset {
-        generation: u64,
-        ack: std::sync::mpsc::SyncSender<()>,
-    },
-    Shutdown {
-        ack: std::sync::mpsc::SyncSender<()>,
-    },
-}
-
+/// Sends are fire-and-forget by contract ([`SerialDebugSink`]): the sink task
+/// drains this channel and a closed WebSocket is normal teardown, so the bridge
+/// thread must not stall on discovering it.
 #[derive(Clone)]
-struct SerialDebugChunkBridgeHandle {
-    generation: Arc<SerialDebugGeneration>,
-    send_lock: Arc<Mutex<()>>,
-    tx: SyncSender<SerialDebugChunkBridgeMessage>,
-    drops: Arc<SerialDebugDropCounter>,
+struct WsSink {
+    tx: tokio::sync::mpsc::UnboundedSender<ServerMessage>,
 }
 
-impl SerialDebugChunkBridgeHandle {
-    /// Hand one chunk to the bridge, or account for it as lost. `try_send`, never
-    /// `send`, for the reason spelled out on the Tauri twin in
-    /// `src-tauri/src/serial_debug.rs`: blocking the serial reader thread stops
-    /// the OS receive buffer being drained, and the driver then discards bytes
-    /// silently. Dropping here keeps the loss countable and reportable.
-    fn send_chunk(&self, chunk: DebugChunk) {
-        let _guard = self.send_lock.lock().unwrap();
-        let bytes = chunk.bytes.len();
-        match self.tx.try_send(SerialDebugChunkBridgeMessage::Chunk {
-            generation: self.generation.current(),
-            chunk,
-        }) {
-            Ok(()) => {}
-            Err(TrySendError::Full(_)) => self.drops.record(bytes, serial_debug_now_ms()),
-            // The bridge thread is gone; the session is being torn down.
-            Err(TrySendError::Disconnected(_)) => {}
-        }
+impl SerialDebugSink for WsSink {
+    fn chunk_batch(&self, chunks: Vec<ArchivedChunk>) {
+        let _ = self
+            .tx
+            .send(ServerMessage::SerialDebugChunkBatch { chunks });
     }
 
-    fn reset(&self) -> Result<u64, String> {
-        let _guard = self.send_lock.lock().unwrap();
-        let generation = self.generation.advance();
-        let (ack_tx, ack_rx) = std::sync::mpsc::sync_channel(0);
-        self.tx
-            .send(SerialDebugChunkBridgeMessage::Reset {
-                generation,
-                ack: ack_tx,
-            })
-            .map_err(|e| e.to_string())?;
-        ack_rx.recv().map_err(|e| e.to_string())?;
-        Ok(generation)
+    fn chunks_dropped(&self, dropped_bytes: u64, archived_before: u64) {
+        let _ = self.tx.send(ServerMessage::SerialDebugChunksDropped {
+            dropped_bytes,
+            archived_before,
+        });
     }
 
-    fn shutdown(self) -> Result<(), String> {
-        let _guard = self.send_lock.lock().unwrap();
-        let (ack_tx, ack_rx) = std::sync::mpsc::sync_channel(0);
-        self.tx
-            .send(SerialDebugChunkBridgeMessage::Shutdown { ack: ack_tx })
-            .map_err(|e| e.to_string())?;
-        ack_rx.recv().map_err(|e| e.to_string())?;
-        Ok(())
+    fn archive_capped(&self, limit_mib: u64, archived_before: u64) {
+        let _ = self.tx.send(ServerMessage::SerialDebugArchiveCapped {
+            limit_mib,
+            archived_before,
+        });
+    }
+
+    fn filter_updated(&self, def: SerialDebugFilterDefinition, stats: SerialDebugFilterStats) {
+        let _ = self.tx.send(ServerMessage::SerialDebugFilterUpdated {
+            def,
+            stats,
+            request_id: None,
+        });
     }
 }
 
@@ -461,6 +411,11 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
     // the sink in a single drainer task fed by an unbounded mpsc.
     use tokio::sync::mpsc;
     let (sink_tx, mut sink_rx) = mpsc::unbounded_channel::<ServerMessage>();
+    // The chunk bridge and every archive-ingest path share one sink for the
+    // life of the connection; it is just a channel handle.
+    let ws_sink = WsSink {
+        tx: sink_tx.clone(),
+    };
 
     let mut sink_moved = sink;
     let pump = tokio::spawn(async move {
@@ -575,14 +530,11 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
                     });
                     continue;
                 }
-                let sink_for_chunk = sink_tx.clone();
                 let sink_for_disc = sink_tx.clone();
-                let archive_for_chunk = Arc::clone(&debug_archive);
-                let filters_for_chunk = Arc::clone(&debug_filters);
-                let chunk_bridge = spawn_serial_debug_chunk_bridge_ws(
-                    sink_for_chunk.clone(),
-                    Arc::clone(&archive_for_chunk),
-                    Arc::clone(&filters_for_chunk),
+                let chunk_bridge = serial_debug_spawn_chunk_bridge(
+                    ws_sink.clone(),
+                    Arc::clone(&debug_archive),
+                    Arc::clone(&debug_filters),
                     Arc::clone(&debug_generation),
                 );
                 let chunk_bridge_for_session = chunk_bridge.clone();
@@ -620,8 +572,8 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
                 }
                 // After the bridge's shutdown ack, so everything it was still
                 // holding is archived and the tail is cut behind all of it.
-                let lines = finalize_serial_debug_pending_ws(&debug_archive);
-                ingest_serial_debug_lines_ws(&sink_tx, &debug_filters, &lines);
+                let lines = serial_debug_finalize_pending(&debug_archive);
+                serial_debug_ingest_lines(&ws_sink, &debug_filters, &lines);
                 let _ = sink_tx.send(ServerMessage::SerialDebugClosed);
             }
             ClientMessage::SerialDebugDeviceReset { chip_id } => {
@@ -675,7 +627,7 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
                             archived_before,
                         )
                     };
-                    ingest_serial_debug_lines_ws(&sink_tx, &debug_filters, &completed);
+                    serial_debug_ingest_lines(&ws_sink, &debug_filters, &completed);
                     let _ = sink_tx.send(ServerMessage::SerialDebugChunk {
                         chunk: ArchivedChunk {
                             chunk,
@@ -741,7 +693,7 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
                 };
                 // `None` once the session archive hit its size cap.
                 if let Some(line) = line {
-                    ingest_serial_debug_lines_ws(&sink_tx, &debug_filters, &[line]);
+                    serial_debug_ingest_lines(&ws_sink, &debug_filters, &[line]);
                 }
             }
             ClientMessage::SerialDebugSetArchiveLimit { max_bytes } => {
@@ -961,246 +913,6 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
     log::info!("WS connection closed");
 }
 
-fn flush_serial_debug_chunk_ws(
-    sink_tx: &tokio::sync::mpsc::UnboundedSender<ServerMessage>,
-    archive: &Arc<Mutex<SerialDebugArchive>>,
-    filters: &Arc<Mutex<SerialDebugFilterIndex>>,
-    chunks: Vec<DebugChunk>,
-) {
-    if chunks.is_empty() {
-        return;
-    }
-    let (completed, archived) = {
-        let mut guard = match archive.lock() {
-            Ok(guard) => guard,
-            Err(_) => return,
-        };
-        let mut completed = Vec::new();
-        let mut archived = Vec::with_capacity(chunks.len());
-        // One `archived_before` per chunk, not one per batch — see the twin in
-        // `src-tauri/src/serial_debug.rs`.
-        for chunk in chunks {
-            let archived_before = guard.total_lines();
-            completed.extend(guard.append_chunk(&chunk).unwrap_or_default());
-            archived.push(ArchivedChunk {
-                chunk,
-                archived_before,
-            });
-        }
-        (completed, archived)
-    };
-    ingest_serial_debug_lines_ws(sink_tx, filters, &completed);
-    let _ = sink_tx.send(ServerMessage::SerialDebugChunkBatch { chunks: archived });
-}
-
-/// Surface one coalesced burst of dropped chunks — `log::warn!` for the
-/// developer, a gap in the archive and a `Sys` notice for the user. Twin of
-/// `report_serial_debug_drops` in `src-tauri/src/serial_debug.rs`; the two hosts
-/// must behave identically (`src/CLAUDE.md`: web and Tauri parity).
-fn report_serial_debug_drops_ws(
-    sink_tx: &tokio::sync::mpsc::UnboundedSender<ServerMessage>,
-    archive: &Arc<Mutex<SerialDebugArchive>>,
-    filters: &Arc<Mutex<SerialDebugFilterIndex>>,
-    pending: &mut SerialDebugChunkBatchBuffer,
-    report: SerialDebugDropReport,
-) {
-    // Everything buffered arrived before the gap.
-    flush_serial_debug_chunk_ws(sink_tx, archive, filters, pending.take());
-    log::warn!(
-        "[serial-debug] chunk bridge queue full (capacity {}): dropped {} chunk(s) / {} byte(s) \
-         of device output",
-        SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY,
-        report.chunks,
-        report.bytes
-    );
-    // Only the reader thread's Rx chunks travel the bounded queue: the Tx path
-    // (`SerialDebugSend`) writes straight to the archive.
-    let (lines, archived_before) = {
-        let mut guard = match archive.lock() {
-            Ok(guard) => guard,
-            Err(_) => return,
-        };
-        // `append_gap` writes the cut-off partial line and the sentinel under one
-        // lock, so one number covers both frontend lines.
-        let archived_before = guard.total_lines();
-        (
-            guard
-                .append_gap(Direction::Rx, serial_debug_now_ms(), report.bytes)
-                .unwrap_or_default(),
-            archived_before,
-        )
-    };
-    ingest_serial_debug_lines_ws(sink_tx, filters, &lines);
-    let _ = sink_tx.send(ServerMessage::SerialDebugChunksDropped {
-        dropped_bytes: report.bytes,
-        archived_before,
-    });
-}
-
-/// Cut the tail the device never terminated into the archive, at the end of a
-/// session. Twin of `finalize_serial_debug_pending` in `src-tauri`.
-///
-/// Nothing else closes that buffer: `append_chunk` only cuts on a newline and
-/// `append_gap` only runs when a chunk is dropped, so a prompt or a progress bar
-/// — output the device deliberately leaves unterminated — would go down with the
-/// port and appear in neither the live view nor the archive.
-fn finalize_serial_debug_pending_ws(
-    archive: &Arc<Mutex<SerialDebugArchive>>,
-) -> Vec<SerialDebugLine> {
-    let mut guard = match archive.lock() {
-        Ok(guard) => guard,
-        Err(_) => return Vec::new(),
-    };
-    guard
-        .finalize_pending_lines(serial_debug_now_ms())
-        .unwrap_or_default()
-}
-
-fn spawn_serial_debug_chunk_bridge_ws(
-    sink_tx: tokio::sync::mpsc::UnboundedSender<ServerMessage>,
-    archive: Arc<Mutex<SerialDebugArchive>>,
-    filters: Arc<Mutex<SerialDebugFilterIndex>>,
-    generation: Arc<SerialDebugGeneration>,
-) -> SerialDebugChunkBridgeHandle {
-    // Bound the bridge queue so sustained ingress can't grow process memory without limit
-    // when archive/filter/UI consumption temporarily lags behind the serial reader.
-    let (tx, rx) =
-        mpsc::sync_channel::<SerialDebugChunkBridgeMessage>(SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY);
-    let drops = Arc::new(SerialDebugDropCounter::default());
-    let handle = SerialDebugChunkBridgeHandle {
-        generation: Arc::clone(&generation),
-        send_lock: Arc::new(Mutex::new(())),
-        tx: tx.clone(),
-        drops: Arc::clone(&drops),
-    };
-    std::thread::spawn(move || {
-        let mut pending = SerialDebugChunkBatchBuffer::new();
-        let mut active_generation = generation.current();
-        loop {
-            // Before every receive, so `recv_timeout`'s own tick is the poll
-            // clock and no `continue` below can skip the check.
-            if let Some(report) = drops.take_report(serial_debug_now_ms()) {
-                report_serial_debug_drops_ws(&sink_tx, &archive, &filters, &mut pending, report);
-            }
-            match rx.recv_timeout(Duration::from_millis(SERIAL_DEBUG_CHUNK_FLUSH_MS)) {
-                Ok(SerialDebugChunkBridgeMessage::Chunk { generation, chunk }) => {
-                    if generation != active_generation {
-                        if generation < active_generation {
-                            continue;
-                        }
-                        let _ = pending.take();
-                        active_generation = generation;
-                    }
-                    pending.push(chunk);
-                    if pending.should_flush_bytes(SERIAL_DEBUG_CHUNK_FLUSH_BYTES) {
-                        flush_serial_debug_chunk_ws(&sink_tx, &archive, &filters, pending.take());
-                    }
-                }
-                Ok(SerialDebugChunkBridgeMessage::Reset { generation, ack }) => {
-                    let _ = pending.take();
-                    // Drops from the cleared session belong to the log the user
-                    // just discarded.
-                    let _ = drops.take_pending();
-                    active_generation = generation;
-                    let _ = ack.send(());
-                }
-                Ok(SerialDebugChunkBridgeMessage::Shutdown { ack }) => {
-                    flush_serial_debug_chunk_ws(&sink_tx, &archive, &filters, pending.take());
-                    if let Some(report) = drops.take_pending() {
-                        report_serial_debug_drops_ws(
-                            &sink_tx,
-                            &archive,
-                            &filters,
-                            &mut pending,
-                            report,
-                        );
-                    }
-                    let _ = ack.send(());
-                    return;
-                }
-                Err(RecvTimeoutError::Timeout) => {
-                    if pending
-                        .should_flush_elapsed(Duration::from_millis(SERIAL_DEBUG_CHUNK_FLUSH_MS))
-                    {
-                        flush_serial_debug_chunk_ws(&sink_tx, &archive, &filters, pending.take());
-                    }
-                }
-                Err(RecvTimeoutError::Disconnected) => {
-                    flush_serial_debug_chunk_ws(&sink_tx, &archive, &filters, pending.take());
-                    // A burst still aggregating at teardown is reported anyway.
-                    if let Some(report) = drops.take_pending() {
-                        report_serial_debug_drops_ws(
-                            &sink_tx,
-                            &archive,
-                            &filters,
-                            &mut pending,
-                            report,
-                        );
-                    }
-                    return;
-                }
-            }
-        }
-    });
-    handle
-}
-
-/// Every line the archive accepts passes through `ingest_serial_debug_lines_ws`,
-/// which makes it the one place that can spot the archive-cap sentinel. The live
-/// view never sees archived lines — it re-splits the raw `serial_debug_chunk*`
-/// payloads itself — so without this message the cap notice would only ever
-/// exist in the archive file and the user would watch the log keep scrolling
-/// with no hint that recording had stopped.
-fn emit_archive_cap_notice_ws(
-    sink_tx: &tokio::sync::mpsc::UnboundedSender<ServerMessage>,
-    lines: &[SerialDebugLine],
-) {
-    if let Some((limit_mib, line_no)) = lines.iter().find_map(|line| {
-        tyutool_core::serial_debug_archive_cap_limit_mib(line).map(|mib| (mib, line.line_no))
-    }) {
-        let _ = sink_tx.send(ServerMessage::SerialDebugArchiveCapped {
-            limit_mib,
-            // The sentinel is an archive line like any other, so its own
-            // position is exactly `line_no - 1`.
-            archived_before: line_no.saturating_sub(1),
-        });
-    }
-}
-
-fn ingest_serial_debug_lines_ws(
-    sink_tx: &tokio::sync::mpsc::UnboundedSender<ServerMessage>,
-    filters: &Arc<Mutex<SerialDebugFilterIndex>>,
-    lines: &[SerialDebugLine],
-) {
-    if lines.is_empty() {
-        return;
-    }
-    emit_archive_cap_notice_ws(sink_tx, lines);
-    let updates = {
-        let mut guard = match filters.lock() {
-            Ok(guard) => guard,
-            Err(_) => return,
-        };
-        guard.ingest_completed_lines(lines).unwrap_or_default()
-    };
-    if updates.is_empty() {
-        return;
-    }
-    let guard = match filters.lock() {
-        Ok(guard) => guard,
-        Err(_) => return,
-    };
-    for stats in updates {
-        if let Some(def) = guard.definition(&stats.filter_id) {
-            let _ = sink_tx.send(ServerMessage::SerialDebugFilterUpdated {
-                def,
-                stats,
-                request_id: None,
-            });
-        }
-    }
-}
-
 // ── Run job handler ──────────────────────────────────────────────────────────
 
 async fn handle_run_job(
@@ -1395,6 +1107,14 @@ fn temp_path(prefix: &str, ext: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    // Only the tests drive the shared bridge directly; production code reaches it
+    // through `serial_debug_spawn_chunk_bridge`, so these stay out of the crate's
+    // top-level imports.
+    use tyutool_core::{
+        serial_debug_flush_chunks, serial_debug_report_drops, Direction,
+        SerialDebugChunkBatchBuffer, SerialDebugDropReport,
+    };
+
     // ── WS 来源校验用例（随实现一并自上游 a2fa599 移植）──────────────────────
     // ⚠ 实现移植了、用例没移植 = 防护没有任何证明，下次重构谁都不知道自己破坏了什么。
     // 六条覆盖：放行（无 Origin 的非浏览器客户端 / localhost / tauri://）与
@@ -1688,24 +1408,16 @@ mod tests {
         assert!(disc.contains(r#""reason":"device removed""#));
     }
 
+    /// *When* the notice fires is core's business and core tests it (only the
+    /// archive's own `Sys` sentinel counts, never identical text from the
+    /// device). What has to be pinned here is the shape it reaches the browser
+    /// in, because `ws-transport.ts` reads these exact field names.
     #[test]
-    fn archive_cap_sentinel_becomes_an_archive_capped_message() {
-        let line = |direction, text: String| SerialDebugLine {
-            line_no: 7,
-            ts_ms: 1,
-            direction,
-            text,
-            raw_bytes: None,
-        };
+    fn the_archive_capped_message_keeps_its_wire_shape() {
         let (sink_tx, mut sink_rx) = tokio::sync::mpsc::unbounded_channel();
 
-        emit_archive_cap_notice_ws(
-            &sink_tx,
-            &[line(
-                tyutool_core::LogDirection::Sys,
-                tyutool_core::serial_debug_archive_cap_sentinel(64),
-            )],
-        );
+        WsSink { tx: sink_tx }.archive_capped(64, 6);
+
         let json = serde_json::to_string(&sink_rx.try_recv().unwrap()).unwrap();
         assert!(json.contains(r#""type":"serial_debug_archive_capped""#));
         // snake_case like every other ServerMessage field (cf. `request_id`);
@@ -1714,69 +1426,13 @@ mod tests {
         // The sentinel sits at line 7, so it is inside a backfill snapshot iff
         // that snapshot is >= 7, i.e. iff `archived_before` (6) < snapshot.
         assert!(json.contains(r#""archived_before":6"#), "{json}");
-
-        // Ordinary device output never triggers it, even byte-for-byte.
-        emit_archive_cap_notice_ws(
-            &sink_tx,
-            &[line(
-                tyutool_core::LogDirection::Rx,
-                tyutool_core::serial_debug_archive_cap_sentinel(64),
-            )],
-        );
-        assert!(sink_rx.try_recv().is_err());
     }
 
-    /// The web host must save the tail exactly like the Tauri host: closing the
-    /// port is the last moment output the device left unterminated — a `login: `
-    /// prompt, a progress bar — can reach the archive at all.
+    /// End to end through [`WsSink`]: the archive cut and the wire message have
+    /// to line up, because the number in the message is what tells the frontend
+    /// where the gap goes.
     #[test]
-    fn finalize_serial_debug_pending_ws_archives_the_unterminated_tail() {
-        let dir = std::env::temp_dir().join(format!(
-            "tyutool-serve-close-tail-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        let archive = Arc::new(Mutex::new(SerialDebugArchive::create(&dir).unwrap()));
-        archive
-            .lock()
-            .unwrap()
-            .append_chunk(&DebugChunk {
-                direction: Direction::Rx,
-                ts_ms: 1,
-                bytes: b"login: ".to_vec(),
-            })
-            .unwrap();
-        assert_eq!(archive.lock().unwrap().total_lines(), 0, "no newline yet");
-
-        let lines = finalize_serial_debug_pending_ws(&archive);
-
-        assert_eq!(lines.len(), 1);
-        assert_eq!(lines[0].text, "login: ");
-        assert_eq!(
-            archive
-                .lock()
-                .unwrap()
-                .read_line_range(1, 10)
-                .unwrap()
-                .iter()
-                .map(|l| l.text.clone())
-                .collect::<Vec<_>>(),
-            vec!["login: ".to_string()]
-        );
-        // Closing again has nothing left to cut: no empty line.
-        assert!(finalize_serial_debug_pending_ws(&archive).is_empty());
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    /// The web host must report dropped device output exactly like the Tauri
-    /// host: cut the open line in the archive so the bytes either side of the gap
-    /// cannot be spliced into one fake line, then announce the gap on the wire.
-    #[test]
-    fn report_serial_debug_drops_ws_cuts_the_line_and_announces_the_gap() {
+    fn dropping_device_output_cuts_the_line_and_announces_the_gap_on_the_wire() {
         let dir = std::env::temp_dir().join(format!(
             "tyutool-serve-drop-report-{}-{}",
             std::process::id(),
@@ -1801,8 +1457,8 @@ mod tests {
             })
             .unwrap();
 
-        report_serial_debug_drops_ws(
-            &sink_tx,
+        serial_debug_report_drops(
+            &WsSink { tx: sink_tx },
             &archive,
             &filters,
             &mut pending,
@@ -1959,8 +1615,8 @@ mod tests {
             ts_ms: 1,
             bytes: bytes.to_vec(),
         };
-        flush_serial_debug_chunk_ws(
-            &sink_tx,
+        serial_debug_flush_chunks(
+            &WsSink { tx: sink_tx },
             &archive,
             &filters,
             vec![
@@ -1998,8 +1654,8 @@ mod tests {
         let archive = Arc::new(Mutex::new(SerialDebugArchive::create(&dir).unwrap()));
         let filters = Arc::new(Mutex::new(SerialDebugFilterIndex::create(&dir).unwrap()));
         let (sink_tx, _sink_rx) = tokio::sync::mpsc::unbounded_channel();
-        let bridge = spawn_serial_debug_chunk_bridge_ws(
-            sink_tx,
+        let bridge = serial_debug_spawn_chunk_bridge(
+            WsSink { tx: sink_tx },
             Arc::clone(&archive),
             filters,
             Arc::new(SerialDebugGeneration::default()),

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
-    "@fortawesome/free-regular-svg-icons": "^7.2.0",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",
     "@fortawesome/vue-fontawesome": "^3.1.3",
     "@tauri-apps/api": "^2",
@@ -39,7 +38,6 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-store": "^2.4.2",
     "pinia": "^3.0.4",
-    "splitpanes": "^4.0.4",
     "vue": "^3.5.13",
     "vue-i18n": "^9.14.5",
     "vue-router": "^4.6.4"
@@ -60,7 +58,6 @@
     "eslint-plugin-vue": "^10.8.0",
     "globals": "^17.4.0",
     "happy-dom": "^17.6.3",
-    "jsdom": "^29.0.2",
     "lefthook": "^2.1.4",
     "prettier": "^3.8.1",
     "tailwindcss": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@fortawesome/fontawesome-svg-core':
         specifier: ^7.2.0
         version: 7.2.0
-      '@fortawesome/free-regular-svg-icons':
-        specifier: ^7.2.0
-        version: 7.2.0
       '@fortawesome/free-solid-svg-icons':
         specifier: ^7.2.0
         version: 7.2.0
@@ -41,9 +38,6 @@ importers:
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@5.6.3)(vue@3.5.31(typescript@5.6.3))
-      splitpanes:
-        specifier: ^4.0.4
-        version: 4.0.4(vue@3.5.31(typescript@5.6.3))
       vue:
         specifier: ^3.5.13
         version: 3.5.31(typescript@5.6.3)
@@ -99,9 +93,6 @@ importers:
       happy-dom:
         specifier: ^17.6.3
         version: 17.6.3
-      jsdom:
-        specifier: ^29.0.2
-        version: 29.0.2
       lefthook:
         specifier: ^2.1.4
         version: 2.1.4
@@ -568,10 +559,6 @@ packages:
 
   '@fortawesome/fontawesome-svg-core@7.2.0':
     resolution: {integrity: sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/free-regular-svg-icons@7.2.0':
-    resolution: {integrity: sha512-iycmlN51EULlQ4D/UU9WZnHiN0CvjJ2TuuCrAh+1MVdzD+4ViKYH2deNAll4XAAYlZa8WAefHR5taSK8hYmSMw==}
     engines: {node: '>=6'}
 
   '@fortawesome/free-solid-svg-icons@7.2.0':
@@ -2011,11 +1998,6 @@ packages:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
 
-  splitpanes@4.0.4:
-    resolution: {integrity: sha512-RbysugZhjbCw5fgplvk3hOXr41stahQDtZhHVkhnnJI6H4wlGDhM2kIpbehy7v92duy9GnMa8zIhHigIV1TWtg==}
-    peerDependencies:
-      vue: ^3.2.0
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2338,6 +2320,7 @@ snapshots:
       '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@asamuzakjp/dom-selector@7.0.9':
     dependencies:
@@ -2345,8 +2328,10 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
+    optional: true
 
-  '@asamuzakjp/nwsapi@2.3.9': {}
+  '@asamuzakjp/nwsapi@2.3.9':
+    optional: true
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -2366,13 +2351,16 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+    optional: true
 
-  '@csstools/color-helpers@6.0.2': {}
+  '@csstools/color-helpers@6.0.2':
+    optional: true
 
   '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -2380,16 +2368,20 @@ snapshots:
       '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
+    optional: true
 
-  '@csstools/css-tokenizer@4.0.0': {}
+  '@csstools/css-tokenizer@4.0.0':
+    optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -2577,17 +2569,14 @@ snapshots:
       '@eslint/core': 1.1.1
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.0': {}
+  '@exodus/bytes@1.15.0':
+    optional: true
 
   '@fontsource-variable/inter@5.2.8': {}
 
   '@fortawesome/fontawesome-common-types@7.2.0': {}
 
   '@fortawesome/fontawesome-svg-core@7.2.0':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 7.2.0
-
-  '@fortawesome/free-regular-svg-icons@7.2.0':
     dependencies:
       '@fortawesome/fontawesome-common-types': 7.2.0
 
@@ -3243,6 +3232,7 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+    optional: true
 
   birpc@2.9.0: {}
 
@@ -3294,6 +3284,7 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+    optional: true
 
   cssesc@3.0.0: {}
 
@@ -3307,6 +3298,7 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   de-indent@1.0.2: {}
 
@@ -3314,7 +3306,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decimal.js@10.6.0: {}
+  decimal.js@10.6.0:
+    optional: true
 
   deep-eql@5.0.2: {}
 
@@ -3333,7 +3326,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.2
 
-  entities@6.0.1: {}
+  entities@6.0.1:
+    optional: true
 
   entities@7.0.1: {}
 
@@ -3593,6 +3587,7 @@ snapshots:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   html-escaper@2.0.2: {}
 
@@ -3612,7 +3607,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  is-potential-custom-element-name@1.0.1: {}
+  is-potential-custom-element-name@1.0.1:
+    optional: true
 
   is-what@5.5.0: {}
 
@@ -3680,6 +3676,7 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   json-buffer@3.0.1: {}
 
@@ -3805,7 +3802,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.3.3: {}
+  lru-cache@11.3.3:
+    optional: true
 
   magic-string@0.30.21:
     dependencies:
@@ -3821,7 +3819,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  mdn-data@2.27.1: {}
+  mdn-data@2.27.1:
+    optional: true
 
   merge2@1.4.1: {}
 
@@ -3883,6 +3882,7 @@ snapshots:
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
+    optional: true
 
   path-browserify@1.0.1: {}
 
@@ -3941,7 +3941,8 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  require-from-string@2.0.2: {}
+  require-from-string@2.0.2:
+    optional: true
 
   reusify@1.1.0: {}
 
@@ -3985,6 +3986,7 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+    optional: true
 
   semver@7.7.4: {}
 
@@ -4004,10 +4006,6 @@ snapshots:
     optional: true
 
   speakingurl@14.0.1: {}
-
-  splitpanes@4.0.4(vue@3.5.31(typescript@5.6.3)):
-    dependencies:
-      vue: 3.5.31(typescript@5.6.3)
 
   stackback@0.0.2: {}
 
@@ -4045,7 +4043,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  symbol-tree@3.2.4: {}
+  symbol-tree@3.2.4:
+    optional: true
 
   tailwindcss@4.2.2: {}
 
@@ -4072,11 +4071,13 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  tldts-core@7.0.28: {}
+  tldts-core@7.0.28:
+    optional: true
 
   tldts@7.0.28:
     dependencies:
       tldts-core: 7.0.28
+    optional: true
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4085,10 +4086,12 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.28
+    optional: true
 
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+    optional: true
 
   ts-api-utils@2.5.0(typescript@5.6.3):
     dependencies:
@@ -4110,7 +4113,8 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@7.28.0: {}
+  undici@7.28.0:
+    optional: true
 
   unplugin@1.16.1:
     dependencies:
@@ -4248,16 +4252,19 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+    optional: true
 
   webidl-conversions@7.0.0: {}
 
-  webidl-conversions@8.0.1: {}
+  webidl-conversions@8.0.1:
+    optional: true
 
   webpack-virtual-modules@0.6.2: {}
 
   whatwg-mimetype@3.0.0: {}
 
-  whatwg-mimetype@5.0.0: {}
+  whatwg-mimetype@5.0.0:
+    optional: true
 
   whatwg-url@16.0.1:
     dependencies:
@@ -4266,6 +4273,7 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   which@2.0.2:
     dependencies:
@@ -4292,9 +4300,11 @@ snapshots:
 
   xml-name-validator@4.0.0: {}
 
-  xml-name-validator@5.0.0: {}
+  xml-name-validator@5.0.0:
+    optional: true
 
-  xmlchars@2.2.0: {}
+  xmlchars@2.2.0:
+    optional: true
 
   yaml-eslint-parser@1.3.2:
     dependencies:

--- a/src-tauri/src/serial_debug.rs
+++ b/src-tauri/src/serial_debug.rs
@@ -1,26 +1,24 @@
-//! Serial-debug session: open/close, send, the chunk bridge that batches device
-//! output for the UI, filters, and device reset.
+//! Serial-debug session: open/close, send, filters, and device reset — the Tauri
+//! host's half of the serial-debug feature.
 //!
-//! The chunk bridge is why this is more than a thin command wrapper: device
-//! output arrives line-by-line but reaches the webview in coalesced chunks
-//! (`SERIAL_DEBUG_CHUNK_FLUSH_*`) so a chatty device cannot flood the IPC
-//! channel.
+//! The chunk bridge that batches device output, bounds its queue and reports what
+//! it had to drop lives in `tyutool_core::serial_debug_bridge`, shared with
+//! `tyutool-serve`. All this file contributes to it is [`TauriSink`]: the four
+//! Tauri events those batches and notices become.
 
-use std::sync::mpsc::{self, RecvTimeoutError, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex as StdMutex};
-use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
 
 use tyutool_core::{
-    serial_debug_fail_backfill_if_current, serial_debug_finish_backfill_if_current,
-    serial_debug_now_ms, serial_debug_scan_filter_matches, DebugChunk, DebugConfig, Direction,
-    SerialDebugArchive, SerialDebugArchiveReader, SerialDebugChunkBatchBuffer,
-    SerialDebugDropCounter, SerialDebugDropReport, SerialDebugFilterBackfillSnapshot,
-    SerialDebugFilterDefinition, SerialDebugFilterIndex, SerialDebugFilterPage,
-    SerialDebugFilterStats, SerialDebugGeneration, SerialDebugLine, SerialDebugSession,
-    SerialDebugSessionPage,
+    serial_debug_fail_backfill_if_current, serial_debug_finalize_pending,
+    serial_debug_finish_backfill_if_current, serial_debug_ingest_lines,
+    serial_debug_scan_filter_matches, serial_debug_spawn_chunk_bridge, ArchivedChunk, DebugChunk,
+    DebugConfig, SerialDebugArchive, SerialDebugArchiveReader, SerialDebugChunkBridgeHandle,
+    SerialDebugFilterBackfillSnapshot, SerialDebugFilterDefinition, SerialDebugFilterIndex,
+    SerialDebugFilterPage, SerialDebugFilterStats, SerialDebugGeneration, SerialDebugSession,
+    SerialDebugSessionPage, SerialDebugSink,
 };
 
 pub(crate) struct DebugState {
@@ -46,6 +44,46 @@ struct ArchiveCappedPayload {
     archived_before: u64,
 }
 
+/// Turns everything the shared chunk bridge produces into Tauri events.
+///
+/// Emits are fire-and-forget by contract ([`SerialDebugSink`]): once the webview
+/// is gone there is nobody left to tell, and the bridge thread must not stall on
+/// finding that out.
+#[derive(Clone)]
+struct TauriSink {
+    app: AppHandle,
+}
+
+impl SerialDebugSink for TauriSink {
+    fn chunk_batch(&self, chunks: Vec<ArchivedChunk>) {
+        let _ = self.app.emit("serial-debug-chunk-batch", &chunks);
+    }
+
+    fn chunks_dropped(&self, dropped_bytes: u64, archived_before: u64) {
+        let _ = self.app.emit(
+            "serial-debug-chunks-dropped",
+            &ChunksDroppedPayload {
+                dropped_bytes,
+                archived_before,
+            },
+        );
+    }
+
+    fn archive_capped(&self, limit_mib: u64, archived_before: u64) {
+        let _ = self.app.emit(
+            "serial-debug-archive-capped",
+            &ArchiveCappedPayload {
+                limit_mib,
+                archived_before,
+            },
+        );
+    }
+
+    fn filter_updated(&self, def: SerialDebugFilterDefinition, stats: SerialDebugFilterStats) {
+        emit_filter_update(&self.app, &def, &stats);
+    }
+}
+
 /// Payload of `serial-debug-chunks-dropped`. Only the byte count crosses — the
 /// wording comes from `serialDebug.log.chunksDropped`.
 #[derive(Clone, Serialize)]
@@ -54,35 +92,6 @@ struct ChunksDroppedPayload {
     dropped_bytes: u64,
     /// `archived_before` of the gap lines this notice belongs to — see
     /// [`ArchivedChunk`].
-    archived_before: u64,
-}
-
-/// One chunk on its way to the webview, plus the number of lines the session
-/// archive held *before* this chunk was appended to it.
-///
-/// That number is what lets the frontend switch auto-save on mid-session without
-/// either duplicating or losing a line. Auto-save enables in two halves — the
-/// archive is paged into the file up to a snapshot `N`, the live queue continues
-/// after it — and the frontend cannot otherwise tell which half a live line
-/// belongs to: its own line counter and the archive's `line_no` diverge (the
-/// archive freezes its numbering once capped, and never holds an unterminated
-/// trailing line).
-///
-/// `archived_before` closes that gap exactly, because `append_chunk` archives a
-/// whole chunk under one lock: no snapshot can land *inside* a chunk, so every
-/// line the chunk produced is either wholly inside `N` or wholly after it.
-/// A live line is therefore already in the backfilled half iff
-/// `archived_before < N` — see `dropBackfilledAutoSaveLines` in
-/// `src/stores/serial-debug.ts`.
-///
-/// Read under the same lock guard as the `append_chunk` it precedes; reading it
-/// outside the guard would let another writer slip in between and make the
-/// number a lie.
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ArchivedChunk {
-    #[serde(flatten)]
-    chunk: DebugChunk,
     archived_before: u64,
 }
 
@@ -99,10 +108,6 @@ pub(crate) struct SerialDebugFilterAddArgs {
     use_regex: bool,
     color: String,
 }
-
-const SERIAL_DEBUG_CHUNK_FLUSH_MS: u64 = 12;
-const SERIAL_DEBUG_CHUNK_FLUSH_BYTES: usize = 32 * 1024;
-const SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY: usize = 256;
 
 fn serial_debug_archive_dir() -> std::path::PathBuf {
     std::env::temp_dir().join("tyutool").join("serial-debug")
@@ -174,294 +179,6 @@ fn emit_filter_update(
     );
 }
 
-/// Every line the archive accepts passes through `ingest_serial_debug_lines`,
-/// which makes it the one place that can spot the archive-cap sentinel. The
-/// live view never sees archived lines — it re-splits the raw
-/// `serial-debug-chunk*` payloads itself — so without this event the cap notice
-/// would only ever exist in the archive file and the user would watch the log
-/// keep scrolling with no hint that recording had stopped.
-fn emit_archive_cap_notice(app: &AppHandle, lines: &[SerialDebugLine]) {
-    if let Some((limit_mib, line_no)) = lines.iter().find_map(|line| {
-        tyutool_core::serial_debug_archive_cap_limit_mib(line).map(|mib| (mib, line.line_no))
-    }) {
-        let _ = app.emit(
-            "serial-debug-archive-capped",
-            &ArchiveCappedPayload {
-                limit_mib,
-                // The sentinel is an archive line like any other, so its own
-                // position is exactly `line_no - 1`.
-                archived_before: line_no.saturating_sub(1),
-            },
-        );
-    }
-}
-
-fn ingest_serial_debug_lines(
-    app: &AppHandle,
-    archive: &Arc<StdMutex<SerialDebugArchive>>,
-    filters: &Arc<StdMutex<SerialDebugFilterIndex>>,
-    lines: &[SerialDebugLine],
-) {
-    if lines.is_empty() {
-        return;
-    }
-    emit_archive_cap_notice(app, lines);
-    let updates = {
-        let mut guard = match filters.lock() {
-            Ok(guard) => guard,
-            Err(_) => return,
-        };
-        guard.ingest_completed_lines(lines).unwrap_or_default()
-    };
-    if updates.is_empty() {
-        return;
-    }
-    let guard = match filters.lock() {
-        Ok(guard) => guard,
-        Err(_) => return,
-    };
-    for stats in updates {
-        if let Some(def) = guard.definition(&stats.filter_id) {
-            emit_filter_update(app, &def, &stats);
-        }
-    }
-    let _ = archive; // keeps the signature symmetric with other bridge helpers
-}
-
-fn flush_serial_debug_chunk(
-    app: &AppHandle,
-    archive: &Arc<StdMutex<SerialDebugArchive>>,
-    filters: &Arc<StdMutex<SerialDebugFilterIndex>>,
-    chunks: Vec<DebugChunk>,
-) {
-    if chunks.is_empty() {
-        return;
-    }
-    let (completed, archived) = {
-        let mut guard = match archive.lock() {
-            Ok(guard) => guard,
-            Err(_) => return,
-        };
-        let mut completed = Vec::new();
-        let mut archived = Vec::with_capacity(chunks.len());
-        // One `archived_before` per chunk, not one per batch: per-chunk only
-        // needs `append_chunk` to be atomic, which the archive guarantees on its
-        // own, whereas a per-batch number would additionally rely on this loop
-        // holding the lock for the whole batch.
-        for chunk in chunks {
-            let archived_before = guard.total_lines();
-            completed.extend(guard.append_chunk(&chunk).unwrap_or_default());
-            archived.push(ArchivedChunk {
-                chunk,
-                archived_before,
-            });
-        }
-        (completed, archived)
-    };
-    ingest_serial_debug_lines(app, archive, filters, &completed);
-    let _ = app.emit("serial-debug-chunk-batch", &archived);
-}
-
-enum SerialDebugChunkBridgeMessage {
-    Chunk {
-        generation: u64,
-        chunk: DebugChunk,
-    },
-    Reset {
-        generation: u64,
-        ack: SyncSender<()>,
-    },
-}
-
-#[derive(Clone)]
-pub(crate) struct SerialDebugChunkBridgeHandle {
-    generation: Arc<SerialDebugGeneration>,
-    send_lock: Arc<StdMutex<()>>,
-    tx: SyncSender<SerialDebugChunkBridgeMessage>,
-    drops: Arc<SerialDebugDropCounter>,
-}
-
-impl SerialDebugChunkBridgeHandle {
-    /// Hand one chunk to the bridge, or account for it as lost.
-    ///
-    /// `try_send`, never `send`: this runs on the serial reader thread, which is
-    /// the only thread draining the OS/driver receive buffer, and the port runs
-    /// without flow control. Blocking here therefore applies no backpressure to
-    /// the *device* — it just stops the buffer being drained until the driver
-    /// overflows and discards bytes we never saw, with no count, no error and
-    /// nothing to show the user. Dropping the chunk here instead keeps the reader
-    /// draining and moves the loss to a boundary we own: we know how many bytes
-    /// went, we can close the archive line so the halves cannot be spliced, and
-    /// we can tell the user (who can lower the baud rate or quieten the device).
-    fn send_chunk(&self, chunk: DebugChunk) {
-        let _guard = self.send_lock.lock().unwrap();
-        let bytes = chunk.bytes.len();
-        match self.tx.try_send(SerialDebugChunkBridgeMessage::Chunk {
-            generation: self.generation.current(),
-            chunk,
-        }) {
-            Ok(()) => {}
-            Err(TrySendError::Full(_)) => self.drops.record(bytes, serial_debug_now_ms()),
-            // The bridge thread is gone; the session is being torn down.
-            Err(TrySendError::Disconnected(_)) => {}
-        }
-    }
-
-    fn reset(&self) -> Result<u64, String> {
-        let _guard = self.send_lock.lock().unwrap();
-        let generation = self.generation.advance();
-        let (ack_tx, ack_rx) = std::sync::mpsc::sync_channel(0);
-        self.tx
-            .send(SerialDebugChunkBridgeMessage::Reset {
-                generation,
-                ack: ack_tx,
-            })
-            .map_err(|e| e.to_string())?;
-        ack_rx.recv().map_err(|e| e.to_string())?;
-        Ok(generation)
-    }
-}
-
-/// Surface one coalesced burst of dropped chunks: a `log::warn!` for the
-/// developer, a gap in the archive and a `Sys` notice for the user.
-///
-/// Whatever is buffered is flushed first — those chunks arrived before the gap,
-/// and emitting them afterwards would put the notice in the wrong place in the
-/// live view.
-fn report_serial_debug_drops(
-    app: &AppHandle,
-    archive: &Arc<StdMutex<SerialDebugArchive>>,
-    filters: &Arc<StdMutex<SerialDebugFilterIndex>>,
-    pending: &mut SerialDebugChunkBatchBuffer,
-    report: SerialDebugDropReport,
-) {
-    flush_serial_debug_chunk(app, archive, filters, pending.take());
-    log::warn!(
-        "[serial-debug] chunk bridge queue full (capacity {}): dropped {} chunk(s) / {} byte(s) \
-         of device output",
-        SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY,
-        report.chunks,
-        report.bytes
-    );
-    // Only the reader thread's Rx chunks travel the bounded queue: the Tx path
-    // (`serial_debug_send`) writes straight to the archive.
-    let (lines, archived_before) = {
-        let mut guard = match archive.lock() {
-            Ok(guard) => guard,
-            Err(_) => return,
-        };
-        // `append_gap` writes the cut-off partial line and the sentinel under one
-        // lock, so one number covers both frontend lines — see [`ArchivedChunk`].
-        let archived_before = guard.total_lines();
-        (
-            guard
-                .append_gap(Direction::Rx, serial_debug_now_ms(), report.bytes)
-                .unwrap_or_default(),
-            archived_before,
-        )
-    };
-    ingest_serial_debug_lines(app, archive, filters, &lines);
-    let _ = app.emit(
-        "serial-debug-chunks-dropped",
-        &ChunksDroppedPayload {
-            dropped_bytes: report.bytes,
-            archived_before,
-        },
-    );
-}
-
-/// Cut the tail the device never terminated into the archive, at the end of a
-/// session. Returns the lines written (empty when nothing was buffered) so the
-/// caller can ingest them like any other archive line.
-///
-/// Nothing else closes that buffer: `append_chunk` only cuts on a newline and
-/// `append_gap` only runs when a chunk is dropped, so a prompt or a progress bar
-/// — output the device deliberately leaves unterminated — would go down with the
-/// port and appear in neither the live view nor the archive.
-fn finalize_serial_debug_pending(
-    archive: &Arc<StdMutex<SerialDebugArchive>>,
-) -> Vec<SerialDebugLine> {
-    let mut guard = match archive.lock() {
-        Ok(guard) => guard,
-        Err(_) => return Vec::new(),
-    };
-    guard
-        .finalize_pending_lines(serial_debug_now_ms())
-        .unwrap_or_default()
-}
-
-fn spawn_serial_debug_chunk_bridge(
-    app: AppHandle,
-    archive: Arc<StdMutex<SerialDebugArchive>>,
-    filters: Arc<StdMutex<SerialDebugFilterIndex>>,
-    generation: Arc<SerialDebugGeneration>,
-) -> SerialDebugChunkBridgeHandle {
-    // Bound the bridge queue so sustained ingress can't grow process memory without limit
-    // when archive/filter/UI consumption temporarily lags behind the serial reader.
-    let (tx, rx) =
-        mpsc::sync_channel::<SerialDebugChunkBridgeMessage>(SERIAL_DEBUG_CHUNK_QUEUE_CAPACITY);
-    let drops = Arc::new(SerialDebugDropCounter::default());
-    let handle = SerialDebugChunkBridgeHandle {
-        generation: Arc::clone(&generation),
-        send_lock: Arc::new(StdMutex::new(())),
-        tx: tx.clone(),
-        drops: Arc::clone(&drops),
-    };
-    std::thread::spawn(move || {
-        let mut pending = SerialDebugChunkBatchBuffer::new();
-        let mut active_generation = generation.current();
-        loop {
-            // Before every receive, so `recv_timeout`'s own tick is the poll
-            // clock and no `continue` below can skip the check.
-            if let Some(report) = drops.take_report(serial_debug_now_ms()) {
-                report_serial_debug_drops(&app, &archive, &filters, &mut pending, report);
-            }
-            match rx.recv_timeout(Duration::from_millis(SERIAL_DEBUG_CHUNK_FLUSH_MS)) {
-                Ok(SerialDebugChunkBridgeMessage::Chunk { generation, chunk }) => {
-                    if generation != active_generation {
-                        if generation < active_generation {
-                            continue;
-                        }
-                        let _ = pending.take();
-                        active_generation = generation;
-                    }
-                    pending.push(chunk);
-                    if pending.should_flush_bytes(SERIAL_DEBUG_CHUNK_FLUSH_BYTES) {
-                        flush_serial_debug_chunk(&app, &archive, &filters, pending.take());
-                    }
-                }
-                Ok(SerialDebugChunkBridgeMessage::Reset { generation, ack }) => {
-                    let _ = pending.take();
-                    // Drops from the cleared session belong to the log the user
-                    // just discarded; reporting them into the new one would be a
-                    // notice about a gap that is no longer there.
-                    let _ = drops.take_pending();
-                    active_generation = generation;
-                    let _ = ack.send(());
-                }
-                Err(RecvTimeoutError::Timeout) => {
-                    if pending
-                        .should_flush_elapsed(Duration::from_millis(SERIAL_DEBUG_CHUNK_FLUSH_MS))
-                    {
-                        flush_serial_debug_chunk(&app, &archive, &filters, pending.take());
-                    }
-                }
-                Err(RecvTimeoutError::Disconnected) => {
-                    flush_serial_debug_chunk(&app, &archive, &filters, pending.take());
-                    // A burst still aggregating at teardown is reported anyway —
-                    // it is the last thing the user needs to know about the log
-                    // they are about to read.
-                    if let Some(report) = drops.take_pending() {
-                        report_serial_debug_drops(&app, &archive, &filters, &mut pending, report);
-                    }
-                    return;
-                }
-            }
-        }
-    });
-    handle
-}
-
 #[tauri::command]
 pub(crate) async fn serial_debug_open(
     app: AppHandle,
@@ -483,14 +200,11 @@ pub(crate) async fn serial_debug_open(
             return Err("already open".into());
         }
     }
-    let archive_for_chunk = Arc::clone(&state.archive);
-    let filters_for_chunk = Arc::clone(&state.filters);
-    let app_for_chunk = app.clone();
     let app_for_disc = app.clone();
-    let chunk_tx = spawn_serial_debug_chunk_bridge(
-        app_for_chunk.clone(),
-        Arc::clone(&archive_for_chunk),
-        Arc::clone(&filters_for_chunk),
+    let chunk_tx = serial_debug_spawn_chunk_bridge(
+        TauriSink { app: app.clone() },
+        Arc::clone(&state.archive),
+        Arc::clone(&state.filters),
         Arc::clone(&state.generation),
     );
     let chunk_tx_for_session = chunk_tx.clone();
@@ -556,10 +270,12 @@ pub(crate) async fn serial_debug_close(
         .take();
     // Cut after the bridge handle is dropped, which is what releases the bridge
     // thread's final flush, so the chunks it was still holding land in the
-    // archive ahead of the tail. (`tyutool-serve`'s bridge acks its shutdown and
-    // is therefore exact about that ordering; this one has no ack.)
-    let lines = finalize_serial_debug_pending(&state.archive);
-    ingest_serial_debug_lines(&app, &state.archive, &state.filters, &lines);
+    // archive ahead of the tail. The shared bridge also offers an acked
+    // `shutdown()` — which is what makes `tyutool-serve` exact about that
+    // ordering — but nothing here waits for it, so this remains a race the drop
+    // usually wins.
+    let lines = serial_debug_finalize_pending(&state.archive);
+    serial_debug_ingest_lines(&TauriSink { app: app.clone() }, &state.filters, &lines);
     Ok(())
 }
 
@@ -605,7 +321,7 @@ pub(crate) fn serial_debug_send(
             archived_before,
         )
     };
-    ingest_serial_debug_lines(&app, &state.archive, &state.filters, &completed);
+    serial_debug_ingest_lines(&TauriSink { app: app.clone() }, &state.filters, &completed);
     let _ = app.emit(
         "serial-debug-chunk",
         &ArchivedChunk {
@@ -694,7 +410,7 @@ pub(crate) fn serial_debug_append_sys_line(
     // `None` once the session archive hit its size cap.
     let line_no = line.as_ref().map(|line| line.line_no);
     if let Some(line) = line {
-        ingest_serial_debug_lines(&app, &state.archive, &state.filters, &[line]);
+        serial_debug_ingest_lines(&TauriSink { app: app.clone() }, &state.filters, &[line]);
     }
     Ok(line_no)
 }
@@ -941,85 +657,5 @@ mod tests {
     fn serial_debug_device_reset_session_requires_open_session() {
         let err = serial_debug_device_reset_session(None, "T5AI").unwrap_err();
         assert_eq!(err, "serial debug not open");
-    }
-
-    /// Closing the port is the last moment the bytes the device printed without
-    /// a trailing newline can be saved — a `login: ` prompt, a progress bar.
-    /// Nothing else in the archive ever cuts them.
-    #[test]
-    fn closing_a_session_archives_the_unterminated_tail() {
-        let dir = std::env::temp_dir().join(format!(
-            "tyutool-gui-serial-debug-close-{}-{}",
-            std::process::id(),
-            serial_debug_now_ms()
-        ));
-        let archive = Arc::new(StdMutex::new(SerialDebugArchive::create(&dir).unwrap()));
-        archive
-            .lock()
-            .unwrap()
-            .append_chunk(&DebugChunk {
-                direction: Direction::Rx,
-                ts_ms: 1,
-                bytes: b"login: ".to_vec(),
-            })
-            .unwrap();
-        assert_eq!(archive.lock().unwrap().total_lines(), 0, "no newline yet");
-
-        let lines = finalize_serial_debug_pending(&archive);
-
-        assert_eq!(lines.len(), 1);
-        assert_eq!(lines[0].text, "login: ");
-        assert_eq!(
-            archive
-                .lock()
-                .unwrap()
-                .read_line_range(1, 10)
-                .unwrap()
-                .iter()
-                .map(|l| l.text.clone())
-                .collect::<Vec<_>>(),
-            vec!["login: ".to_string()]
-        );
-        // Closing again has nothing left to cut: no empty line.
-        assert!(finalize_serial_debug_pending(&archive).is_empty());
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    /// A full queue must cost us the chunk, not the reader thread.
-    ///
-    /// This test would hang rather than fail if `send_chunk` went back to a
-    /// blocking `send`: nothing drains `rx`, so the third call would park
-    /// forever — which is exactly what stalls the serial reader in production
-    /// and lets the OS receive buffer overflow behind our back.
-    #[test]
-    fn full_bridge_queue_drops_chunks_instead_of_blocking_the_reader() {
-        let (tx, rx) = mpsc::sync_channel::<SerialDebugChunkBridgeMessage>(1);
-        let handle = SerialDebugChunkBridgeHandle {
-            generation: Arc::new(SerialDebugGeneration::default()),
-            send_lock: Arc::new(StdMutex::new(())),
-            tx,
-            drops: Arc::new(SerialDebugDropCounter::default()),
-        };
-        let chunk = |bytes: usize| DebugChunk {
-            direction: Direction::Rx,
-            ts_ms: 1,
-            bytes: vec![b'x'; bytes],
-        };
-
-        handle.send_chunk(chunk(4)); // fits the capacity-1 queue
-        handle.send_chunk(chunk(8)); // dropped
-        handle.send_chunk(chunk(16)); // dropped
-
-        // One report for the whole burst, carrying the total loss.
-        let report = handle.drops.take_pending().unwrap();
-        assert_eq!(report.chunks, 2);
-        assert_eq!(report.bytes, 24);
-        assert!(handle.drops.take_pending().is_none());
-
-        drop(rx);
-        // A disconnected queue is a closing session, not a data loss.
-        handle.send_chunk(chunk(32));
-        assert!(handle.drops.take_pending().is_none());
     }
 }

--- a/src/splitpanes.d.ts
+++ b/src/splitpanes.d.ts
@@ -1,1 +1,0 @@
-declare module 'splitpanes';


### PR DESCRIPTION
Moves the serial-debug chunk bridge into `tyutool-core` so the Tauri host and the
`serve` host share one implementation instead of each carrying its own.

```
crates/tyutool-core/src/serial_debug_bridge.rs | 699 +++++++++++++++++++++
crates/tyutool-core/src/lib.rs                 |   7 +
crates/tyutool-serve/src/lib.rs                | 490 +++--------------
src-tauri/src/serial_debug.rs                  | 494 +++--------------
package.json / pnpm-lock.yaml                  |  drops splitpanes,
src/splitpanes.d.ts                            |  free-regular-svg-icons, jsdom
```

## Validation status

Frontend gates pass on this branch: `pnpm run build`, `pnpm run lint`,
`pnpm run test` (919/919). The removed dependencies have no remaining references
in `src/`.

**The Rust changes — which are the substance of this branch — have not been
compiled or tested locally**; no Rust toolchain was available in the environment
where these gates were run. `cargo test -p tyutool-core` and
`cargo test -p tyutool-cli` still need to pass before merge.

Please confirm the deduplicated bridge behaves identically on both hosts.
