### PR TITLE
docs: remove dead comments and land the last normalization wrap-up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,7 +52,8 @@ updates:
   # Covers the pinned actions in ci.yml / bridge.yml / release.yml and friends.
   # Note `dtolnay/rust-toolchain@stable` is a floating tag, not a version, so
   # Dependabot cannot track it — the Rust toolchain stays unpinned by design.
-  # See "Rust 工具链不固定" in docs/specs/2026-08-27-refactor-v3-normalization-design.md
+  # See "Rust 工具链不固定" in
+  # docs/specs/completed/2026-08-27-refactor-v3-normalization-design.md
   # for why that is a held decision rather than an oversight.
   - package-ecosystem: github-actions
     directory: "/"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -421,6 +421,19 @@ refactor/v3    ← main development branch (default); feature PRs merge here
   crate existing is not by itself a reason. A rule that applies repo-wide belongs in the root
   `AGENTS.md`, once; do not restate it in a scoped file.
 
+### Dispatching read-only sub-agents
+
+"Don't modify any files" is not a sufficient brief. An agent that reads it literally can still
+`git checkout <rev> -- .` to look at an older tree and consider that a read — that is exactly
+what happened once here, reverting and staging 29 tracked files on top of the caller's
+uncommitted work.
+
+- **List the commands the agent may run**: `git show` / `git log` / `git diff` / `grep` / `wc` /
+  `find` / `cat`.
+- **Explicitly forbid** `git checkout`, `git restore`, `git reset`, `git stash` and `git clean`
+  — *including* a temporary switch that gets switched back. The working tree is shared with the
+  caller, and one temporary switch overwrites whatever the caller has not committed.
+
 ### Documentation layout
 
 | Path | Contents |

