### PR TITLE
chore(docs): 归档 job-control 与 write-path 两对文档，并给旧 spec 补前向指针

### DIFF
--- a/docs/plans/completed/2026-08-31-job-control-slots.md
+++ b/docs/plans/completed/2026-08-31-job-control-slots.md
@@ -1,6 +1,8 @@
 # 任务控制槽位 实施计划
 
-**Spec:** `docs/specs/2026-08-31-job-control-slots-design.md`
+**Spec:** `docs/specs/completed/2026-08-31-job-control-slots-design.md`
+
+**状态：** 已交付——PR #173，rebase-merge 至 `refactor/v3`，提交 `36997e0`。
 
 **Goal:** 把「同一时刻只跑一个任务，且新任务不得抹掉旧任务的取消」这个不变量，以及确认握手，
 从 `src-tauri` 与 `tyutool-serve` 各自的实现中提取到 `tyutool-core`，让正确性成为数据结构

--- a/docs/plans/completed/2026-09-01-write-path-replay.md
+++ b/docs/plans/completed/2026-09-01-write-path-replay.md
@@ -1,6 +1,8 @@
 # 写入路径录制回放 实施计划
 
-**Spec:** `docs/specs/2026-09-01-write-path-replay-design.md`
+**Spec:** `docs/specs/completed/2026-09-01-write-path-replay-design.md`
+
+**状态：** 已交付——PR #174，rebase-merge 至 `refactor/v3`，提交 `06fa5af`。
 
 **Goal:** 给 Beken 驱动的写入路径（解保护 → 擦除 → 写 → 每扇区 CRC → 保护）补一条来自真实
 硬件的协议基线，并把上一轮遗留的另外两个缺口各自定性收口。

--- a/docs/specs/completed/2026-08-31-flash-test-seams-design.md
+++ b/docs/specs/completed/2026-08-31-flash-test-seams-design.md
@@ -5,9 +5,16 @@
 **范围：** `tyutool-core` 的插件注册与 `run_job` 调度入口；实际向上延伸到了
 `tyutool-serve`（修复取消失效）与 `src-tauri`（命令测试）
 **计划：** `docs/plans/completed/2026-08-31-flash-test-seams.md`
-**未完成部分：** 四个阶段均已交付，但本文列举的几项缺口仍在：
-`AuthorizeConfirm` 死锁无直接测试、录制回放只盖读取路径且只盖 Beken 系。
-另外「`flash_run` 与 `handle_run_job` 重复编排」未合并，另起一份 spec。
+**本文遗留缺口的去向（后来都已收口，在别处）：**
+
+| 缺口 | 结果 | 在哪 |
+|---|---|---|
+| 写入路径无协议基线 | 已补上（实机录制 16 KiB 写入） | `completed/2026-09-01-write-path-replay-design.md` |
+| `AuthorizeConfirm` 死锁无直接测试 | **重新定义**：同根因已有哨兵；真正的题是 authorize 流程没有任何假件，需另行立题 | 同上 |
+| ESP 系无法录制 | **已评估，不做**（结构性限制，非投入问题） | 同上 |
+| `flash_run` 与 `handle_run_job` 重复编排 | 已做**窄的提取**（`CancelSlot` / `ConfirmSlot`） | `completed/2026-08-31-job-control-slots-design.md` |
+
+下文「代价，说清楚」一节写于那些缺口还开着的时候，保留原样作为当时的判断记录。
 **实测基准：** 本文所有计数、行号均实测于 `edece84`（`refactor/v3`）。修改本文时请重测并更新此行的 commit。
 
 ---

--- a/docs/specs/completed/2026-08-31-job-control-slots-design.md
+++ b/docs/specs/completed/2026-08-31-job-control-slots-design.md
@@ -1,9 +1,10 @@
 # 任务控制的两个共用槽位：`CancelSlot` 与 `ConfirmSlot`
 
 **日期：** 2026-08-31
-**状态：** 待实现
+**状态：** 已实现（PR #173，rebase-merge 至 `refactor/v3`，提交 `36997e0`）。
+两个前端的测试数量一个未变（serve 31、tauri 36）——行为未变的证据。
 **范围：** `tyutool-core` 新增 `job_control` 模块；`src-tauri` 与 `tyutool-serve` 改为使用它
-**计划：** `docs/plans/2026-08-31-job-control-slots.md`
+**计划：** `docs/plans/completed/2026-08-31-job-control-slots.md`
 **前置：** `docs/specs/completed/2026-08-31-flash-test-seams-design.md`（那轮给两边都补上了测试，
 本次重构才有网可依）
 **实测基准：** 行号实测于 `869fcb1`（`refactor/v3`）。

--- a/docs/specs/completed/2026-09-01-write-path-replay-design.md
+++ b/docs/specs/completed/2026-09-01-write-path-replay-design.md
@@ -1,9 +1,9 @@
 # 写入路径的录制回放基线
 
 **日期：** 2026-09-01
-**状态：** 待实现
+**状态：** 已实现（PR #174，rebase-merge 至 `refactor/v3`，提交 `06fa5af`）
 **范围：** `tyutool-core` 的 Beken 驱动写入路径（`plugins/beken`）
-**计划：** `docs/plans/2026-09-01-write-path-replay.md`
+**计划：** `docs/plans/completed/2026-09-01-write-path-replay.md`
 **前置：** `docs/specs/completed/2026-08-31-flash-test-seams-design.md` 建立了
 `RecordIo` / `ReplayIo` 与第一条读取基线；本文补上写入路径。
 


### PR DESCRIPTION
#173 与 #174 都已合入，按约定把两对 spec/plan 移进 `completed/`。各自头部记录落点，spec 与 plan 之间的交叉引用也重新指向归档路径。

**更有用的是给 flash-test-seams spec 补的前向指针。** 它 ship 时带着四个未关闭的缺口，并且诚实地写了出来——但后来的读者无从知道那四条**后来都在别处解决了**。一份放在 `completed/` 里却列着开放缺口的文档，正是最容易被反复重新评估的那种东西。

现在它头部有一张表，写清楚每条的结果和该去读哪份 spec：

| 缺口 | 结果 |
|---|---|
| 写入路径无协议基线 | 已补上（#174） |
| `AuthorizeConfirm` 死锁无直接测试 | 重新定义，非填补（#174 的 spec） |
| ESP 系无法录制 | 已评估，不做（#174 的 spec） |
| `flash_run` / `handle_run_job` 重复编排 | 已做窄的提取（#173） |

它那节「代价，说清楚」**刻意保留原样**——那些话在缺口还开着的时候是准确的，改写它等于抹掉当时的判断依据，而不是记录它。

`docs/specs/` 与 `docs/plans/` 现在已无 in-flight 文档。纯文档改动。