### PR TITLE
chore(docs): 归档 flash-test-seams 的 spec/plan 到 completed/

### DIFF
--- a/docs/plans/completed/2026-08-31-flash-test-seams.md
+++ b/docs/plans/completed/2026-08-31-flash-test-seams.md
@@ -1,6 +1,9 @@
 # 烧录编排可测缝隙 实施计划
 
-**Spec:** `docs/specs/2026-08-31-flash-test-seams-design.md`
+**Spec:** `docs/specs/completed/2026-08-31-flash-test-seams-design.md`
+
+**状态：** 已交付——PR #171，rebase-merge 至 `refactor/v3`，末位提交 `869fcb1`。
+CI 全绿（core+cli+serve 1m41s、tauri 2m8s、bridge 2m26s、frontend 51s）。
 
 **Goal:** 给 `tyutool-core` 开一个插件注入缝隙，并提供一个 feature 门控的假芯片插件，
 使 `run_job` 的编排逻辑（事件顺序、取消、错误映射）第一次可以在没有硬件的情况下被测试。

--- a/docs/specs/completed/2026-08-31-flash-test-seams-design.md
+++ b/docs/specs/completed/2026-08-31-flash-test-seams-design.md
@@ -1,9 +1,13 @@
 # 烧录编排的可测缝隙设计：假芯片插件
 
 **日期：** 2026-08-31
-**状态：** 待实现
-**范围：** `tyutool-core` 的插件注册与 `run_job` 调度入口
-**计划：** `docs/plans/2026-08-31-flash-test-seams.md`
+**状态：** 已实现（PR #171，rebase-merge 至 `refactor/v3`，末位提交 `869fcb1`）
+**范围：** `tyutool-core` 的插件注册与 `run_job` 调度入口；实际向上延伸到了
+`tyutool-serve`（修复取消失效）与 `src-tauri`（命令测试）
+**计划：** `docs/plans/completed/2026-08-31-flash-test-seams.md`
+**未完成部分：** 四个阶段均已交付，但本文列举的几项缺口仍在：
+`AuthorizeConfirm` 死锁无直接测试、录制回放只盖读取路径且只盖 Beken 系。
+另外「`flash_run` 与 `handle_run_job` 重复编排」未合并，另起一份 spec。
 **实测基准：** 本文所有计数、行号均实测于 `edece84`（`refactor/v3`）。修改本文时请重测并更新此行的 commit。
 
 ---


### PR DESCRIPTION
#171 已合入，按 `AGENTS.md` 的约定把 spec 与 plan 在一个提交里移进 `completed/`（沿用 `597f05e` 的做法）。

两份文档的头部现在记录了落点（rebase-merge 到 `refactor/v3`，末位提交 `869fcb1`），spec 的交叉引用也重新指向了归档后的 plan。

spec 里另外**明确写出了没有关掉的部分**，免得后来的人从「它在 completed/ 目录里」推断出「全做完了」：

- `AuthorizeConfirm` 死锁没有直接测试（Authorize 绕开注册表，假芯片插不进去）
- 录制回放只盖读取路径，且只盖 Beken 系
- `flash_run` 与 `handle_run_job` 的重复编排仍未合并——这条另起一份 spec

纯文档移动，无代码改动。