### PR TITLE
ci: stop minting per-PR and per-tag copies of the Rust caches

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -129,7 +129,17 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-        with: { key: "bridge-check" }
+        with:
+          key: "bridge-check"
+          # This one deliberately still saves on PR refs, unlike ci.yml's two rust
+          # caches. A run only ever falls back to the DEFAULT branch's caches (or,
+          # for a PR, its base branch) -- and this workflow never runs on
+          # `refactor/v3`: see the `on:` block, where push is `bridge/main` +
+          # `bridge-v*` only. So there is no default-branch copy for a PR to
+          # restore, and gating the save on the default branch would mean this
+          # cache is never written at all, turning every bridge PR into a cold
+          # ~530 MB dependency build. The per-PR copy is reused across pushes
+          # within that PR and dies with it.
 
       - name: Clippy
         run: cargo clippy -p tyutool-bridge --all-targets -- -D warnings
@@ -235,7 +245,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with: { targets: "${{ matrix.rust_targets }}" }
       - uses: Swatinem/rust-cache@v2
-        with: { key: "bridge-${{ matrix.platform }}-${{ matrix.arch }}" }
+        with:
+          key: "bridge-${{ matrix.platform }}-${{ matrix.arch }}"
+          # Restore-only: this job runs only on a `bridge-v*` tag (it needs
+          # `prepare`), and a tag-scoped cache is unreadable by the next tag.
+          save-if: false
 
       # bash on every platform (git-bash on Windows) so one loop covers both the
       # single-target and the two-target (macOS universal) case.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,16 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-        with: { key: "ci-rust" }
+        with:
+          key: "ci-rust"
+          # Save on the default branch only. A cache written by a PR run is
+          # scoped to that PR's ref and can be read by nothing else, so every
+          # PR minted its own private copy of this key -- three live copies of
+          # `ci-rust` plus three of `ci-tauri` had the repo pinned at GitHub's
+          # 10 GB ceiling, evicting the caches that do get hit. PR runs still
+          # RESTORE from the default branch, which is where their hits came
+          # from all along.
+          save-if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       - name: Format check
         run: cargo fmt --all --check
       - name: Clippy
@@ -109,7 +118,12 @@ jobs:
           exit 1
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-        with: { key: "ci-tauri" }
+        with:
+          # Default branch only -- see the `rust` job. This is the largest
+          # cache in the repo (~1.8 GB a copy), so it is where the per-PR
+          # duplicates cost the most.
+          key: "ci-tauri"
+          save-if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       - name: Clippy
         run: cargo clippy -p tyutool_gui --all-targets -- -D warnings
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with: { targets: "${{ matrix.target }}" }
       - uses: Swatinem/rust-cache@v2
-        with: { key: "cli-${{ matrix.target }}" }
+        with:
+          key: "cli-${{ matrix.target }}"
+          # Restore-only. This job runs on a `v*.*.*` tag, and a cache saved
+          # under `refs/tags/...` is visible only to a re-run of that exact tag
+          # -- the next release cannot read it. Writing it only spends repo
+          # cache budget (shared with ci.yml, which does get hits) and adds a
+          # multi-hundred-MB upload to every release job.
+          save-if: false
 
       - name: Install cross
         if: matrix.use_cross
@@ -223,9 +230,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # shared-key replaces the per-job key suffix so a target's cache is reusable
-          # across runs; each target now compiles in a single job, so always persist it.
+          # across runs -- but only across runs on the SAME ref, and this job only ever
+          # runs on a `v*.*.*` tag, whose cache scope no later tag can read. So it is
+          # restore-only: a tag run still reads the default branch's caches, while its
+          # own multi-GB writes stop competing with ci.yml for the 10 GB repo quota.
           shared-key: "gui-${{ matrix.target }}"
-          save-if: true
+          save-if: false
 
       # ── Frontend dist (pre-built, platform-independent) ──
       - uses: actions/download-artifact@v8


### PR DESCRIPTION
The repo was sitting at 9.41 GiB of Actions cache against GitHub's 10 GB per-repository ceiling, so every run evicted something and PRs kept cold-starting against a cache that was nominally there. Thirteen entries, and only three of them were reachable by anything. Two sources:

  * `ci.yml`'s `ci-rust` (777 MiB) and `ci-tauri` (1.8 GiB) saved on every ref. A cache written under `refs/pull/N/merge` can be restored by nothing but that one PR, and `Swatinem/rust-cache` prunes the workspace's own artifacts before saving — so the per-PR copy was near-identical to the default-branch copy the PR already restores from, at 2.6 GiB a PR. Gate the save on the default branch. Restores are untouched: `refactor/v3` runs on every push, and its key hash matches the PRs' exactly, so PRs keep hitting it.

  * `release.yml` (CLI + GUI) and `bridge.yml`'s `build` only ever run on a tag, and a cache saved under `refs/tags/...` is visible only to a re-run of that same tag — the next release cannot read it. They are restore-only now, which also drops a multi-GB upload from every release job. This corrects the comment on the GUI cache, which reasoned that `shared-key` made the cache "reusable across runs": it does, but only across runs on the same ref, which for a tag-triggered job is a set of one.

`bridge.yml`'s `check` deliberately keeps saving on PR refs, and now says why. A run only falls back to the default branch's caches (or, for a PR, its base branch), and that workflow never runs on `refactor/v3` — its `on:` block pushes `bridge/main` and `bridge-v*` only. There is no default-branch copy to fall back to, so gating it the way `ci.yml` is gated would mean the cache is never written at all, turning every bridge PR into a cold ~530 MB dependency build.

The stale entries were deleted by hand alongside this: six PR-scoped caches whose PRs (#164, #171, #173, #174) had merged, and four superseded key hashes on `refactor/v3` that no run could match any more. Note that `save-if` does not address that second kind — rust-cache never deletes its own superseded entries, so they linger until the 7-day TTL or an eviction, and the directory is worth a manual sweep now and then. 9.41 GiB -> 2.61 GiB, 3 entries.

Considered and rejected: `CARGO_PROFILE_DEV_DEBUG: line-tables-only`, which would roughly halve `ci-tauri`. With 7.4 GB now free it buys budget nobody needs, and because `rust-cache` hashes `CARGO*`/`RUST*` env vars into its key, adding it would invalidate every cache here for one cold run. Worth revisiting only if cache pressure returns, or as part of a measured pass at CI wall-clock time — where the `tauri` job's apt step is the larger target anyway.