### PR TITLE
refactor(core): finish the batch consolidation, and cancel the stage that had no cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,13 +195,17 @@ declares **no `default` feature** — every optional cost is opted into explicit
 feature with who must enable it and who must not; `libudev` is the model (GUI/glibc only — CLI
 musl builds and CI must leave it off).
 
-**Known outstanding violation — do not add to it.** One remains: the batch-flash
-*orchestration* (`src-tauri/src/batch.rs`, ~930 lines) lives only in `src-tauri`, so no
-other frontend can drive a batch run. Its `AppHandle`/`emit` use is confined to the
-command layer — `run_batch_auth_slot` already takes an `emit` callback instead of an
-`AppHandle`, which is both what makes it testable and the seam a future move would use.
-The Excel half is done: `batch_auth.rs` moved to `tyutool_core::batch_auth` behind the
-`excel` feature.
+**Known outstanding violation — do not add to it.** What is left of `src-tauri/src/batch.rs`
+(~540 lines) is the Tauri command layer for batch runs: `AppHandle`, `State<'_, _>`, the
+per-port thread pool, and the `emit` forwarding. By the table above most of that *belongs*
+here. The open question is not "move the rest" but **what a second frontend actually needs**:
+`tyutool_core::batch_slot::run_batch_slot` already gives it one port's full run driven by an
+`emit` callback, so a CLI would only have to write its own concurrency shell. Decide that
+before moving anything else — see the P4b section of the consolidation spec.
+
+The parts that were unambiguously misplaced are done: `batch_auth.rs` → `tyutool_core::batch_auth`
+(behind `excel`), `BatchAuthTraceWriter` → `core/diagnostics.rs`, and the slot orchestration →
+`tyutool_core::batch_slot`.
 
 The consolidation plan is `docs/specs/2026-08-26-core-consolidation-design.md`, whose phase
 table is the authority on what is done — read it before moving anything between crates. Delete
@@ -225,7 +229,7 @@ each item here as its stage lands; a fixed item left listed is worse than no lis
 
 | Crate | Binary / lib | Role |
 |-------|--------------|------|
-| `tyutool-core` | lib | Flash logic, chip plugins, serial utils, authorize flow, serial-debug engine, the serial-debug chunk bridge shared by `tyutool-serve` and `src-tauri` (`serial_debug_bridge.rs`), and the Excel batch-auth row allocator behind the `excel` feature (`batch_auth.rs`). **No binaries.** |
+| `tyutool-core` | lib | Flash logic, chip plugins, serial utils, authorize flow, serial-debug engine, the serial-debug chunk bridge shared by `tyutool-serve` and `src-tauri` (`serial_debug_bridge.rs`), and behind the `excel` feature both the batch-auth row allocator (`batch_auth.rs`) and one port's batch-slot orchestration (`batch_slot.rs`). **No binaries.** |
 | `tyutool-cli` | bin `tyutool_cli` | Interactive CLI. The `serve` subcommand delegates to `tyutool-serve`. |
 | `tyutool-serve` | lib (used by `tyutool-cli serve`) | WS dev-serve backend for `pnpm run dev:web` — **binds 127.0.0.1:9527, loopback `Host` + local-`Origin` handshake check (`validate_ws_origin`), no authentication, dev-only**. Not shipped to end users. |
 | `tyutool-bridge` | bin `tyutool-bridge` ("Cobuilder Bridge") | Resident tray + WS helper for cobuilder-web — **localhost:18730, Origin allowlist + per-connection token grants, single-execution lock, audit log**. Independent release line (`bridge-v*` tags). See `crates/tyutool-bridge/AGENTS.md` and `PROTOCOL.md`. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,35 +195,11 @@ declares **no `default` feature** — every optional cost is opted into explicit
 feature with who must enable it and who must not; `libudev` is the model (GUI/glibc only — CLI
 musl builds and CI must leave it off).
 
-**Known outstanding violation — do not add to it.** What is left of `src-tauri/src/batch.rs`
-(~540 lines) is the Tauri command layer for batch runs: `AppHandle`, `State<'_, _>`, the
-per-port thread pool, and the `emit` forwarding. By the table above most of that *belongs*
-here. The open question is not "move the rest" but **what a second frontend actually needs**:
-`tyutool_core::batch_slot::run_batch_slot` already gives it one port's full run driven by an
-`emit` callback, so a CLI would only have to write its own concurrency shell. Decide that
-before moving anything else — see the P4b section of the consolidation spec.
-
-The parts that were unambiguously misplaced are done: `batch_auth.rs` → `tyutool_core::batch_auth`
-(behind `excel`), `BatchAuthTraceWriter` → `core/diagnostics.rs`, and the slot orchestration →
-`tyutool_core::batch_slot`.
-
-The consolidation plan is `docs/specs/2026-08-26-core-consolidation-design.md`, whose phase
-table is the authority on what is done — read it before moving anything between crates. Delete
-each item here as its stage lands; a fixed item left listed is worse than no list.
-
-> **Done:** the second violation — helpers reachable in core but not exposed — is closed.
-> `tyutool logs list / tail / export` (P6) now drives the same
-> `tyutool_core::diagnostics` helpers the GUI log viewer uses, so the CLI can list, tail and
-> export logs; `docs/cli.md` documents it and `tyutool-core`'s `zip` feature is enabled for
-> the CLI. Moving code is not the same as shipping the capability — that is why it was its
-> own stage.
->
-> **Done:** `prune_log_files` was implemented three times; P0 merged it into
-> `tyutool_core::prune_log_files(dir, &LogRetention)`, with the three budgets kept distinct as
-> a parameter rather than a constant. P1a and P1b then moved log retention, reading, listing,
-> the report header, credential redaction and zip bundling into `tyutool_core::diagnostics`;
-> `src-tauri/src/logs.rs` went from 1467 to about 790 lines and dropped its own `zip`
-> dependency, which now sits behind core's `zip` feature so bridge and serve do not link it.
+**There is no outstanding violation of this rule today** — the list that used to live here is
+empty and was deleted rather than kept as a monument. The history is in
+`docs/specs/completed/2026-08-26-core-consolidation-design.md`, whose phase table records what
+moved, what was cancelled, and why; read it before moving anything between crates, and note
+that two of its stages were cancelled on evidence rather than completed.
 
 **Crate responsibilities (5 workspace members):**
 
@@ -479,7 +455,7 @@ refactor/v3    ← main development branch (default); feature PRs merge here
   feature's comment in `crates/tyutool-core/Cargo.toml`.
 - Every other frontend type mirroring a Rust type (`FlashEvent` and its payload family in
   `flash-ipc-types.ts`, `serial-debug/types.ts`, etc.) is still hand-written; annotate with a
-  comment pointing to the Rust source. `docs/specs/2026-08-26-core-consolidation-design.md`
+  comment pointing to the Rust source. `docs/specs/completed/2026-08-26-core-consolidation-design.md`
   plans to extend `ts-rs` generation to cover them — update this pair of rules as each family
   moves over, and delete the hand-mirroring rule only once none remain
 - Tauri APIs (`@tauri-apps/api/*`) and `@tauri-apps/plugin-store` must be dynamically imported (`await import(...)`), never top-level imported

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,7 +364,10 @@ Logs exist partly so users can file good bug reports. Preserve these guarantees:
   that need bytes re-encode the text.
 - **Credential isolation (two-channel model):** batch-auth plaintext interaction data
   (verify comparison UUID/AuthKey values) is written to `batch-auth-<ts>.trace` via
-  `BatchAuthTraceWriter`, **never** into `tyutool-*.log`. The `.trace` file uses a non-`.log`
+  `tyutool_core::BatchAuthTraceWriter`, **never** into `tyutool-*.log`. The writer sits
+  directly beside `prune_trace_files` in `core/diagnostics.rs` on purpose: naming and
+  retention are one contract, and splitting them across crates let one be changed
+  without the other. The `.trace` file uses a non-`.log`
   extension and non-`tyutool-` prefix on purpose — `collect_log_files`/`prune_log_files`/
   `list_log_files_impl`/`pick_active_log` all ignore it, so it can never land in an export or
   archive zip. It is the operator's local diagnosis record. `prune_trace_files` bounds growth