--- a/crates/tyutool-cli/src/main.rs
+++ b/crates/tyutool-cli/src/main.rs
@@ -102,7 +102,7 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Dump raw USB/serial metadata for cross-OS survey (JSON). See `tmp/usb-port-survey.md`.
+    /// Dump raw USB/serial metadata for cross-OS survey (JSON).
     UsbPortSurvey,
     /// Hardware-reset the device via DTR/RTS (UART)
     Reset {

--- a/crates/tyutool-core/src/batch_auth.rs
+++ b/crates/tyutool-core/src/batch_auth.rs
@@ -1,4 +1,3 @@
-// src-tauri/src/batch_auth.rs
 //! Excel-based authorization row allocator for batch auth.
 
 use std::collections::HashSet;

--- a/crates/tyutool-core/src/tuya_dev_usb.rs
+++ b/crates/tyutool-core/src/tuya_dev_usb.rs
@@ -1,6 +1,7 @@
 //! Known Tuya / dev-board USB dual-serial role hints: `(VID, PID, interface)` → role string for UI.
 //!
-//! Populate [`USB_PORT_ROLE_RULES`] from hardware docs and `tmp/usb-port-survey.md` measurements.
+//! Populate [`USB_PORT_ROLE_RULES`] from hardware docs and real-hardware measurements
+//! (the CLI `usb-port-survey` subcommand dumps them).
 //! Wrong rules mislabel ports — prefer empty table until verified.
 
 /// Stable machine keys consumed by the Vue i18n tree `flash.portRoles.*`.

--- a/crates/tyutool-core/src/usb_port_survey.rs
+++ b/crates/tyutool-core/src/usb_port_survey.rs
@@ -1,4 +1,5 @@
-//! Raw serial/USB enumeration for cross-OS surveys (see `tmp/usb-port-survey.md`).
+//! Raw serial/USB enumeration for cross-OS surveys; exposed as the CLI `usb-port-survey`
+//! subcommand.
 //! Uses the same `usbportinfo-interface` data as the rest of the crate; independent of
 //! `list_serial_ports` filtering except for the `wouldListInTyutool` hint.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -554,7 +554,7 @@ tyutool-cli serve listening on ws://127.0.0.1:9527
 Press Ctrl+C to stop.
 ```
 
-It binds `127.0.0.1` only, requires a loopback `Host` header (blocking DNS-rebinding tricks), and rejects a handshake whose `Origin` is a remote page — a random web page cannot reach in and flash your hardware. It is still a **development tool**: there is no authentication, and any local process can connect. Do not run it as a background service on a shared machine, and stop it with Ctrl+C when you are done. If the port is taken, the command fails with `failed to bind 127.0.0.1:<port>` — pick another with `--port` and point the client at the same one.
+It binds `127.0.0.1` only, requires a loopback `Host` header (blocking DNS-rebinding tricks), and rejects a handshake whose `Origin` is a remote page — a random web page cannot reach in and flash your hardware. It is still a **development tool**: there is no authentication, and any local process can connect. Do not run it as a background service on a shared machine, and stop it with Ctrl+C when you are done. If the port is taken, the command fails with `failed to bind 127.0.0.1:<port>`. Free 9527 rather than moving the server: the browser client has `9527` hard-coded (`src/transport/ws-transport.ts`) with no setting for it, so pointing `serve` elsewhere leaves the page connecting to nothing. (`pnpm run dev:web` does honour `TYUTOOL_SERVE_PORT`, but that moves only the server half.) `--port` is for a host that tells its own client where to connect — tuyaopen-ide does that by injecting `__TUYAOPEN_IDE_CONFIG.wsUrl`.
 
 For the shipped, hardened variant of this idea — token grants, an Origin allowlist, an audit log — see the separate `tyutool-bridge` binary.
 

--- a/docs/specs/completed/2026-08-26-core-consolidation-design.md
+++ b/docs/specs/completed/2026-08-26-core-consolidation-design.md
@@ -509,7 +509,7 @@ fn verify_sha256(data: &[u8], expected_hex: &str) -> bool   // 算 + 比
    或再造一个 feature，机械成本超过省下的 5 行。
 3. SHA-256 是固定标准，两份实现**不可能产生行为漂移**，只有写法差异。
 
-按 `docs/specs/2026-08-27-refactor-v3-normalization-design.md` 定的筛选判据
+按 `docs/specs/completed/2026-08-27-refactor-v3-normalization-design.md` 定的筛选判据
 （有实测证据 + 不做有具体代价），**这一项两条都不满足**。
 
 #### 重新打开的条件
@@ -611,7 +611,7 @@ P0–P2 合计约一周半，将 `src-tauri` 从 5953 降至约 **5520**（−P0
 
 | 文档 | 关系 |
 |---|---|
-| `docs/specs/2026-08-27-refactor-v3-normalization-design.md` | **上层总纲**。本文是它七个维度中的一条主线；总纲回答「做不做、先做哪个」，本文回答「怎么做」 |
+| `docs/specs/completed/2026-08-27-refactor-v3-normalization-design.md` | **上层总纲**。本文是它七个维度中的一条主线；总纲回答「做不做、先做哪个」，本文回答「怎么做」 |
 
 > 本文的「实现顺序」一节是**阶段划分的唯一真相源**。总纲故意不复制那张表，
 > 修改阶段时只需改本文一处。

--- a/docs/specs/completed/2026-08-27-refactor-v3-normalization-design.md
+++ b/docs/specs/completed/2026-08-27-refactor-v3-normalization-design.md
@@ -1,7 +1,9 @@
 # refactor/v3 规范化总纲：先做什么，以及为什么不做其余的
 
 **日期：** 2026-08-27
-**状态：** 已确认并执行；Section 1 三项已全部落地（2026-08-28）
+**状态：** 已完成并归档（2026-08-31）。Section 1 三项全部落地，§5.1 的规则已写入根 `AGENTS.md`
+（「Dispatching read-only sub-agents」一节）。**唯一遗留需人工操作**：GitHub Settings → Code security
+里开启 Dependabot alerts / security updates 并 triage 存量告警——仓库文件无法代劳，见 §1.2。
 **范围：** refactor/v3 的工程规范化全局，`docs/specs/completed/2026-08-26-core-consolidation-design.md` 是其下的一个子项
 **实测基准：** 正文数字初测于 `b22d5f0`，2026-08-28 在 `cad3731` 重测。**结论一条未变**，四处数字随后续提交漂移，已就地更新：`tyutool-serve` 1691 → 1630 行（测试仍是 28 个）、`Cargo.lock` 716 → 719 个包、CLI 子命令 11 → 12 个（P6 新增 `logs`）、`crates/tyutool-core` 的 `unwrap()` 总数已高于附录 A1 记录的 276，但 A1 的结论（几乎全在 `mod tests` 内）未重新切分，该节按初测日期读。**修改本文时请重测并更新此行。**
 
@@ -249,7 +251,7 @@ crate 边界判据、CI 门槛。剩一条来自**本次协作事故**的教训�
 
 它并未违反字面指令——它显然认为「checkout 到临时状态再改回来」不算「修改文件」。
 
-**建议写入 AGENTS.md**：
+**已写入根 `AGENTS.md`（2026-08-31）**，见「Dispatching read-only sub-agents」一节。原始措辞：
 
 > 派发只读调查类 agent 时，不要只说「不要修改文件」。明确列出允许的命令
 > （`git show` / `git log` / `git diff` / `grep` / `wc` / `find`），并**明确禁止**

--- a/src/stores/flash.ts
+++ b/src/stores/flash.ts
@@ -512,7 +512,9 @@ export const useFlashStore = defineStore("flash", () => {
         kind === "authorize" ? authorizeUuid.value.trim() || null : null,
       authorizeKey:
         kind === "authorize" ? authorizeAuthKey.value.trim() || null : null,
-      // TODO: expose authorizeStorage for T5AI when single-device auth UI supports OTP
+      // authorizeStorage is deliberately left unset (Rust defaults it to "kv"):
+      // single-device authorize never writes OTP. OTP is irreversible, so it is
+      // offered only on the batch-flash-auth path, behind its own warning.
     };
   }
 

--- a/src/utils/serial-port-label.ts
+++ b/src/utils/serial-port-label.ts
@@ -65,11 +65,8 @@ export type TauriSerialPortRow = {
 };
 
 /**
- * Builds the dropdown / log label: `path (product)` plus optional i18n role suffix
- * when `portRole` matches `flash.portRoles.<role>`.
- */
-/**
- * Hover hint for VID/PID `1a86:55d2` only, keyed by USB interface (see `tmp/usb-port-survey.md`).
+ * Hover hint for VID/PID `1a86:55d2` only, keyed by USB interface (interface numbers
+ * measured on real hardware via the CLI `usb-port-survey` subcommand).
  * When the OS omits `usbInterface` (common on Linux), returns a generic dual-port hint instead of no tooltip.
  * macOS exposes CDC data interfaces (`1` / `3`), while Windows reports the paired control interfaces (`0` / `2`).
  * Returns `null` when not this probe or interface is outside those known dual-serial pairs.
@@ -101,6 +98,10 @@ export function tuyaDualSerialHoverTooltip(
   return null;
 }
 
+/**
+ * Builds the dropdown / log label: `path (product)` plus optional i18n role suffix
+ * when `portRole` matches `flash.portRoles.<role>`.
+ */
 export function formatSerialPortLabel(
   p: TauriSerialPortRow,
   t: (key: string) => string,


### PR DESCRIPTION
Docs-only cleanup, two commits. No behaviour changes, no source logic touched.

## 1. `791ec67` — dead and misleading comments

**Removed**

- `crates/tyutool-core/src/batch_auth.rs` kept a `// src-tauri/src/batch_auth.rs` first-line path header from before P4a moved the file into core. It is the only such header in the repo, so it is a leftover rather than a convention.
- `src/utils/serial-port-label.ts` had two doc blocks stacked on `tuyaDualSerialHoverTooltip`; the first one describes `formatSerialPortLabel`, which had no doc of its own. Moved it to the function it documents.

**Corrected**

- `src/stores/flash.ts` read as a pending task (`TODO: expose authorizeStorage for T5AI when single-device auth UI supports OTP`). Single-device authorize deliberately never writes OTP — OTP is irreversible and is offered only on the batch-flash-auth path, behind its own warning (`BatchAuthConfig.vue` is the only place that can select `"otp"`). The comment now says that.
- Four comments pointed at `tmp/usb-port-survey.md`, which was never committed (`tmp/` is gitignored; `git log --all` has no history for the path). One of them is a clap doc comment, so `tyutool usb-port-survey --help` advertised a file users cannot open. They now point at the `usb-port-survey` subcommand itself.

## 2. `cf10943` — the last normalization wrap-up items

- **`AGENTS.md` gains "Dispatching read-only sub-agents"** — the one rule from the normalization spec's §5.1 that had never been written down. A read-only brief must list the commands the agent may run and explicitly forbid `checkout` / `restore` / `reset` / `stash` / `clean`, *including* a temporary switch that gets switched back. That is how the rule was earned: 29 tracked files reverted and staged under a running session.
- **`docs/cli.md` `serve --port`** — it told readers to move the server off a busy 9527 and "point the client at the same one". The browser client cannot follow that: `WS_PORT` is a hard-coded const in `src/transport/ws-transport.ts`, and only the IDE runtime can inject a URL (`__TUYAOPEN_IDE_CONFIG.wsUrl`); `dev:web`'s `TYUTOOL_SERVE_PORT` moves the server half only. It now says to free the port, and says who `--port` is actually for.
- **The normalization spec moves to `docs/specs/completed/`** per the docs layout rule. Its status line records the one item no repo file can close: enabling Dependabot alerts / security updates in GitHub Settings → Code security, and triaging the existing alerts. References from the core-consolidation spec and `dependabot.yml` follow the move.

## Verification

- `cargo fmt --all --check` — pass
- `cargo clippy -p tyutool-core -p tyutool-cli -p tyutool-serve --all-targets -- -D warnings` — pass
- `cargo clippy -p tyutool-core --all-targets --features zip,excel -- -D warnings` — pass
- `pnpm run lint` — pass
- `vitest run src/utils/serial-port-label.test.ts src/stores/flash.test.ts` — 95 passed

`docs/cli.md` needs no command-contract update: no subcommand, flag or default changed.

## Not in scope

`crates/tyutool-bridge` is untouched by request, including its three open TODOs (tray menu URLs, no in-session log rollover, macOS `SMAppService`).

