### PR TITLE
ci(gitee): keep Dependabot out of the mirror

### DIFF
--- a/.github/workflows/sync-to-gitee.yml
+++ b/.github/workflows/sync-to-gitee.yml
@@ -14,6 +14,14 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # Dependabot-triggered runs read a separate secret store, so every
+    # `secrets.GITEE_*` below expands to an empty string and the remote URL
+    # collapses to `https://gitee.com/.git` -- `fatal: repository not found`,
+    # every single time. That was the bulk of this workflow's failures. Skipping
+    # loses no mirroring: the branches Dependabot pushes are excluded from the
+    # mirror below anyway, and merging its PRs is a human action whose own push
+    # event still runs this job.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout GitHub code
         uses: actions/checkout@v7
@@ -39,12 +47,26 @@ jobs:
         run: |
           set -u
 
+          # Dependabot's PR branches are transient and worth nothing on the mirror,
+          # and they are where the remaining ref races came from: a batch of merges
+          # deletes several of them while a mirror run is in flight, and the
+          # force-push then reports "incorrect old value provided" or "reference
+          # does not exist". Dropping the remote-tracking refs keeps them out of
+          # the push, and --prune deletes the ones already on Gitee. The pattern is
+          # a literal prefix, which git matches up to a slash, so it covers the
+          # full refs/remotes/origin/dependabot/<ecosystem>/<dep> shape.
+          drop_dependabot_refs() {
+            git for-each-ref --format='%(refname)' refs/remotes/origin/dependabot |
+              while read -r ref; do git update-ref -d "$ref"; done
+          }
+
           # Re-fetch right before pushing: a branch deleted since checkout is the
           # "reference does not exist" rejection.
           refresh() {
             git fetch --prune --prune-tags --force origin \
               "+refs/heads/*:refs/remotes/origin/*" "+refs/tags/*:refs/tags/*"
             git remote set-head origin -d || true  # drop origin/HEAD so it is not pushed as a branch
+            drop_dependabot_refs
           }
 
           # True mirror: origin wins for every branch and tag; --prune deletes


### PR DESCRIPTION
近 250 次运行里，Gitee 镜像失败 42 次 / 共 123 次，是仓库里最吵的一个 workflow，而且全部可以追到 Dependabot。两个独立的成因，这里一起收掉。

## 1. Dependabot 触发的运行必然失败

Dependabot 触发的 workflow 读的是独立的 secret store，所以 `secrets.GITEE_TOKEN` 与 `secrets.GITEE_REPO` 展开为空串，远程 URL 塌缩成 `https://gitee.com/.git`：

```
fatal: repository 'https://gitee.com/.git/' not found
```

每个 Dependabot PR 从开到合会产生三到四次这样的红叉。现在按 actor 跳过该 job。不丢任何镜像内容：它推的分支下面本来就被排除，而合并它的 PR 是人的动作，那次 push 事件照常触发本 job。

## 2. 剩下的 ref 竞态也都在 `dependabot/*` 上

Dependabot 一次最多开 5 个 PR，集中合并会同时删掉好几个分支，撞上在途的 mirror run，force-push 随即拒绝：

```
! [remote rejected] origin/dependabot/npm_and_yarn/intlify/unplugin-vue-i18n-11.2.5 -> ... (incorrect old value provided)
! [remote rejected] dependabot/npm_and_yarn/npm-minor-and-patch-... (reference does not exist)
```

#170 加的 concurrency group 把运行串行化了，但救不了这一类——ref 是在某次运行已经过了 fetch 之后才动的。现在每次 `refresh` 之后丢掉 `refs/remotes/origin/dependabot` 下的 remote-tracking ref，整类问题消失。

因为 push refspec 是带 `--prune` 的通配，这一改顺带把 Gitee 上已经堆着的 dependabot 分支在下次运行时清掉，而不是一直留着。

## 验证

- YAML 解析通过，`if` 表达式与 5 个 step 正常解出；`bash -n` 检查 `Push to Gitee` 整个 run block 语法 OK。
- 端到端模拟：两个本地裸库当 origin 与 gitee，按当前真实状态种上 `master` / `refactor/v3` / 两个 dependabot 分支 / 一个 tag，原样跑改后的 `refresh` + `push_all`：

```
--- gitee AFTER ---
refs/heads/master
refs/heads/refactor/v3
refs/tags/v3.2.9
PASS: dependabot branches gone, code branches and tags intact
```

- `git for-each-ref` 用字面前缀而非通配：git 按斜杠边界匹配，`refs/remotes/origin/dependabot` 能覆盖 `dependabot/npm_and_yarn/vite-8.2.2` 这种嵌套形状，已在真实仓库上单独确认。

## 范围

镜像内容不变，仍然只有代码与标签，以 git ref 推送。发布产物从来没走过这里，桌面版也早已停止发布到 Gitee（见 `docs/release.md` 的「Gitee 镜像已下线」）。唯一还在往 Gitee 上传产物的是 `release-auth-firmware.yml`，那是独立的手动 workflow，不在本次范围内。

远程 URL 里硬编码的 `flyingcys` 用户名保持原样——2026-08-04 的审计把它和「无分支过滤」一起标了，但只有过滤是正确性问题。