--- a/crates/tyutool-core/src/batch_slot.rs
+++ b/crates/tyutool-core/src/batch_slot.rs
@@ -1,0 +1,404 @@
+//! Batch-auth slot orchestration: what one serial port goes through during a
+//! batch run — optional firmware flash, then the authorize transaction, with
+//! the Excel row allocated, updated and released around it.
+//!
+//! This is the layer above `authorize::run_batch_auth_slot` (which performs the
+//! single device transaction) and above `batch_auth::ExcelRowAllocator` (which
+//! owns the sheet). It depends on no frontend: progress is reported through an
+//! `emit` callback, so a Tauri command forwards to `app.emit` while a test
+//! records the payloads. The thread pool that runs several of these at once
+//! stays with the frontend that owns the port list.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+
+use crate::batch_auth;
+
+/// Excel allocator + count of slot threads using it, guarded by ONE mutex so
+/// acquire (batch_auth_start) and release (last SlotSessionGuard drop) can
+/// never interleave. Invariant: `alloc.is_some() ⇒ active > 0` — the file
+/// lock is held exactly while slots run, so the sheet can be edited between
+/// batches and every new batch re-reads it from disk.
+pub struct AllocatorSession {
+    pub alloc: Option<std::sync::Arc<batch_auth::ExcelRowAllocator>>,
+    pub active: usize,
+}
+
+/// Decrements the session's active count when a slot thread exits (any path,
+/// including early returns and panics); the last one out releases the file
+/// lock and drops the allocator.
+struct SlotSessionGuard(Arc<StdMutex<AllocatorSession>>);
+
+impl Drop for SlotSessionGuard {
+    fn drop(&mut self) {
+        if let Ok(mut session) = self.0.lock() {
+            session.active = session.active.saturating_sub(1);
+            if session.active == 0 {
+                if let Some(alloc) = session.alloc.take() {
+                    alloc.release_lock();
+                    log::info!("[batch-auth] last slot finished; excel session closed");
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchAuthStartConfig {
+    pub chip_id: String,
+    pub baud_rate: u32,
+    pub auth_baud_rate: u32,
+    pub firmware_path: Option<String>,
+    pub flash_start_hex: Option<String>,
+    pub flash_end_hex: Option<String>,
+    pub excel_path: String,
+    pub conflict_policy: String,
+    pub auth_storage: Option<String>,
+    /// false ⇒ flash-only batch: skip the Excel session and the auth step.
+    #[serde(default = "default_authorize_enabled")]
+    pub authorize_enabled: bool,
+}
+
+fn default_authorize_enabled() -> bool {
+    true
+}
+
+/// One batch-auth slot: optional firmware flash, then the authorize pipeline,
+/// for a single port. Runs on its own thread.
+///
+/// `emit` receives every `batch-auth-progress` payload. Taking a callback rather
+/// than an `AppHandle` is what makes this callable from a test: the production
+/// caller forwards to `app.emit`, while a test can record the payloads and
+/// assert the slot's step sequence.
+#[allow(clippy::too_many_arguments)]
+pub fn run_batch_slot(
+    port: String,
+    config: BatchAuthStartConfig,
+    cancel: Arc<AtomicBool>,
+    allocator: Option<Arc<batch_auth::ExcelRowAllocator>>,
+    session: Arc<StdMutex<AllocatorSession>>,
+    trace: Option<Arc<StdMutex<crate::BatchAuthTraceWriter>>>,
+    conflict_policy: crate::ConflictPolicy,
+    auth_storage: crate::AuthStorage,
+    emit: &dyn Fn(serde_json::Value),
+) {
+    // Must be the first statement: every exit path (early returns,
+    // panics) has to decrement the session count. Flash-only batches
+    // never incremented it, so they get no guard.
+    let _session_guard = allocator.is_some().then(|| SlotSessionGuard(session));
+    // Last Excel write failure for this slot; attached to the final
+    // progress emit so the operator sees the sheet was NOT updated.
+    let excel_err: Arc<StdMutex<Option<String>>> = Arc::new(StdMutex::new(None));
+    log::info!(
+        "[batch-auth] slot begin  port={port} chip={}",
+        config.chip_id
+    );
+    if let Some(ref fw_path) = config.firmware_path {
+        if !fw_path.is_empty() {
+            let job = crate::FlashJob {
+                firmware_path: Some(fw_path.clone()),
+                flash_start_hex: config.flash_start_hex.clone(),
+                flash_end_hex: config.flash_end_hex.clone(),
+                ..crate::FlashJob::new(
+                    crate::FlashMode::Flash,
+                    config.chip_id.clone(),
+                    port.clone(),
+                    config.baud_rate,
+                )
+            };
+            log::info!(
+                "[batch-auth] flash start  port={port} chip={} firmware={fw_path}",
+                config.chip_id
+            );
+            let port2 = port.clone();
+            let flash_result = crate::run_job(&job, &cancel, |p| {
+                emit(serde_json::json!({
+                    "port": port2,
+                    "step": "flashing",
+                    "event": p
+                }));
+            });
+            if !config.authorize_enabled {
+                // Flash-only: a user cancel is not a failure — mirror
+                // the auth pipeline's "cancelled" step so the slot
+                // returns to idle without polluting the cumulative
+                // stats. On Ok, a late cancel changes nothing: the
+                // run_job Done event forwarded above is already the
+                // terminal signal, so emitting a second outcome here
+                // would double-count the slot.
+                match flash_result {
+                    Err(crate::FlashError::Cancelled) => {
+                        log::info!("[batch-auth] flash cancelled  port={port}");
+                        emit(serde_json::json!({
+                            "port": port,
+                            "step": "cancelled"
+                        }));
+                        return;
+                    }
+                    Err(e) => {
+                        log::warn!("[batch-auth] flash failed  port={port} error={e}");
+                        emit(serde_json::json!({
+                            "port": port,
+                            "step": "failed",
+                            "error": e.to_string()
+                        }));
+                        return;
+                    }
+                    Ok(()) => {}
+                }
+            } else if flash_result.is_err() || cancel.load(Ordering::Relaxed) {
+                let error = flash_result
+                    .err()
+                    .map(|e| e.to_string())
+                    .unwrap_or_else(|| "cancelled".into());
+                log::warn!("[batch-auth] flash failed  port={port} error={error}");
+                emit(serde_json::json!({
+                    "port": port,
+                    "step": "failed",
+                    "error": error
+                }));
+                return;
+            }
+            log::info!("[batch-auth] flash done  port={port}");
+            if config.authorize_enabled {
+                // Wait for the device to boot naturally after flash before the auth
+                // slot issues a hardware reset. Non-fatal, and passive: it exits as
+                // soon as the device answers, so only a silent device pays the full
+                // WAIT_AFTER_FLASH_MAX window. Each port has its own thread, so a
+                // longer worst case does not accumulate across the batch.
+                crate::wait_after_firmware_flash(
+                    &port,
+                    config.auth_baud_rate,
+                    &config.chip_id,
+                    &cancel,
+                );
+                if cancel.load(Ordering::Relaxed) {
+                    return;
+                }
+            }
+        }
+    }
+
+    // Flash-only batch: run_job's Done event (forwarded above under
+    // step "flashing") is the terminal signal for the frontend —
+    // nothing to authorize, no Excel to update.
+    let Some(allocator) = allocator else {
+        log::info!("[batch-auth] slot done (flash-only)  port={port}");
+        return;
+    };
+
+    // find_by_mac: look up Excel row by device MAC address
+    let alloc_find = allocator.clone();
+    let find_by_mac =
+        move |mac: &str| -> Option<(usize, String, String)> { alloc_find.find_by_mac(mac) };
+
+    // allocate_row: claim a new unused row
+    let alloc_alloc = allocator.clone();
+    let allocate_row = move || -> Option<(usize, String, String)> {
+        match alloc_alloc.allocate_row() {
+            Ok(row) => Some((row.row_idx, row.uuid, row.authkey)),
+            Err(e) => {
+                log::warn!("[batch-auth] allocate_row error: {e}");
+                None
+            }
+        }
+    };
+
+    // update_row: translate BatchAuthRowUpdate → RowStatus + step_name, then write to Excel
+    let alloc_update = allocator.clone();
+    let port_for_update = port.clone();
+    let excel_err_update = excel_err.clone();
+    let update_row = move |row_idx: usize, mac: &str, update: crate::BatchAuthRowUpdate| {
+        use crate::batch_auth::RowStatus;
+        use crate::BatchAuthRowUpdate as U;
+        let (status, step_name, error): (RowStatus, Option<&str>, Option<String>) = match update {
+            U::MacRead => (RowStatus::MacRead, Some("mac_read"), None),
+            U::AuthWritten => (RowStatus::AuthWritten, Some("auth_written"), None),
+            U::AuthVerified => (RowStatus::AuthVerified, Some("auth_verified"), None),
+            // Done: keep last step in Excel (STATUS=DONE is sufficient)
+            U::Done => (RowStatus::Done, None, None),
+            U::StepFailed { step, error } => {
+                let status = if step == "auth_write" {
+                    RowStatus::MacRead
+                } else {
+                    RowStatus::AuthWritten
+                };
+                (status, Some(step), Some(error))
+            }
+        };
+        if let Err(e) =
+            alloc_update.update_row_state(row_idx, mac, status, step_name, error.as_deref())
+        {
+            log::error!(
+                "[batch-auth] excel-update-failed  port={port_for_update} row={row_idx} err={e}"
+            );
+            if let Ok(mut slot) = excel_err_update.lock() {
+                *slot = Some(e);
+            }
+        }
+    };
+
+    let slot_config = crate::BatchAuthSlotConfig {
+        auth_baud_rate: config.auth_baud_rate,
+        conflict_policy,
+        auth_storage,
+    };
+    let result = crate::run_batch_auth_slot(
+        &port,
+        &config.chip_id,
+        &slot_config,
+        find_by_mac,
+        allocate_row,
+        update_row,
+        &cancel,
+        |step| {
+            let step_str = match step {
+                crate::BatchAuthStep::ReadingMac => "reading_mac",
+                crate::BatchAuthStep::ReadingAuth => "reading_auth",
+                crate::BatchAuthStep::WritingAuth => "writing_auth",
+                crate::BatchAuthStep::Verifying => "verifying",
+            };
+            emit(serde_json::json!({ "port": port, "step": step_str }));
+        },
+        |line: &str| {
+            if let Some(tw) = &trace {
+                if let Ok(mut w) = tw.lock() {
+                    w.writeln(line);
+                }
+            }
+        },
+    );
+
+    // Attach the captured Excel write failure (if any) to a final
+    // emit — the frontend renders it as a per-slot warning.
+    let emit_final = |mut payload: serde_json::Value| {
+        if let Some(e) = excel_err.lock().ok().and_then(|g| g.clone()) {
+            payload["excelError"] = serde_json::Value::String(e);
+        }
+        emit(payload);
+    };
+
+    match result {
+        // Done — state already written to Excel by update_row(Done)
+        Ok(crate::BatchAuthSlotResult::Done { mac }) => {
+            log::info!("[batch-auth] slot done  port={port} mac={mac}");
+            emit_final(serde_json::json!({ "port": port, "step": "done", "mac": mac }));
+        }
+        // AlreadyDone — state already written to Excel by update_row(Done) in authorize.rs
+        Ok(crate::BatchAuthSlotResult::AlreadyDone { mac }) => {
+            log::info!("[batch-auth] slot already-done  port={port} mac={mac}");
+            emit_final(serde_json::json!({ "port": port, "step": "done", "mac": mac }));
+        }
+        // InsufficientCodes — no row was allocated, nothing to write
+        Ok(crate::BatchAuthSlotResult::InsufficientCodes { mac }) => {
+            log::info!("[batch-auth] slot no-code  port={port} mac={mac}");
+            emit(serde_json::json!({ "port": port, "step": "no_code", "mac": mac }));
+        }
+        // Skipped — device already carries auth we didn't (knowingly) write.
+        // If that UUID is still an unclaimed row in our sheet, claim it for this
+        // MAC so the same code can't later be handed to a different device.
+        Ok(crate::BatchAuthSlotResult::Skipped { mac, existing_uuid }) => {
+            log::info!(
+                "[batch-auth] slot skipped  port={port} mac={mac} existing_uuid={existing_uuid}"
+            );
+            if let Err(e) = allocator.confirm_existing_uuid(&existing_uuid, &mac) {
+                log::error!("[batch-auth] excel-confirm-skipped-failed  port={port} existing_uuid={existing_uuid} err={e}");
+                if let Ok(mut slot) = excel_err.lock() {
+                    *slot = Some(e);
+                }
+            }
+            emit_final(
+                serde_json::json!({ "port": port, "step": "skipped", "mac": mac, "existingUuid": existing_uuid }),
+            );
+        }
+        // Cancelled — pre-write cancel; if MacRead was written, row stays in MacRead state (recoverable)
+        Ok(crate::BatchAuthSlotResult::Cancelled) => {
+            log::info!("[batch-auth] slot cancelled  port={port}");
+            emit(serde_json::json!({ "port": port, "step": "cancelled" }));
+        }
+        // CancelledAfterWrite — state already written to Excel by update_row(AuthWritten)
+        Ok(crate::BatchAuthSlotResult::CancelledAfterWrite { mac, uuid }) => {
+            log::warn!(
+                "[batch-auth] slot cancelled AFTER auth_write  port={port} mac={mac} uuid={uuid}"
+            );
+            emit_final(
+                serde_json::json!({ "port": port, "step": "cancelled_after_write", "mac": mac, "uuid": uuid }),
+            );
+        }
+        // DefaultMac — T5/T5AI factory default MAC; no row allocation
+        Ok(crate::BatchAuthSlotResult::DefaultMac { mac }) => {
+            log::warn!("[batch-auth] slot default-mac  port={port} mac={mac}");
+            emit(serde_json::json!({ "port": port, "step": "default_mac", "mac": mac }));
+        }
+        // Err — state already written by update_row(StepFailed) inside authorize.rs
+        Err(e) => {
+            log::warn!("[batch-auth] slot failed  port={port} error={e}");
+            emit_final(
+                serde_json::json!({ "port": port, "step": "failed", "error": e.to_string() }),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The point of `run_batch_slot` taking an `emit` callback instead of an
+    /// `AppHandle`: the slot body can be driven from a test. This covers the
+    /// flash-only-with-nothing-to-do path, which touches no serial port.
+    #[test]
+    fn flash_only_slot_without_firmware_or_allocator_emits_nothing() {
+        let seen: Arc<StdMutex<Vec<serde_json::Value>>> = Arc::new(StdMutex::new(Vec::new()));
+        let sink = seen.clone();
+
+        run_batch_slot(
+            "COM_TEST".to_string(),
+            BatchAuthStartConfig {
+                chip_id: "T5AI".into(),
+                baud_rate: 921_600,
+                auth_baud_rate: 115_200,
+                firmware_path: None,
+                flash_start_hex: None,
+                flash_end_hex: None,
+                excel_path: String::new(),
+                conflict_policy: "skip".into(),
+                auth_storage: None,
+                authorize_enabled: false,
+            },
+            Arc::new(AtomicBool::new(false)),
+            None,
+            Arc::new(StdMutex::new(AllocatorSession {
+                alloc: None,
+                active: 0,
+            })),
+            None,
+            crate::ConflictPolicy::Skip,
+            crate::AuthStorage::Kv,
+            &move |payload| sink.lock().unwrap().push(payload),
+        );
+
+        assert!(
+            seen.lock().unwrap().is_empty(),
+            "a flash-only slot with no firmware has nothing to report"
+        );
+    }
+
+    #[test]
+    fn batch_auth_start_config_defaults_authorize_enabled_to_true() {
+        let cfg: BatchAuthStartConfig = serde_json::from_str(
+            r#"{"chipId":"esp32","baudRate":921600,"authBaudRate":115200,
+                "excelPath":"codes.xlsx","conflictPolicy":"skip"}"#,
+        )
+        .unwrap();
+        assert!(cfg.authorize_enabled);
+
+        let cfg: BatchAuthStartConfig = serde_json::from_str(
+            r#"{"chipId":"esp32","baudRate":921600,"authBaudRate":115200,
+                "excelPath":"","conflictPolicy":"skip","authorizeEnabled":false}"#,
+        )
+        .unwrap();
+        assert!(!cfg.authorize_enabled);
+    }
+}

--- a/crates/tyutool-core/src/diagnostics.rs
+++ b/crates/tyutool-core/src/diagnostics.rs
@@ -187,6 +187,40 @@ fn pick_active_log(dir: &Path) -> Option<PathBuf> {
 }
 
 /// Read the last `max_bytes` bytes of `path` as UTF-8 (lossy).
+/// Plaintext writer for batch-auth device-interaction data (auth-read raw lines,
+/// auth-write responses, verify comparison values). Lives in its own
+/// `batch-auth-<ts>.trace` file — deliberately NOT a `.log` file and NOT
+/// `tyutool-`-prefixed, so `collect_log_files` / `prune_log_files` /
+/// `list_log_files_impl` / `pick_active_log` all ignore it. The export-for-report
+/// zip therefore can never contain it; only the operator's local machine keeps it.
+///
+/// Retention for what this writes is `prune_trace_files` directly above: the two
+/// halves of the `.trace` contract stay in one file so a change to the naming
+/// scheme cannot update one and miss the other.
+pub struct BatchAuthTraceWriter {
+    file: std::fs::File,
+}
+
+impl BatchAuthTraceWriter {
+    /// Create `<log_dir>/batch-auth-<ts>.trace` (append mode). `ts` should be a
+    /// sortable timestamp stem (matching the `tyutool-<ts>.log` convention).
+    pub fn open(log_dir: &Path, ts: &str) -> std::io::Result<Self> {
+        let path = log_dir.join(format!("batch-auth-{ts}.trace"));
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)?;
+        Ok(Self { file })
+    }
+
+    /// Append one line (trailing newline added). Errors are swallowed — trace
+    /// logging is best-effort and must never break a batch run.
+    pub fn writeln(&mut self, line: &str) {
+        use std::io::Write;
+        let _ = writeln!(self.file, "{line}");
+    }
+}
+
 fn tail_bytes(path: &Path, max_bytes: u64) -> std::io::Result<String> {
     use std::io::{Read, Seek, SeekFrom};
     let len = std::fs::metadata(path)?.len();
@@ -424,6 +458,18 @@ pub fn gather_and_write_logs_zip(
 mod tests {
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn batch_auth_trace_writer_creates_dot_trace_file_with_plaintext() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut w = BatchAuthTraceWriter::open(dir.path(), "20260804-120000").unwrap();
+        w.writeln("[verify] wrote uuid=real-uuid authkey=real-secret-key");
+        drop(w);
+        let path = dir.path().join("batch-auth-20260804-120000.trace");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("uuid=real-uuid"));
+        assert!(content.contains("authkey=real-secret-key"));
+    }
 
     #[test]
     fn banner_includes_session_and_metadata() {

--- a/crates/tyutool-core/src/lib.rs
+++ b/crates/tyutool-core/src/lib.rs
@@ -3,6 +3,8 @@
 mod authorize;
 #[cfg(feature = "excel")]
 pub mod batch_auth;
+#[cfg(feature = "excel")]
+pub mod batch_slot;
 pub mod diagnostics;
 mod error;
 pub mod flash_event;
@@ -24,6 +26,8 @@ pub use authorize::{
 };
 #[cfg(feature = "excel")]
 pub use batch_auth::{ExcelRow, ExcelRowAllocator, ExcelStats, RowStatus};
+#[cfg(feature = "excel")]
+pub use batch_slot::{run_batch_slot, AllocatorSession, BatchAuthStartConfig};
 #[cfg(feature = "zip")]
 pub use diagnostics::gather_and_write_logs_zip;
 pub use diagnostics::{

--- a/crates/tyutool-core/src/lib.rs
+++ b/crates/tyutool-core/src/lib.rs
@@ -29,7 +29,7 @@ pub use diagnostics::gather_and_write_logs_zip;
 pub use diagnostics::{
     build_report_info, collect_log_files, list_log_files_impl, prune_log_files, prune_trace_files,
     read_log_tail_impl, read_named_log_impl, redact_log_content, resolve_log_open_path,
-    LogFileInfo, LogRetention, REDACT_PREFIXES,
+    BatchAuthTraceWriter, LogFileInfo, LogRetention, REDACT_PREFIXES,
 };
 pub use error::FlashError;
 pub use flash_event::{

--- a/docs/specs/2026-08-26-core-consolidation-design.md
+++ b/docs/specs/2026-08-26-core-consolidation-design.md
@@ -417,7 +417,9 @@ pub enum FlashMode { Flash, Erase, Read, Authorize }
 | **P2-2** | `ts-rs` 生成 TS 类型（**仅 `FlashJob` 家族**） | 2–3 天 | 前端手工镜像部分退役；CI 校验无 drift | ✅ 已完成 |
 | ~~**P3**~~ | ~~updater 纯逻辑下沉~~ | — | — | ❌ **已取消**，见下 |
 | **P4a** | `batch_auth.rs` 下沉 + `excel` feature | 半天（实测） | Excel 行分配器对任意前端可用 | ✅ 已完成 |
-| **P4b** | 批量编排（`batch.rs`）下沉 | 待评估 | 代码层面对 CLI 可用 | 待评估 |
+| **P4b-1** | `BatchAuthTraceWriter` 下沉，与 `prune_trace_files` 团聚 | 半天 | `.trace` 契约两半合一 | ✅ 已完成 |
+| **P4b-2** | 单口 slot 编排下沉 → `core/batch_slot.rs` | 一天（实测） | 一个端口的完整批量流程对任意前端可用 | ✅ 已完成 |
+| **P4b-3** | 多口线程池 / `State` 生命周期 | — | — | ⏸ 阻塞于一个设计问题，见下 |
 | **P5** | 弹性归档创建两份合一 → `core/serial_debug.rs` | 低 | 消除一份曾造成手工移植负担的重复 | ✅ 已完成 |
 | — | 修复 P5 暴露的 backfill 目录 bug（GUI 命中 fallback 时索引写错位置） | 半天 | 行为修复，含回归测试 | ✅ 已完成 |
 | **P6** | 把已下沉的能力接成 CLI 子命令 + 同步 `docs/cli.md` | 半天 | **真正兑现「CLI 能用」** | ✅ 已完成 |
@@ -539,6 +541,28 @@ P4a 顺带暴露了一个 CI 洞：`tyutool-core` 无 default feature，
 batch_auth 的 18 个测试跑在 `cargo test -p tyutool_gui` 里；若不动 CI，
 搬完就没人跑了（`zip` 门后的 2 个测试此前已经处于这个状态）。
 已在 `ci.yml` 增加一步专跑 `--features zip,excel`。
+
+**P4b 同样不是一件事（2026-08-28 实测）。** 剩下的 927 行按耦合再切：
+
+| 部分 | 行数 | Tauri 耦合 | 结论 |
+|---|---:|---|---|
+| `run_batch_auth_slot` + 配置/守卫结构 | ~320 | **零** | P4b-2，已搬 |
+| `BatchAuthTraceWriter`（在 `logs.rs`） | ~40 | 零 | P4b-1，已搬 |
+| `batch_flash_start` / `batch_auth_start` / `batch_auth_read_ports` | ~470 | `AppHandle`、`State`、起线程、转发 emit | 见下 |
+| 4 个 cancel 命令 + 状态结构 | ~110 | `State` | 按判据本就该留在 src-tauri |
+
+那个 270 行的 slot 编排**从来就不需要「先把状态机和事件发射拆开」**——那次拆分早在
+`emit: &dyn Fn(serde_json::Value)` 这个签名里做完了，注释写明是为了可测试。
+所以它是搬迁，不是重写；初稿把 2094 行整体估成「重写」，两次都高估了。
+
+**P4b-3 阻塞于一个设计问题，不是工程量问题：**
+
+> 按 crate 边界规则，`AppHandle` / `State` 的东西本来就该留在 `src-tauri`。
+> 那么「CLI 也能跑批量」到底要求 core 提供什么——一个完整的多口线程池驱动，
+> 还是只提供单口 slot（P4b-2 已交付），由每个前端自己写并发外壳？
+
+选后者，则违规在 P4b-2 之后已实质关闭，P4b-3 不存在。选前者，才需要评估那 470 行。
+**先答这个问题再动手。**
 
 P0–P2 合计约一周半，将 `src-tauri` 从 5953 降至约 **5520**（−P0 60 −P1 370）。
 行数下降不是目的；目的是留下一条被验证过、可重复的下沉路径，并让 CLI 白拿

--- a/docs/specs/2026-08-27-refactor-v3-normalization-design.md
+++ b/docs/specs/2026-08-27-refactor-v3-normalization-design.md
@@ -2,7 +2,7 @@
 
 **日期：** 2026-08-27
 **状态：** 已确认并执行；Section 1 三项已全部落地（2026-08-28）
-**范围：** refactor/v3 的工程规范化全局，`docs/specs/2026-08-26-core-consolidation-design.md` 是其下的一个子项
+**范围：** refactor/v3 的工程规范化全局，`docs/specs/completed/2026-08-26-core-consolidation-design.md` 是其下的一个子项
 **实测基准：** 正文数字初测于 `b22d5f0`，2026-08-28 在 `cad3731` 重测。**结论一条未变**，四处数字随后续提交漂移，已就地更新：`tyutool-serve` 1691 → 1630 行（测试仍是 28 个）、`Cargo.lock` 716 → 719 个包、CLI 子命令 11 → 12 个（P6 新增 `logs`）、`crates/tyutool-core` 的 `unwrap()` 总数已高于附录 A1 记录的 276，但 A1 的结论（几乎全在 `mod tests` 内）未重新切分，该节按初测日期读。**修改本文时请重测并更新此行。**
 
 ---
@@ -158,7 +158,7 @@ pre-commit                                          ← 钩子也一直在
 维度 1、2、4、5 收敛到同一条主线上。
 
 **阶段划分、量级与验收标准均以
-`docs/specs/2026-08-26-core-consolidation-design.md` 的「实现顺序」一节为准**——
+`docs/specs/completed/2026-08-26-core-consolidation-design.md` 的「实现顺序」一节为准**——
 那里是主线的唯一真相源。本文**不复制那张阶段表**，否则两处会各自漂移——
 这正是本次规范化要消除的那类重复。
 
@@ -225,7 +225,7 @@ workspace 里、同一次提交中一起改。代价目前是理论的。
 ### 4.1 沿用核心下沉设计中的四条否决
 
 守护进程 + 瘦客户端、统一 46 个 Tauri 命令表、引入 `tauri-specta`、引入 TauRPC / rspc。
-理由见 `2026-08-26-core-consolidation-design.md` Section 4，不在此重复。
+理由见 `completed/2026-08-26-core-consolidation-design.md` Section 4，不在此重复。
 
 ### 4.2 本次新增的否决
 
@@ -335,7 +335,8 @@ Section 3 的两项（工具链固定、SemVer 边界）**先不做**，等触�
 **为它们写一份 checkbox 计划文档比直接做掉还贵**。直接执行，完成后把本文
 移入 `docs/specs/completed/`。
 
-需要 plan 的只有主线，那份归 `docs/plans/2026-08-26-core-consolidation.md`（待立）。
+主线也没有另立 plan：阶段表本身就是任务清单，且每个阶段都在一到两个提交内落地，
+为已经完成的工作补一份 checkbox 文档只会多一处需要同步的真相源。
 
 ---
 
@@ -343,7 +344,6 @@ Section 3 的两项（工具链固定、SemVer 边界）**先不做**，等触�
 
 | 文档 | 关系 |
 |---|---|
-| `docs/specs/2026-08-26-core-consolidation-design.md` | 主线的详细设计，**阶段划分以它为准** |
-| `docs/plans/2026-08-26-core-consolidation.md`（待立） | 主线的实现计划，**本仓库唯一一份规范化 plan** |
+| `docs/specs/completed/2026-08-26-core-consolidation-design.md` | 主线的详细设计，**阶段划分以它为准** |
 
 本文与主线 spec 的分工：**本文回答「做不做、先做哪个」，主线 spec 回答「怎么做」。**

--- a/docs/specs/completed/2026-08-26-core-consolidation-design.md
+++ b/docs/specs/completed/2026-08-26-core-consolidation-design.md
@@ -419,7 +419,7 @@ pub enum FlashMode { Flash, Erase, Read, Authorize }
 | **P4a** | `batch_auth.rs` 下沉 + `excel` feature | 半天（实测） | Excel 行分配器对任意前端可用 | ✅ 已完成 |
 | **P4b-1** | `BatchAuthTraceWriter` 下沉，与 `prune_trace_files` 团聚 | 半天 | `.trace` 契约两半合一 | ✅ 已完成 |
 | **P4b-2** | 单口 slot 编排下沉 → `core/batch_slot.rs` | 一天（实测） | 一个端口的完整批量流程对任意前端可用 | ✅ 已完成 |
-| **P4b-3** | 多口线程池 / `State` 生命周期 | — | — | ⏸ 阻塞于一个设计问题，见下 |
+| ~~**P4b-3**~~ | ~~多口线程池 / `State` 生命周期~~ | — | — | ❌ **已取消**，见下 |
 | **P5** | 弹性归档创建两份合一 → `core/serial_debug.rs` | 低 | 消除一份曾造成手工移植负担的重复 | ✅ 已完成 |
 | — | 修复 P5 暴露的 backfill 目录 bug（GUI 命中 fallback 时索引写错位置） | 半天 | 行为修复，含回归测试 | ✅ 已完成 |
 | **P6** | 把已下沉的能力接成 CLI 子命令 + 同步 `docs/cli.md` | 半天 | **真正兑现「CLI 能用」** | ✅ 已完成 |
@@ -564,6 +564,27 @@ batch_auth 的 18 个测试跑在 `cargo test -p tyutool_gui` 里；若不动 CI
 选后者，则违规在 P4b-2 之后已实质关闭，P4b-3 不存在。选前者，才需要评估那 470 行。
 **先答这个问题再动手。**
 
+**答案（2026-08-28）：选后者，P4b-3 取消。** 两条独立证据：
+
+1. **CLI 不需要批量烧录授权**——产品决定，不是工程妥协。
+2. **bridge 试过这条路并主动撤了。** `PROTOCOL.md:162` 记着全过程：bridge 曾接
+   `run_batch_auth_slot`，但那条路第一步必须读 MAC（MAC 是查表格行的键），
+   CoBuilder 没有表格，适配层把查表回调写成 `|_mac| None`，MAC 读取却仍是硬前置——
+   2026-07-31 真机上表现为「shell 625 ms 应答、固件探测成功，却报
+   `Failed to read MAC address`」。bridge 改走 `FlashMode::Authorize`，
+   `lib.rs:4695` 的断言写死了「MAC-free 的单设备流程是 Authorize 模式，不是 batch slot」。
+
+于是「批量编排困在 src-tauri，别的前端驱动不了」这条违规**不再有代价可言**：
+没有第二个前端想驱动它。按总纲的判据第 2 条，说不出代价就不做。
+`batch.rs` 剩下的 543 行按 crate 边界规则本就归 `src-tauri`。
+
+**重新打开的条件**：出现一个确实需要多口批量的非 Tauri 前端。届时起点不是那 543 行，
+而是 `core::batch_slot::run_batch_slot` —— 单口完整流程已经在 core 里，新前端只需自己的并发外壳。
+
+P4a / P4b-1 / P4b-2 三次搬迁**不因此白做**，但理由要说准：它们的依据是 AGENTS.md
+的机械判据（不依赖平台特定类型 ⇒ 归 core），以及 P4b-1 合上了 `.trace` 契约被劈成
+两半的问题——不是「为了让 CLI 能跑批量」。
+
 P0–P2 合计约一周半，将 `src-tauri` 从 5953 降至约 **5520**（−P0 60 −P1 370）。
 行数下降不是目的；目的是留下一条被验证过、可重复的下沉路径，并让 CLI 白拿
 日志导出与脱敏能力。
@@ -591,7 +612,6 @@ P0–P2 合计约一周半，将 `src-tauri` 从 5953 降至约 **5520**（−P0
 | 文档 | 关系 |
 |---|---|
 | `docs/specs/2026-08-27-refactor-v3-normalization-design.md` | **上层总纲**。本文是它七个维度中的一条主线；总纲回答「做不做、先做哪个」，本文回答「怎么做」 |
-| `docs/plans/2026-08-26-core-consolidation.md`（待立） | 本文的实现计划，按 P0–P5 拆成 checkbox 任务，遵循仓库既有 plan 格式。**规范化工作共用这一份 plan**，总纲不另立 |
 
 > 本文的「实现顺序」一节是**阶段划分的唯一真相源**。总纲故意不复制那张表，
 > 修改阶段时只需改本文一处。

--- a/src-tauri/src/batch.rs
+++ b/src-tauri/src/batch.rs
@@ -14,7 +14,6 @@ use std::time::Duration;
 
 use tauri::{AppHandle, Emitter, Manager, State};
 
-use crate::logs;
 use tyutool_core::batch_auth;
 
 pub(crate) struct BatchSlot {
@@ -275,7 +274,7 @@ fn run_batch_auth_slot(
     cancel: Arc<AtomicBool>,
     allocator: Option<Arc<batch_auth::ExcelRowAllocator>>,
     session: Arc<StdMutex<AllocatorSession>>,
-    trace: Option<Arc<StdMutex<logs::BatchAuthTraceWriter>>>,
+    trace: Option<Arc<StdMutex<tyutool_core::BatchAuthTraceWriter>>>,
     conflict_policy: tyutool_core::ConflictPolicy,
     auth_storage: tyutool_core::AuthStorage,
     emit: &dyn Fn(serde_json::Value),
@@ -637,7 +636,7 @@ pub(crate) fn batch_auth_start(
     let trace_writer = match app.path().app_log_dir() {
         Ok(log_dir) => {
             let ts = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
-            match logs::BatchAuthTraceWriter::open(&log_dir, &ts) {
+            match tyutool_core::BatchAuthTraceWriter::open(&log_dir, &ts) {
                 Ok(w) => Some(std::sync::Arc::new(std::sync::Mutex::new(w))),
                 Err(e) => {
                     log::warn!("[batch-auth] trace writer unavailable: {e}");

--- a/src-tauri/src/batch.rs
+++ b/src-tauri/src/batch.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use tyutool_core::batch_auth;
+use tyutool_core::batch_slot::{run_batch_slot, AllocatorSession, BatchAuthStartConfig};
 
 pub(crate) struct BatchSlot {
     pub cancel: Arc<AtomicBool>,
@@ -31,35 +32,6 @@ pub(crate) struct BatchAuthState {
     pub session: Arc<StdMutex<AllocatorSession>>,
 }
 
-/// Excel allocator + count of slot threads using it, guarded by ONE mutex so
-/// acquire (batch_auth_start) and release (last SlotSessionGuard drop) can
-/// never interleave. Invariant: `alloc.is_some() ⇒ active > 0` — the file
-/// lock is held exactly while slots run, so the sheet can be edited between
-/// batches and every new batch re-reads it from disk.
-pub(crate) struct AllocatorSession {
-    pub alloc: Option<std::sync::Arc<batch_auth::ExcelRowAllocator>>,
-    pub active: usize,
-}
-
-/// Decrements the session's active count when a slot thread exits (any path,
-/// including early returns and panics); the last one out releases the file
-/// lock and drops the allocator.
-struct SlotSessionGuard(Arc<StdMutex<AllocatorSession>>);
-
-impl Drop for SlotSessionGuard {
-    fn drop(&mut self) {
-        if let Ok(mut session) = self.0.lock() {
-            session.active = session.active.saturating_sub(1);
-            if session.active == 0 {
-                if let Some(alloc) = session.alloc.take() {
-                    alloc.release_lock();
-                    log::info!("[batch-auth] last slot finished; excel session closed");
-                }
-            }
-        }
-    }
-}
-
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct BatchFlashStartConfig {
@@ -68,27 +40,6 @@ pub(crate) struct BatchFlashStartConfig {
     firmware_path: String,
     flash_start_hex: Option<String>,
     flash_end_hex: Option<String>,
-}
-
-#[derive(Debug, Clone, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct BatchAuthStartConfig {
-    chip_id: String,
-    baud_rate: u32,
-    auth_baud_rate: u32,
-    firmware_path: Option<String>,
-    flash_start_hex: Option<String>,
-    flash_end_hex: Option<String>,
-    excel_path: String,
-    conflict_policy: String,
-    auth_storage: Option<String>,
-    /// false ⇒ flash-only batch: skip the Excel session and the auth step.
-    #[serde(default = "default_authorize_enabled")]
-    authorize_enabled: bool,
-}
-
-fn default_authorize_enabled() -> bool {
-    true
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -260,283 +211,6 @@ pub(crate) fn validate_excel_cmd(path: String) -> Result<batch_auth::ExcelStats,
     Ok(stats)
 }
 
-/// One batch-auth slot: optional firmware flash, then the authorize pipeline,
-/// for a single port. Runs on its own thread.
-///
-/// `emit` receives every `batch-auth-progress` payload. Taking a callback rather
-/// than an `AppHandle` is what makes this callable from a test: the production
-/// caller forwards to `app.emit`, while a test can record the payloads and
-/// assert the slot's step sequence.
-#[allow(clippy::too_many_arguments)]
-fn run_batch_auth_slot(
-    port: String,
-    config: BatchAuthStartConfig,
-    cancel: Arc<AtomicBool>,
-    allocator: Option<Arc<batch_auth::ExcelRowAllocator>>,
-    session: Arc<StdMutex<AllocatorSession>>,
-    trace: Option<Arc<StdMutex<tyutool_core::BatchAuthTraceWriter>>>,
-    conflict_policy: tyutool_core::ConflictPolicy,
-    auth_storage: tyutool_core::AuthStorage,
-    emit: &dyn Fn(serde_json::Value),
-) {
-    // Must be the first statement: every exit path (early returns,
-    // panics) has to decrement the session count. Flash-only batches
-    // never incremented it, so they get no guard.
-    let _session_guard = allocator.is_some().then(|| SlotSessionGuard(session));
-    // Last Excel write failure for this slot; attached to the final
-    // progress emit so the operator sees the sheet was NOT updated.
-    let excel_err: Arc<StdMutex<Option<String>>> = Arc::new(StdMutex::new(None));
-    log::info!(
-        "[batch-auth] slot begin  port={port} chip={}",
-        config.chip_id
-    );
-    if let Some(ref fw_path) = config.firmware_path {
-        if !fw_path.is_empty() {
-            let job = tyutool_core::FlashJob {
-                firmware_path: Some(fw_path.clone()),
-                flash_start_hex: config.flash_start_hex.clone(),
-                flash_end_hex: config.flash_end_hex.clone(),
-                ..tyutool_core::FlashJob::new(
-                    tyutool_core::FlashMode::Flash,
-                    config.chip_id.clone(),
-                    port.clone(),
-                    config.baud_rate,
-                )
-            };
-            log::info!(
-                "[batch-auth] flash start  port={port} chip={} firmware={fw_path}",
-                config.chip_id
-            );
-            let port2 = port.clone();
-            let flash_result = tyutool_core::run_job(&job, &cancel, |p| {
-                emit(serde_json::json!({
-                    "port": port2,
-                    "step": "flashing",
-                    "event": p
-                }));
-            });
-            if !config.authorize_enabled {
-                // Flash-only: a user cancel is not a failure — mirror
-                // the auth pipeline's "cancelled" step so the slot
-                // returns to idle without polluting the cumulative
-                // stats. On Ok, a late cancel changes nothing: the
-                // run_job Done event forwarded above is already the
-                // terminal signal, so emitting a second outcome here
-                // would double-count the slot.
-                match flash_result {
-                    Err(tyutool_core::FlashError::Cancelled) => {
-                        log::info!("[batch-auth] flash cancelled  port={port}");
-                        emit(serde_json::json!({
-                            "port": port,
-                            "step": "cancelled"
-                        }));
-                        return;
-                    }
-                    Err(e) => {
-                        log::warn!("[batch-auth] flash failed  port={port} error={e}");
-                        emit(serde_json::json!({
-                            "port": port,
-                            "step": "failed",
-                            "error": e.to_string()
-                        }));
-                        return;
-                    }
-                    Ok(()) => {}
-                }
-            } else if flash_result.is_err() || cancel.load(Ordering::Relaxed) {
-                let error = flash_result
-                    .err()
-                    .map(|e| e.to_string())
-                    .unwrap_or_else(|| "cancelled".into());
-                log::warn!("[batch-auth] flash failed  port={port} error={error}");
-                emit(serde_json::json!({
-                    "port": port,
-                    "step": "failed",
-                    "error": error
-                }));
-                return;
-            }
-            log::info!("[batch-auth] flash done  port={port}");
-            if config.authorize_enabled {
-                // Wait for the device to boot naturally after flash before the auth
-                // slot issues a hardware reset. Non-fatal, and passive: it exits as
-                // soon as the device answers, so only a silent device pays the full
-                // WAIT_AFTER_FLASH_MAX window. Each port has its own thread, so a
-                // longer worst case does not accumulate across the batch.
-                tyutool_core::wait_after_firmware_flash(
-                    &port,
-                    config.auth_baud_rate,
-                    &config.chip_id,
-                    &cancel,
-                );
-                if cancel.load(Ordering::Relaxed) {
-                    return;
-                }
-            }
-        }
-    }
-
-    // Flash-only batch: run_job's Done event (forwarded above under
-    // step "flashing") is the terminal signal for the frontend —
-    // nothing to authorize, no Excel to update.
-    let Some(allocator) = allocator else {
-        log::info!("[batch-auth] slot done (flash-only)  port={port}");
-        return;
-    };
-
-    // find_by_mac: look up Excel row by device MAC address
-    let alloc_find = allocator.clone();
-    let find_by_mac =
-        move |mac: &str| -> Option<(usize, String, String)> { alloc_find.find_by_mac(mac) };
-
-    // allocate_row: claim a new unused row
-    let alloc_alloc = allocator.clone();
-    let allocate_row = move || -> Option<(usize, String, String)> {
-        match alloc_alloc.allocate_row() {
-            Ok(row) => Some((row.row_idx, row.uuid, row.authkey)),
-            Err(e) => {
-                log::warn!("[batch-auth] allocate_row error: {e}");
-                None
-            }
-        }
-    };
-
-    // update_row: translate BatchAuthRowUpdate → RowStatus + step_name, then write to Excel
-    let alloc_update = allocator.clone();
-    let port_for_update = port.clone();
-    let excel_err_update = excel_err.clone();
-    let update_row = move |row_idx: usize, mac: &str, update: tyutool_core::BatchAuthRowUpdate| {
-        use tyutool_core::batch_auth::RowStatus;
-        use tyutool_core::BatchAuthRowUpdate as U;
-        let (status, step_name, error): (RowStatus, Option<&str>, Option<String>) = match update {
-            U::MacRead => (RowStatus::MacRead, Some("mac_read"), None),
-            U::AuthWritten => (RowStatus::AuthWritten, Some("auth_written"), None),
-            U::AuthVerified => (RowStatus::AuthVerified, Some("auth_verified"), None),
-            // Done: keep last step in Excel (STATUS=DONE is sufficient)
-            U::Done => (RowStatus::Done, None, None),
-            U::StepFailed { step, error } => {
-                let status = if step == "auth_write" {
-                    RowStatus::MacRead
-                } else {
-                    RowStatus::AuthWritten
-                };
-                (status, Some(step), Some(error))
-            }
-        };
-        if let Err(e) =
-            alloc_update.update_row_state(row_idx, mac, status, step_name, error.as_deref())
-        {
-            log::error!(
-                "[batch-auth] excel-update-failed  port={port_for_update} row={row_idx} err={e}"
-            );
-            if let Ok(mut slot) = excel_err_update.lock() {
-                *slot = Some(e);
-            }
-        }
-    };
-
-    let slot_config = tyutool_core::BatchAuthSlotConfig {
-        auth_baud_rate: config.auth_baud_rate,
-        conflict_policy,
-        auth_storage,
-    };
-    let result = tyutool_core::run_batch_auth_slot(
-        &port,
-        &config.chip_id,
-        &slot_config,
-        find_by_mac,
-        allocate_row,
-        update_row,
-        &cancel,
-        |step| {
-            let step_str = match step {
-                tyutool_core::BatchAuthStep::ReadingMac => "reading_mac",
-                tyutool_core::BatchAuthStep::ReadingAuth => "reading_auth",
-                tyutool_core::BatchAuthStep::WritingAuth => "writing_auth",
-                tyutool_core::BatchAuthStep::Verifying => "verifying",
-            };
-            emit(serde_json::json!({ "port": port, "step": step_str }));
-        },
-        |line: &str| {
-            if let Some(tw) = &trace {
-                if let Ok(mut w) = tw.lock() {
-                    w.writeln(line);
-                }
-            }
-        },
-    );
-
-    // Attach the captured Excel write failure (if any) to a final
-    // emit — the frontend renders it as a per-slot warning.
-    let emit_final = |mut payload: serde_json::Value| {
-        if let Some(e) = excel_err.lock().ok().and_then(|g| g.clone()) {
-            payload["excelError"] = serde_json::Value::String(e);
-        }
-        emit(payload);
-    };
-
-    match result {
-        // Done — state already written to Excel by update_row(Done)
-        Ok(tyutool_core::BatchAuthSlotResult::Done { mac }) => {
-            log::info!("[batch-auth] slot done  port={port} mac={mac}");
-            emit_final(serde_json::json!({ "port": port, "step": "done", "mac": mac }));
-        }
-        // AlreadyDone — state already written to Excel by update_row(Done) in authorize.rs
-        Ok(tyutool_core::BatchAuthSlotResult::AlreadyDone { mac }) => {
-            log::info!("[batch-auth] slot already-done  port={port} mac={mac}");
-            emit_final(serde_json::json!({ "port": port, "step": "done", "mac": mac }));
-        }
-        // InsufficientCodes — no row was allocated, nothing to write
-        Ok(tyutool_core::BatchAuthSlotResult::InsufficientCodes { mac }) => {
-            log::info!("[batch-auth] slot no-code  port={port} mac={mac}");
-            emit(serde_json::json!({ "port": port, "step": "no_code", "mac": mac }));
-        }
-        // Skipped — device already carries auth we didn't (knowingly) write.
-        // If that UUID is still an unclaimed row in our sheet, claim it for this
-        // MAC so the same code can't later be handed to a different device.
-        Ok(tyutool_core::BatchAuthSlotResult::Skipped { mac, existing_uuid }) => {
-            log::info!(
-                "[batch-auth] slot skipped  port={port} mac={mac} existing_uuid={existing_uuid}"
-            );
-            if let Err(e) = allocator.confirm_existing_uuid(&existing_uuid, &mac) {
-                log::error!("[batch-auth] excel-confirm-skipped-failed  port={port} existing_uuid={existing_uuid} err={e}");
-                if let Ok(mut slot) = excel_err.lock() {
-                    *slot = Some(e);
-                }
-            }
-            emit_final(
-                serde_json::json!({ "port": port, "step": "skipped", "mac": mac, "existingUuid": existing_uuid }),
-            );
-        }
-        // Cancelled — pre-write cancel; if MacRead was written, row stays in MacRead state (recoverable)
-        Ok(tyutool_core::BatchAuthSlotResult::Cancelled) => {
-            log::info!("[batch-auth] slot cancelled  port={port}");
-            emit(serde_json::json!({ "port": port, "step": "cancelled" }));
-        }
-        // CancelledAfterWrite — state already written to Excel by update_row(AuthWritten)
-        Ok(tyutool_core::BatchAuthSlotResult::CancelledAfterWrite { mac, uuid }) => {
-            log::warn!(
-                "[batch-auth] slot cancelled AFTER auth_write  port={port} mac={mac} uuid={uuid}"
-            );
-            emit_final(
-                serde_json::json!({ "port": port, "step": "cancelled_after_write", "mac": mac, "uuid": uuid }),
-            );
-        }
-        // DefaultMac — T5/T5AI factory default MAC; no row allocation
-        Ok(tyutool_core::BatchAuthSlotResult::DefaultMac { mac }) => {
-            log::warn!("[batch-auth] slot default-mac  port={port} mac={mac}");
-            emit(serde_json::json!({ "port": port, "step": "default_mac", "mac": mac }));
-        }
-        // Err — state already written by update_row(StepFailed) inside authorize.rs
-        Err(e) => {
-            log::warn!("[batch-auth] slot failed  port={port} error={e}");
-            emit_final(
-                serde_json::json!({ "port": port, "step": "failed", "error": e.to_string() }),
-            );
-        }
-    }
-}
-
 #[tauri::command]
 pub(crate) fn batch_auth_start(
     app: AppHandle,
@@ -668,7 +342,7 @@ pub(crate) fn batch_auth_start(
         let trace_clone = trace_writer.clone();
 
         let handle = std::thread::spawn(move || {
-            run_batch_auth_slot(
+            run_batch_slot(
                 port_clone,
                 config_clone,
                 cancel_clone,
@@ -830,68 +504,6 @@ pub(crate) fn batch_auth_read_ports(
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The point of `run_batch_auth_slot` taking an `emit` callback instead of an
-    /// `AppHandle`: the slot body can be driven from a test. This covers the
-    /// flash-only-with-nothing-to-do path, which touches no serial port.
-    #[test]
-    fn flash_only_slot_without_firmware_or_allocator_emits_nothing() {
-        let seen: Arc<StdMutex<Vec<serde_json::Value>>> = Arc::new(StdMutex::new(Vec::new()));
-        let sink = seen.clone();
-
-        run_batch_auth_slot(
-            "COM_TEST".to_string(),
-            BatchAuthStartConfig {
-                chip_id: "T5AI".into(),
-                baud_rate: 921_600,
-                auth_baud_rate: 115_200,
-                firmware_path: None,
-                flash_start_hex: None,
-                flash_end_hex: None,
-                excel_path: String::new(),
-                conflict_policy: "skip".into(),
-                auth_storage: None,
-                authorize_enabled: false,
-            },
-            Arc::new(AtomicBool::new(false)),
-            None,
-            Arc::new(StdMutex::new(AllocatorSession {
-                alloc: None,
-                active: 0,
-            })),
-            None,
-            tyutool_core::ConflictPolicy::Skip,
-            tyutool_core::AuthStorage::Kv,
-            &move |payload| sink.lock().unwrap().push(payload),
-        );
-
-        assert!(
-            seen.lock().unwrap().is_empty(),
-            "a flash-only slot with no firmware has nothing to report"
-        );
-    }
-
-    #[test]
-    fn batch_auth_start_config_defaults_authorize_enabled_to_true() {
-        let cfg: BatchAuthStartConfig = serde_json::from_str(
-            r#"{"chipId":"esp32","baudRate":921600,"authBaudRate":115200,
-                "excelPath":"codes.xlsx","conflictPolicy":"skip"}"#,
-        )
-        .unwrap();
-        assert!(cfg.authorize_enabled);
-
-        let cfg: BatchAuthStartConfig = serde_json::from_str(
-            r#"{"chipId":"esp32","baudRate":921600,"authBaudRate":115200,
-                "excelPath":"","conflictPolicy":"skip","authorizeEnabled":false}"#,
-        )
-        .unwrap();
-        assert!(!cfg.authorize_enabled);
-    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -661,7 +661,7 @@ pub fn run() {
         })
         .manage(batch::BatchAuthState {
             slots: StdMutex::new(HashMap::new()),
-            session: Arc::new(StdMutex::new(batch::AllocatorSession {
+            session: Arc::new(StdMutex::new(tyutool_core::batch_slot::AllocatorSession {
                 alloc: None,
                 active: 0,
             })),

--- a/src-tauri/src/logs.rs
+++ b/src-tauri/src/logs.rs
@@ -198,36 +198,6 @@ pub(crate) const LOG_RETENTION: tyutool_core::LogRetention = tyutool_core::LogRe
     max_files: 100,
     max_bytes_total: 100 * 1024 * 1024, // 100 MB
 };
-/// Plaintext writer for batch-auth device-interaction data (auth-read raw lines,
-/// auth-write responses, verify comparison values). Lives in its own
-/// `batch-auth-<ts>.trace` file — deliberately NOT a `.log` file and NOT
-/// `tyutool-`-prefixed, so `tyutool_core::collect_log_files` / `prune_log_files` /
-/// `list_log_files_impl` / `pick_active_log` all ignore it. The export-for-report
-/// zip therefore can never contain it; only the operator's local machine keeps it.
-pub(crate) struct BatchAuthTraceWriter {
-    file: std::fs::File,
-}
-
-impl BatchAuthTraceWriter {
-    /// Create `<log_dir>/batch-auth-<ts>.trace` (append mode). `ts` should be a
-    /// sortable timestamp stem (matching the `tyutool-<ts>.log` convention).
-    pub(crate) fn open(log_dir: &std::path::Path, ts: &str) -> std::io::Result<Self> {
-        let path = log_dir.join(format!("batch-auth-{ts}.trace"));
-        let file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)?;
-        Ok(Self { file })
-    }
-
-    /// Append one line (trailing newline added). Errors are swallowed — trace
-    /// logging is best-effort and must never break a batch run.
-    pub(crate) fn writeln(&mut self, line: &str) {
-        use std::io::Write;
-        let _ = writeln!(self.file, "{line}");
-    }
-}
-
 #[derive(Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LogFileOpener {
@@ -692,18 +662,6 @@ pub(crate) fn export_logs_zip(app: AppHandle, dest_path: String) -> Result<(), S
 #[cfg(test)]
 mod log_tools_tests {
     use super::*;
-
-    #[test]
-    fn batch_auth_trace_writer_creates_dot_trace_file_with_plaintext() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut w = BatchAuthTraceWriter::open(dir.path(), "20260804-120000").unwrap();
-        w.writeln("[verify] wrote uuid=real-uuid authkey=real-secret-key");
-        drop(w);
-        let path = dir.path().join("batch-auth-20260804-120000.trace");
-        let content = std::fs::read_to_string(&path).unwrap();
-        assert!(content.contains("uuid=real-uuid"));
-        assert!(content.contains("authkey=real-secret-key"));
-    }
 
     #[test]
     fn supported_log_editor_catalog_starts_with_system_default() {


### PR DESCRIPTION
把核心下沉主线的最后一段做完，并**取消**其中一个阶段——取消的依据比完成的依据更值得看。

承接 #143。阶段表在 `docs/specs/completed/2026-08-26-core-consolidation-design.md`（本 PR 将其归档）。

---

## 代码改动

**P4b-1：`BatchAuthTraceWriter` 与它的保留策略团聚**

`.trace` 凭据隔离契约此前被劈成两半：core 拥有保留策略（`prune_trace_files`，P1a 搬过去的），
src-tauri 却仍拥有创建这些文件的写入方。两半编码的是同一套命名方案
（`batch-auth-<ts>.trace`，刻意不是 `.log`、不带 `tyutool-` 前缀，因此任何导出或归档 zip
都收不到它），**改一半漏另一半是可能的**。写入方是 40 行 `std::fs::File`，无 Tauri 依赖。

**P4b-2：单口 slot 编排下沉（270 行）**

spec 原本说这一步是重写：「必须先把不含 IO 的编排状态机与事件发射拆开」。
**那次拆分早就做完了**——函数签名从写出来那天起就是
`emit: &dyn Fn(serde_json::Value)` 而不是 `AppHandle`，注释写明是为了可测试。
所以它对 Tauri 零引用，唯一拴在本 crate 的东西是 `logs::BatchAuthTraceWriter`，而 P4b-1 刚把它搬走。

于是这是搬迁不是重写。改名 `run_batch_slot`，以区别于 core 里已有的
`authorize::run_batch_auth_slot`（下一层的单次设备事务）。两个测试跟随。
`BatchAuthStartConfig` 的字段改为 `pub`——它由前端反序列化、由命令层读取，而这两者现在跨了 crate 边界。

`src-tauri/src/batch.rs`：**927 → 543 行**。

---

## 取消 P4b-3，以及为什么这比做掉它更正确

剩下的 543 行是 Tauri 命令层（`AppHandle`、`State`、每端口线程池、emit 转发），
按 crate 边界表本就归 `src-tauri`。真正的问题不是「搬不搬」，而是
**第二个前端到底需要 core 提供什么**。

答案是：不需要。两条独立证据——

1. **CLI 不需要批量烧录授权。** 产品决定。
2. **bridge 试过这条路并主动撤了。** `PROTOCOL.md:162` 记着全过程：
   `run_batch_auth_slot` 第一步必须读 MAC，因为 MAC 是它去表格里查凭证行的键；
   CoBuilder 没有表格，适配层把查表回调写成 `|_mac| None`，但 MAC 读取本身仍是硬前置——
   2026-07-31 真机上表现为「shell 625 ms 应答、固件探测成功，却报
   `Failed to read MAC address`」。bridge 改走 `FlashMode::Authorize`，
   `lib.rs:4695` 的断言写死了「MAC-free 的单设备流程是 Authorize 模式，不是 batch slot」。

所以「批量编排困在 src-tauri，别的前端驱动不了」这条违规**不再有代价可言**：
没有第二个前端想驱动它。按规范化总纲的判据第 2 条（说不出代价就不做），取消。

spec 里记了重新打开的条件：出现确实需要多口批量的非 Tauri 前端。
届时起点不是那 543 行，而是 `core::batch_slot::run_batch_slot`——单口完整流程已经在 core 里。

⚠ **一处必须说准的话**：P4a / P4b-1 / P4b-2 三次搬迁不因此白做，但理由是
**AGENTS.md 的机械判据**（不依赖平台特定类型 ⇒ 归 core）和 P4b-1 合上的 `.trace` 契约裂缝，
**不是**「为了让 CLI 能跑批量」。spec 里写明了这个区别。

---

## 文档

- **AGENTS.md 的「已知违规」清单整段删除**——它现在是空的，而该文件自己写着
  「一个已修好却还留在清单里的条目比没有清单更糟」。底下两段 `> **Done:**` 纪念碑一并删除，历史归 spec。
- **核心下沉 spec 归档到 `docs/specs/completed/`**，按 docs 布局规则；所有引用同步更新。
- **删除悬空引用**：两份 spec 都引用了一个从未创建的
  `docs/plans/2026-08-26-core-consolidation.md`（待立）。补一份已完工的 checkbox 计划只会
  多一处需要同步的真相源，因此改为说明为何不需要 plan。
- 规范化总纲**仍留在 `docs/specs/` 下**：Section 3「观察」两条按判据仍不该做，但也没有消失。

---

## 验证

```
cargo fmt --all --check
cargo clippy -p tyutool-core --all-targets --features zip,excel -- -D warnings
cargo clippy -p tyutool-cli -p tyutool-serve --all-targets -- -D warnings
cargo clippy -p tyutool_gui --all-targets -- -D warnings
pnpm run test:coverage && pnpm run build
```

测试数：core 329（+2，随 slot 迁入）/ cli 59 / serve 28 / gui 32（−2，随 slot 迁出）；
前端 919 passed / 62 files。搬迁前后测试总数守恒。

---

## 合并方式

本分支上的三个任务各是一个 `--no-ff` 合并，为的是每个任务能被整体回退。
#143 是用 rebase 合的，那些合并点被平掉了。**这次请选 Create a merge commit。**
