### PR TITLE
refactor(core): 把取消与确认两个槽位提取到 core，两个前端共用

### DIFF
--- a/crates/tyutool-core/src/job_control.rs
+++ b/crates/tyutool-core/src/job_control.rs
@@ -1,0 +1,230 @@
+//! The two pieces of per-job control that every frontend needs and none of them
+//! should own: the cancel flag's lifecycle, and the overwrite-confirmation
+//! handshake.
+//!
+//! Deliberately *not* here: threads, tasks, event sinks, and the policy for what
+//! to do when a job is already running. `src-tauri` runs jobs on a
+//! `std::thread` and waits for the previous one; `tyutool-serve` runs them on a
+//! tokio task and refuses a second. Those differences are real and reasonable,
+//! and folding them into one abstraction would cost more than the duplication
+//! it removed. What is shared is the *semantics* below, nothing else.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+
+/// Hands out the cancel flag for one job at a time.
+///
+/// The point of the type is a single invariant: **starting a new job can never
+/// clear the flag an old job is still watching.** [`begin`](Self::begin) does
+/// not reset the existing flag, it replaces it — the outgoing `Arc` is left
+/// `true` forever, and the job holding it keeps seeing the cancel it was given.
+///
+/// That matters because the alternative — one shared flag, reset at the start of
+/// each job — is only safe while something *elsewhere* forbids two jobs from
+/// overlapping. `tyutool-serve` was in exactly that position: correct, but
+/// correct because of a check in another function rather than because of
+/// anything the data structure guaranteed. Here the guarantee is local.
+#[derive(Debug)]
+pub struct CancelSlot {
+    current: Mutex<Arc<AtomicBool>>,
+}
+
+impl CancelSlot {
+    pub fn new() -> Self {
+        Self {
+            current: Mutex::new(Arc::new(AtomicBool::new(false))),
+        }
+    }
+
+    /// Signal whatever is running to stop, and return a fresh flag for the new
+    /// job. The swap happens under the lock so the two flags are never the same
+    /// `Arc`, however the calls interleave.
+    pub fn begin(&self) -> Arc<AtomicBool> {
+        let fresh = Arc::new(AtomicBool::new(false));
+        let previous = {
+            let mut guard = self.lock();
+            std::mem::replace(&mut *guard, Arc::clone(&fresh))
+        };
+        previous.store(true, Ordering::SeqCst);
+        fresh
+    }
+
+    /// Signal the job currently in flight to stop.
+    pub fn cancel(&self) {
+        self.lock().store(true, Ordering::SeqCst);
+    }
+
+    /// The flag of the job currently in flight, for a caller that needs to hand
+    /// it to something after the job has already begun.
+    pub fn current(&self) -> Arc<AtomicBool> {
+        Arc::clone(&*self.lock())
+    }
+
+    /// A poisoned lock here means some other thread panicked while holding it.
+    /// The flag behind it is an `AtomicBool` with no invariant to corrupt, so
+    /// recovering is strictly better than propagating a panic into a flash job.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Arc<AtomicBool>> {
+        self.current.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl Default for CancelSlot {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The overwrite-confirmation handshake: a blocking job thread asks, and
+/// whatever frontend owns the user answers.
+///
+/// `tyutool-core`'s authorize flow calls [`ask`](Self::ask) from inside
+/// `FlashJob::confirm_overwrite` and blocks there. The frontend shows whatever
+/// it shows — a Tauri dialog, a WebSocket frame — and then calls
+/// [`resolve`](Self::resolve). What gets shown is not this type's business.
+#[derive(Debug)]
+pub struct ConfirmSlot {
+    pending: Mutex<Option<mpsc::Sender<bool>>>,
+}
+
+impl ConfirmSlot {
+    pub fn new() -> Self {
+        Self {
+            pending: Mutex::new(None),
+        }
+    }
+
+    /// Blocks until [`resolve`](Self::resolve) or [`clear`](Self::clear) is
+    /// called. Answers `false` if the sender is dropped, so a frontend that
+    /// disappears mid-prompt declines rather than parking the job thread on a
+    /// serial port forever.
+    pub fn ask(&self) -> bool {
+        let (tx, rx) = mpsc::channel::<bool>();
+        *self.lock() = Some(tx);
+        rx.recv().unwrap_or(false)
+    }
+
+    /// Answer a pending ask. Returns whether there was one.
+    ///
+    /// The return value is not decoration: `src-tauri` turns `false` into an
+    /// error, because a confirm command that silently succeeded with nothing
+    /// pending would let the frontend believe a dialog had been dealt with.
+    pub fn resolve(&self, answer: bool) -> bool {
+        match self.lock().take() {
+            Some(tx) => {
+                let _ = tx.send(answer);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Drop a stale pending ask left behind by a run that exited abnormally.
+    /// The waiter, if any, sees `false`.
+    pub fn clear(&self) {
+        let _ = self.lock().take();
+    }
+
+    /// See [`CancelSlot::lock`] for why a poisoned lock is recovered rather
+    /// than propagated.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Option<mpsc::Sender<bool>>> {
+        self.pending.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl Default for ConfirmSlot {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn begin_leaves_the_previous_flag_cancelled() {
+        let slot = CancelSlot::new();
+        let first = slot.begin();
+        assert!(!first.load(Ordering::SeqCst));
+
+        let second = slot.begin();
+
+        // The whole reason this type exists: the job holding `first` still sees
+        // the cancel it was given, even though a new job has started.
+        assert!(
+            first.load(Ordering::SeqCst),
+            "starting a new job must cancel the old one, not un-cancel it",
+        );
+        assert!(!second.load(Ordering::SeqCst));
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "two jobs must never share a cancel flag",
+        );
+    }
+
+    #[test]
+    fn cancel_reaches_the_job_in_flight() {
+        let slot = CancelSlot::new();
+        let running = slot.begin();
+        slot.cancel();
+        assert!(running.load(Ordering::SeqCst));
+        assert!(slot.current().load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn cancelling_before_any_job_does_not_leak_into_the_next_one() {
+        let slot = CancelSlot::new();
+        // A cancel arriving with nothing running (a stray click, a disconnect)
+        // must not pre-cancel whatever starts next.
+        slot.cancel();
+        assert!(!slot.begin().load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn resolve_reports_whether_anything_was_pending() {
+        let slot = ConfirmSlot::new();
+        assert!(!slot.resolve(true), "nothing was pending");
+    }
+
+    #[test]
+    fn ask_returns_the_answer_it_was_given() {
+        let slot = Arc::new(ConfirmSlot::new());
+        let asker = Arc::clone(&slot);
+        let handle = std::thread::spawn(move || asker.ask());
+
+        // `ask` registers its sender before blocking; retry until it appears
+        // rather than sleeping a guessed amount.
+        loop {
+            if slot.resolve(true) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+
+        assert!(handle.join().expect("asker thread"));
+    }
+
+    #[test]
+    fn clear_releases_a_waiter_with_a_refusal() {
+        let slot = Arc::new(ConfirmSlot::new());
+        let asker = Arc::clone(&slot);
+        let handle = std::thread::spawn(move || asker.ask());
+
+        loop {
+            {
+                let mut guard = slot.lock();
+                if guard.is_some() {
+                    let _ = guard.take();
+                    break;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+
+        // Dropping the sender must unblock the job thread as a decline, not
+        // leave it holding the serial port forever.
+        assert!(!handle.join().expect("asker thread"));
+    }
+}

--- a/crates/tyutool-core/src/lib.rs
+++ b/crates/tyutool-core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod diagnostics;
 mod error;
 pub mod flash_event;
 mod job;
+mod job_control;
 mod plugin;
 pub mod plugins;
 mod registry;
@@ -64,6 +65,7 @@ pub use flash_event::{
     FlashEvent, FlashMilestone, FlashPhase, FlashResult, JobDetails, JobSummary,
 };
 pub use job::{FlashJob, FlashMode};
+pub use job_control::{CancelSlot, ConfirmSlot};
 pub use plugin::FlashPlugin;
 #[cfg(feature = "mock-chip")]
 pub use plugins::mock::MockPlugin;

--- a/crates/tyutool-serve/src/lib.rs
+++ b/crates/tyutool-serve/src/lib.rs
@@ -5,7 +5,7 @@
 //! Usage: tyutool-cli serve [--port 9527]
 
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -339,9 +339,12 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
     };
 
     let (sink, mut stream) = ws.split();
-    let cancel = Arc::new(AtomicBool::new(false));
-    let pending_confirm: Arc<Mutex<Option<std::sync::mpsc::Sender<bool>>>> =
-        Arc::new(Mutex::new(None));
+    // Per-connection job control. `CancelSlot` hands each job a fresh flag
+    // rather than resetting a shared one, so a new job cannot clear the cancel
+    // an older one is still watching — a property of the slot itself, no longer
+    // something the "one job at a time" check below has to be relied on for.
+    let cancel_slot = Arc::new(tyutool_core::CancelSlot::new());
+    let pending_confirm = Arc::new(tyutool_core::ConfirmSlot::new());
     // The in-flight flash job, if any.
     //
     // It runs on its own task rather than being awaited inside the message loop
@@ -446,12 +449,9 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
                 let _ = sink_tx.send(msg);
             }
             ClientMessage::Cancel => {
-                cancel.store(true, Ordering::Relaxed);
+                cancel_slot.cancel();
                 // Wake any thread blocked in confirm_overwrite so it can return Cancelled.
-                let mut g = pending_confirm.lock().unwrap_or_else(|e| e.into_inner());
-                if let Some(tx) = g.take() {
-                    let _ = tx.send(false);
-                }
+                pending_confirm.resolve(false);
             }
             ClientMessage::RunJob {
                 job,
@@ -471,10 +471,9 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
                     });
                     continue;
                 }
-                cancel.store(false, Ordering::Relaxed);
                 running_job = Some(tokio::spawn(handle_run_job(
                     sink_tx.clone(),
-                    Arc::clone(&cancel),
+                    cancel_slot.begin(),
                     job,
                     file_content,
                     file_contents,
@@ -836,10 +835,7 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
                 }
             }
             ClientMessage::AuthorizeConfirm { confirmed } => {
-                let mut guard = pending_confirm.lock().unwrap_or_else(|e| e.into_inner());
-                if let Some(tx) = guard.take() {
-                    let _ = tx.send(confirmed);
-                }
+                pending_confirm.resolve(confirmed);
             }
         }
     }
@@ -847,13 +843,8 @@ async fn handle_connection(stream: tokio::net::TcpStream) {
     // Best-effort: wake any auth thread blocked on confirm_overwrite, and signal cancel.
     // Without this, a WS disconnect during an AuthConflict prompt would park the
     // blocking thread forever (holding the serial port open).
-    cancel.store(true, Ordering::Relaxed);
-    {
-        let mut g = pending_confirm.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(tx) = g.take() {
-            let _ = tx.send(false);
-        }
-    }
+    cancel_slot.cancel();
+    pending_confirm.resolve(false);
 
     // Let the cancelled job finish unwinding before the sink goes away, so the
     // serial port is released and its task does not outlive the connection.
@@ -889,7 +880,7 @@ async fn handle_run_job(
     mut job: FlashJob,
     file_content: Option<String>,
     file_contents: Option<Vec<String>>,
-    pending_confirm: Arc<Mutex<Option<std::sync::mpsc::Sender<bool>>>>,
+    pending_confirm: Arc<tyutool_core::ConfirmSlot>,
 ) {
     let mut temp_paths: Vec<String> = Vec::new();
 
@@ -958,6 +949,8 @@ async fn handle_run_job(
     let confirm_store = Arc::clone(&pending_confirm);
     job_clone.confirm_overwrite = Some(Box::new(move |existing_uuid, existing_authkey| {
         use tyutool_core::{FlashEvent, FlashMilestone};
+        // Raising the prompt is this frontend's business; the handshake that
+        // follows is not, and lives in `ConfirmSlot`.
         if let Ok(v) = serde_json::to_value(FlashEvent::Milestone {
             milestone: FlashMilestone::AuthConflict {
                 existing_uuid,
@@ -966,12 +959,7 @@ async fn handle_run_job(
         }) {
             let _ = sink_for_confirm.send(ServerMessage::Progress { payload: v });
         }
-        let (tx, rx) = std::sync::mpsc::channel::<bool>();
-        {
-            let mut guard = confirm_store.lock().unwrap_or_else(|e| e.into_inner());
-            *guard = Some(tx);
-        }
-        rx.recv().unwrap_or(false)
+        confirm_store.ask()
     }));
 
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<serde_json::Value>();

--- a/docs/plans/2026-08-31-job-control-slots.md
+++ b/docs/plans/2026-08-31-job-control-slots.md
@@ -1,0 +1,83 @@
+# 任务控制槽位 实施计划
+
+**Spec:** `docs/specs/2026-08-31-job-control-slots-design.md`
+
+**Goal:** 把「同一时刻只跑一个任务，且新任务不得抹掉旧任务的取消」这个不变量，以及确认握手，
+从 `src-tauri` 与 `tyutool-serve` 各自的实现中提取到 `tyutool-core`，让正确性成为数据结构
+自身的性质而不是远处约束的副产品。
+
+**Architecture:** core 新增一个 flat 模块 `job_control.rs`，放 `CancelSlot` 与 `ConfirmSlot`。
+两个前端替换掉自己那份，**保留各自的线程模型与并发策略**。外部行为零变化。
+
+**Tech Stack:** Rust 2021。core 的测试内联；两个前端的行为由上一轮建立的测试兜底
+（serve 31、src-tauri 36），重构前后都必须全绿。
+
+**基线（`869fcb1`）：** core 322 / cli 59 / serve 31 / tauri 36。
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `crates/tyutool-core/src/job_control.rs` | 新文件：`CancelSlot`、`ConfirmSlot` + 测试 |
+| `crates/tyutool-core/src/lib.rs` | 挂模块并 re-export |
+| `src-tauri/src/lib.rs` | `FlashState.cancel` / `ConfirmState` 改用槽位；`flash_run`、`flash_cancel`、`authorize_confirm_cmd` 跟着改 |
+| `crates/tyutool-serve/src/lib.rs` | 连接级 `cancel` / `pending_confirm` 改用槽位 |
+| `docs/specs/…-design.md` / `docs/plans/…` | 本对文档 |
+
+---
+
+## Task 1: `CancelSlot`
+
+**Files:** Create `crates/tyutool-core/src/job_control.rs`; modify `lib.rs`
+
+- [x] **Step 1:** `begin()` 在互斥锁里 `std::mem::replace` 出新 Arc，并把旧的置 `true`；
+  `cancel()`、`current()`
+- [x] **Step 2:** 测试，重点是那条不变量：**`begin()` 之后旧标志仍为 `true`**，
+  新标志为 `false`，两者不是同一个 Arc
+- [x] **Step 3:** `cargo test -p tyutool-core` 仍 322 + 新增
+
+## Task 2: `ConfirmSlot`
+
+**Files:** Modify `crates/tyutool-core/src/job_control.rs`
+
+- [x] **Step 1:** `ask()` / `resolve()` / `clear()`。`resolve` 返回「是否真的有待决」
+- [x] **Step 2:** 测试：无待决时 `resolve` 返回 false；`ask` 在另一线程 `resolve` 后返回；
+  `clear` 之后原来的 `ask` 得到 false 而不是永久阻塞
+
+## Task 3: `src-tauri` 改用槽位
+
+**Files:** Modify `src-tauri/src/lib.rs`
+
+- [x] **Step 1:** `FlashState.cancel` 换成 `CancelSlot`；`ConfirmState` 换成 `ConfirmSlot`
+- [x] **Step 2:** `flash_run` 里那段「换新 Arc + 置旧为 true」换成 `slot.begin()`，
+  **3 秒 join 与拒绝逻辑原样保留**
+- [x] **Step 3:** `flash_cancel` → `cancel()` + `resolve(false)`；
+  `authorize_confirm_cmd` → 用 `resolve()` 的返回值决定 Ok/Err
+- [x] **Step 4:** `cargo test -p tyutool_gui` 仍 **36 全绿**（行为不变的证据）
+
+## Task 4: `tyutool-serve` 改用槽位
+
+**Files:** Modify `crates/tyutool-serve/src/lib.rs`
+
+- [x] **Step 1:** 连接级 `cancel` 换成 `CancelSlot`。⚠ 原来的 `cancel.store(false)`
+  换成 `begin()`——这是本次的**实质改进**：不再依赖「拒绝并发任务」来保证正确性
+- [x] **Step 2:** `pending_confirm` 换成 `ConfirmSlot`；`AuthConflict` 帧仍在前端侧发
+- [x] **Step 3:** 关闭连接时的 `cancel` + 唤醒改用槽位
+- [x] **Step 4:** `cargo test -p tyutool-serve` 仍 **31 全绿**
+
+## Task 5: 门禁
+
+- [x] **Step 1:** 全量门禁（fmt / clippy ×3 / 全部测试 / bindings）
+- [x] **Step 2:** 计数核对：core 增加，cli / serve / tauri **数量不变**——
+  数量变了就说明行为动了，那是本次不该发生的事
+
+---
+
+## 验收标准
+
+- 两个前端的测试数**一个不多一个不少**且全绿：行为不变的最好证据
+- `CancelSlot` 有自己的不变量测试
+- 线程模型、并发策略、事件出口**一行未动**
+- `AGENTS.md` 的「never re-implement a helper」不再被违反

--- a/docs/specs/2026-08-31-job-control-slots-design.md
+++ b/docs/specs/2026-08-31-job-control-slots-design.md
@@ -1,0 +1,125 @@
+# 任务控制的两个共用槽位：`CancelSlot` 与 `ConfirmSlot`
+
+**日期：** 2026-08-31
+**状态：** 待实现
+**范围：** `tyutool-core` 新增 `job_control` 模块；`src-tauri` 与 `tyutool-serve` 改为使用它
+**计划：** `docs/plans/2026-08-31-job-control-slots.md`
+**前置：** `docs/specs/completed/2026-08-31-flash-test-seams-design.md`（那轮给两边都补上了测试，
+本次重构才有网可依）
+**实测基准：** 行号实测于 `869fcb1`（`refactor/v3`）。
+
+---
+
+## 背景
+
+`AGENTS.md` 写着：
+
+> Never re-implement a helper that already exists in another crate. If two binaries
+> need the same behaviour, it belongs in `tyutool-core`.
+
+这条目前是被违反的状态：`src-tauri` 的 `flash_run` 和 `tyutool-serve` 的
+`handle_connection` 各自实现了同一件事——**同一时刻只跑一个任务，且新任务不得抹掉旧任务的
+取消**——而且实现方式不同。
+
+**这不是理论问题，它已经造成过一个 bug。** 上一轮在 serve 里发现并修掉的取消失效
+（PR #171，`d61d987`），根因就是两边对「任务与消息循环如何共存」各想各的。
+
+### 现状对照（`869fcb1`）
+
+| | `src-tauri`（`lib.rs:172-201`） | `tyutool-serve`（`lib.rs:455-483`） |
+|---|---|---|
+| 取消标志 | 互斥锁里**换一个新 Arc**，旧的留在 `true` | **复用同一个 Arc**，新任务把它重置为 `false` |
+| 并发策略 | 等旧线程最多 3 秒，超时则拒绝新任务 | 直接拒绝第二个任务 |
+| 并发模型 | `std::thread` + 阻塞 `join` | `tokio::spawn` + `await` |
+| 事件出口 | `app.emit` | mpsc → WS sink |
+
+**取消标志那一行是真正的问题所在。** src-tauri 的做法自带正确性——两个任务从不共用一个
+标志位。serve 的做法之所以安全，是因为**另一个地方**（拒绝并发任务）恰好挡住了危险路径；
+correctness 依赖于一个远处的约束，而不是这个数据结构自身的性质。这种安全是脆的：哪天
+并发策略一放松，重置就会把前一个任务的取消一并抹掉，而且不会有任何东西报错。
+
+另有一处**完全相同**的重复：确认握手。两边都是
+`Arc<Mutex<Option<mpsc::Sender<bool>>>>`，都是「建 channel → 存 sender → 阻塞 recv」，
+解析端都是「take sender → send」。逐行等价。
+
+---
+
+## 决策
+
+### 不做什么
+
+**不合并线程模型。** 一边是 `std::thread` + 阻塞 join，一边是 `tokio::spawn` + await；
+一边往 `AppHandle` emit，一边往 mpsc 送。把这些塞进一个抽象，做出来的东西会比两份清楚的
+重复更难懂——错误的抽象比重复更贵。**两个前端各自保留自己的线程模型和并发策略。**
+
+**不动并发策略。** src-tauri 等 3 秒、serve 直接拒绝，这是两种前端的合理差异（GUI 用户会
+连点按钮；WS 客户端不该并发发任务）。
+
+### 做什么
+
+在 `tyutool-core` 新增 `job_control` 模块，只提取两样**语义**，不提取控制流：
+
+#### 1. `CancelSlot`
+
+```rust
+/// Hands out the cancel flag for one job at a time, so that starting a new job
+/// can never clear the flag an old one is still watching.
+pub struct CancelSlot { /* Mutex<Arc<AtomicBool>> */ }
+
+impl CancelSlot {
+    /// Signal whatever is running to stop, and hand back a *fresh* flag for the
+    /// new job. The old Arc stays `true` forever.
+    pub fn begin(&self) -> Arc<AtomicBool>;
+    /// Signal the current job to stop.
+    pub fn cancel(&self);
+    /// The flag of the job already in flight.
+    pub fn current(&self) -> Arc<AtomicBool>;
+}
+```
+
+关键在于 `begin()` **返回新标志**而不是重置旧的——正确性变成这个类型自身的性质，不再依赖
+调用方是否恰好禁止了并发。serve 由此从「安全但靠远处约束」变成「结构上就不可能错」。
+
+#### 2. `ConfirmSlot`
+
+```rust
+/// The overwrite-confirmation handshake between a blocking job thread and
+/// whatever frontend is going to ask the user.
+pub struct ConfirmSlot { /* Mutex<Option<Sender<bool>>> */ }
+
+impl ConfirmSlot {
+    /// Blocks until answered. Called from the job thread.
+    pub fn ask(&self) -> bool;
+    /// Answer a pending ask; false if nothing was pending.
+    pub fn resolve(&self, answer: bool) -> bool;
+    /// Drop a stale pending ask left by a run that exited abnormally.
+    pub fn clear(&self);
+}
+```
+
+`resolve` 返回 bool 同时满足两边：src-tauri 的 `authorize_confirm_cmd` 靠它区分「有待决」
+与「无待决」（后者要返回 Err，否则前端会以为对话框处理过了）；serve 忽略返回值。
+
+**「弹什么、怎么弹」留在前端。** serve 在阻塞之前还要往 WS 送一帧 `AuthConflict`，那是它
+的事，不进 core。
+
+---
+
+## 明确否掉的方案
+
+**把 `run_job` 的整段编排搬进 core（含线程管理）。** 这是最初想到的做法，也是 spec
+`2026-08-31-flash-test-seams-design.md` 里提过的「合并重复编排」。否掉的理由见上：线程模型
+不同，硬合并会造出一个既不像线程也不像任务的四不像。
+
+**照搬 `tyutool-bridge` 的 `FlashBackend`。** 那是一个「把整个执行面注入进来」的 trait，
+解决的是**测试注入**问题，不是**共用不变量**问题。bridge 已经有它了，且 bridge 不在本次范围。
+
+**统一并发策略。** 见上，两种前端的差异是合理的。
+
+---
+
+## 验收
+
+- 两个前端的**外部行为一律不变**：serve 仍拒绝并发任务，src-tauri 仍等 3 秒后拒绝。
+- 上一轮建立的测试是这次重构的网：serve 31 个、src-tauri 36 个，重构前后都必须全绿。
+- `CancelSlot` 自身要有测试，尤其是那条不变量：**`begin()` 之后，旧标志仍为 `true`**。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ mod updater;
 mod window;
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::thread::JoinHandle;
@@ -21,14 +21,17 @@ use tyutool_core::{
 static SESSION_ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 
 struct FlashState {
-    /// Cancel signal for the **current** operation. Wrapped in a Mutex so
-    /// flash_run can atomically swap in a fresh Arc for the new operation while
-    /// leaving the old Arc signalled — preventing the old thread's cancel from
-    /// being cleared when a new operation starts.
-    cancel: StdMutex<Arc<AtomicBool>>,
+    /// Cancel signal for the current operation. The slot guarantees a new
+    /// operation gets a *fresh* flag rather than a reset one, so starting a job
+    /// can never clear the cancel an older thread is still watching.
+    cancel: tyutool_core::CancelSlot,
     /// Handle to the running flash thread, if any. Joined (with 3 s timeout)
     /// before a new operation spawns, ensuring the serial port is fully
     /// released. On timeout the new operation is rejected rather than racing.
+    ///
+    /// Stays here rather than in the slot: waiting for the previous thread is
+    /// this frontend's policy (tyutool-serve refuses instead), and the handle
+    /// type is `std::thread`'s, not tokio's.
     thread: StdMutex<Option<JoinHandle<()>>>,
 }
 
@@ -36,7 +39,7 @@ struct FlashState {
 /// overwrite-confirmation dialog. The sender is set by `flash_run` before
 /// blocking; `authorize_confirm_cmd` resolves it with the user's choice.
 struct ConfirmState {
-    sender: Arc<StdMutex<Option<std::sync::mpsc::Sender<bool>>>>,
+    slot: Arc<tyutool_core::ConfirmSlot>,
 }
 
 /// Detect the installation type at runtime based on the executable's path.
@@ -165,20 +168,11 @@ fn flash_run<R: Runtime>(
     );
 
     // Clear any stale confirm sender from a previous run that exited abnormally.
-    if let Ok(mut g) = confirm_state.sender.lock() {
-        *g = None;
-    }
+    confirm_state.slot.clear();
 
-    // Create a fresh cancel flag for this operation and signal the old one.
-    // Swapping atomically under the mutex ensures the old Arc stays `true`
-    // while the new Arc starts at `false` — the two operations never share a
-    // cancel flag, so starting a new job cannot un-cancel the previous one.
-    let new_cancel = Arc::new(AtomicBool::new(false));
-    let old_cancel = {
-        let mut guard = state.cancel.lock().map_err(|e| e.to_string())?;
-        std::mem::replace(&mut *guard, new_cancel.clone())
-    };
-    old_cancel.store(true, Ordering::SeqCst);
+    // Signal the previous operation and take a fresh flag for this one. The two
+    // never share a flag — see `CancelSlot`.
+    let cancel = state.cancel.begin();
 
     // Wait up to 3 seconds for the previous thread to exit.  If it hasn't
     // finished — e.g. blocked on a serial read with a long timeout — reject
@@ -200,18 +194,11 @@ fn flash_run<R: Runtime>(
         }
     }
 
-    let cancel = new_cancel;
-
     // Inject confirm callback: blocks until the frontend calls authorize_confirm_cmd.
     // AuthConflict is already emitted by core's progress callback; no need to re-emit here.
-    let confirm_sender = Arc::clone(&confirm_state.inner().sender);
+    let confirm = Arc::clone(&confirm_state.inner().slot);
     job.confirm_overwrite = Some(Box::new(move |_existing_uuid, _existing_authkey| {
-        let (tx, rx) = std::sync::mpsc::channel::<bool>();
-        {
-            let mut guard = confirm_sender.lock().unwrap_or_else(|e| e.into_inner());
-            *guard = Some(tx);
-        }
-        rx.recv().unwrap_or(false)
+        confirm.ask()
     }));
 
     let app = app.clone();
@@ -228,27 +215,21 @@ fn flash_run<R: Runtime>(
 #[tauri::command]
 fn flash_cancel(state: State<'_, FlashState>, confirm_state: State<'_, ConfirmState>) {
     log::info!("[Flash] User cancelled operation");
-    if let Ok(guard) = state.cancel.lock() {
-        guard.store(true, Ordering::SeqCst);
-    }
+    state.cancel.cancel();
     // Wake any thread blocked in confirm_overwrite so it can return Cancelled.
-    if let Ok(mut sender_guard) = confirm_state.sender.lock() {
-        if let Some(tx) = sender_guard.take() {
-            let _ = tx.send(false);
-        }
-    }
+    confirm_state.slot.resolve(false);
 }
 
 /// Resolve a pending overwrite-confirmation from `run_authorize`.
 /// Called by the frontend after the user responds to the AuthConflict dialog.
 #[tauri::command]
 fn authorize_confirm_cmd(state: State<'_, ConfirmState>, confirmed: bool) -> Result<(), String> {
-    let mut guard = state.sender.lock().map_err(|e| e.to_string())?;
-    if let Some(tx) = guard.take() {
-        let _ = tx.send(confirmed);
+    if state.slot.resolve(confirmed) {
         log::info!("[auth] confirm resolved: {}", confirmed);
         Ok(())
     } else {
+        // Not cosmetic: succeeding here with nothing pending would let the
+        // frontend believe a dialog it never raised had been dealt with.
         log::warn!("[auth] confirm called with no pending authorization");
         Err("no pending authorization confirmation".into())
     }
@@ -640,7 +621,7 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .manage(FlashState {
-            cancel: StdMutex::new(Arc::new(AtomicBool::new(false))),
+            cancel: tyutool_core::CancelSlot::new(),
             thread: StdMutex::new(None),
         })
         .manage({
@@ -671,7 +652,7 @@ pub fn run() {
             })),
         })
         .manage(ConfirmState {
-            sender: Arc::new(StdMutex::new(None)),
+            slot: Arc::new(tyutool_core::ConfirmSlot::new()),
         })
         .manage(updater::UpdateState {
             pending: StdMutex::new(None),
@@ -929,11 +910,11 @@ mod tests {
         fn test_app() -> App<MockRuntime> {
             mock_builder()
                 .manage(FlashState {
-                    cancel: StdMutex::new(Arc::new(AtomicBool::new(false))),
+                    cancel: tyutool_core::CancelSlot::new(),
                     thread: StdMutex::new(None),
                 })
                 .manage(ConfirmState {
-                    sender: Arc::new(StdMutex::new(None)),
+                    slot: Arc::new(tyutool_core::ConfirmSlot::new()),
                 })
                 .build(mock_context(noop_assets()))
                 .expect("the mock app should build")


### PR DESCRIPTION
## 为什么

`AGENTS.md` 写着「never re-implement a helper that already exists in another crate」。这条目前是被违反的：`src-tauri` 的 `flash_run` 和 `tyutool-serve` 的 `handle_connection` 各自实现了同一件事——**同一时刻只跑一个任务，且新任务不得抹掉旧任务的取消**——而且实现方式不同。

**这不是理论问题。** 上一轮在 serve 里发现并修掉的取消失效（#171 的 `d61d987`），根因就是两边对同一个问题各想各的。

## 有意思的那一半：取消标志

| | `src-tauri` | `tyutool-serve`（改之前） |
|---|---|---|
| 做法 | 互斥锁里**换一个新 Arc**，旧的留在 `true` | **复用同一个 Arc**，新任务把它重置为 `false` |
| 正确性来自 | 数据结构本身 | **另一个 match 分支**里的「拒绝并发任务」检查 |

serve 那版是**安全的**——但安全性寄存在别处。哪天并发策略一放松，重置就会把正在跑的任务的取消一并抹掉,而且不会有任何东西报错。

`CancelSlot::begin()` **返回新标志**而不是重置旧的，正确性因此变成这个类型自身的局部性质。serve 从「安全但靠远处约束」变成「结构上就不可能错」。

最锋利的那个测试直接钉住这条不变量：

```rust
let first = slot.begin();
let second = slot.begin();
assert!(first.load(SeqCst), "starting a new job must cancel the old one, not un-cancel it");
assert!(!Arc::ptr_eq(&first, &second), "two jobs must never share a cancel flag");
```

## 平淡的那一半：确认握手

两边原本是**逐行等价**的 `Arc<Mutex<Option<Sender<bool>>>>`：建 channel → 存 sender → 阻塞 recv；解析端 take → send。

`ConfirmSlot::resolve()` 返回「是否真的有待决」——这个返回值不是装饰：`authorize_confirm_cmd` 靠它在无待决时继续返回 Err，否则前端会以为一个它从没弹过的对话框已经被处理了。

## 刻意**没有**合并的东西

线程模型、并发策略、事件出口。`src-tauri` 用 `std::thread` 跑任务、等旧线程最多 3 秒；`tyutool-serve` 用 `tokio::spawn`、直接拒绝第二个。这些差异是**合理的**——GUI 用户会连点按钮，WS 客户端不该并发发任务——把它们塞进一个抽象，做出来的东西会比两份清楚的重复更贵。

**只搬语义，不搬控制流。**

## 行为不变，测试数是证据

| | 前 | 后 |
|---|---|---|
| `tyutool-serve` | 31 | **31**（一个不变） |
| `src-tauri` | 36 | **36**（一个不变） |
| `tyutool-core` | 322 | **328**（+6，新模块自己的测试） |
| `tyutool-cli` | 59 | 59 |

两个前端的测试数**一个不多一个不少**，是行为未变的最好证据。代码量上两边都是净减少（serve −46 行改动、src-tauri −69 行改动，core 新增一个 230 行的模块含测试）。

## 依赖关系

**这次重构在 #171 之前是不敢做的**——那时两边都没有测试。现在那 67 个前端测试就是这次落地的网。

## 文档

- `docs/specs/2026-08-31-job-control-slots-design.md`——含**明确否掉的方案**（整段编排搬进 core、照搬 bridge 的 `FlashBackend`、统一并发策略）
- `docs/plans/2026-08-31-job-control-slots.md`
