### PR TITLE
build(deps): bump the bridge to muda 0.19 + tray-icon 0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,27 +2933,6 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
-dependencies = [
- "crossbeam-channel",
- "dpi",
- "gtk",
- "keyboard-types",
- "libxdo",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-foundation",
- "once_cell",
- "png 0.17.16",
- "thiserror 2.0.20",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "muda"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
@@ -2962,6 +2941,7 @@ dependencies = [
  "dpi",
  "gtk",
  "keyboard-types",
+ "libxdo",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
@@ -5225,7 +5205,7 @@ dependencies = [
  "libc",
  "log",
  "mime",
- "muda 0.19.3",
+ "muda",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -5247,7 +5227,7 @@ dependencies = [
  "tauri-utils",
  "thiserror 2.0.20",
  "tokio",
- "tray-icon 0.24.2",
+ "tray-icon",
  "url",
  "webkit2gtk",
  "webview2-com",
@@ -5982,27 +5962,6 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
-dependencies = [
- "crossbeam-channel",
- "dirs",
- "libappindicator",
- "muda 0.17.1",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation",
- "once_cell",
- "png 0.17.16",
- "thiserror 2.0.20",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "tray-icon"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
@@ -6010,7 +5969,7 @@ dependencies = [
  "crossbeam-channel",
  "dirs",
  "libappindicator",
- "muda 0.19.3",
+ "muda",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
@@ -6098,7 +6057,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.4.2",
  "log",
- "muda 0.17.1",
+ "muda",
  "png 0.17.16",
  "serde",
  "serde_json",
@@ -6107,7 +6066,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "toml 0.8.2",
- "tray-icon 0.21.3",
+ "tray-icon",
  "tyutool-core",
  "windows-sys 0.61.2",
  "winresource",

--- a/crates/tyutool-bridge/Cargo.toml
+++ b/crates/tyutool-bridge/Cargo.toml
@@ -27,7 +27,7 @@ dirs = "6"
 fern = "0.7"
 getrandom = "0.4"
 log = "0.4"
-muda = "0.17"
+muda = "0.19"
 # Decodes the embedded tray artwork (see `tray_glyph`). `tray_icon::Icon` only
 # takes raw RGBA, and `Icon::from_path` would mean shipping a loose file and
 # resolving it inside the `.app` bundle at runtime — embedding the PNG and
@@ -36,7 +36,7 @@ muda = "0.17"
 # no new version to the tree.
 png = "0.17"
 tao = "0.35"
-tray-icon = "0.21"
+tray-icon = "0.24"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # The GUI-process locale, read from CFLocale / GetUserDefaultLocaleName rather


### PR DESCRIPTION
Supersedes #183.

Dependabot's #183 moved `muda` 0.17 → 0.19 alone and failed `Bridge (clippy + test)`
with `E0277`: `tray-icon 0.21` re-exports its **own** muda 0.17 as
`tray_icon::menu`, so a direct muda 0.19 put two copies in the tree and
`muda::Menu` (0.19) no longer satisfied `tray_icon::menu::ContextMenu` (0.17).
The two crates are a matched pair and must move together.

Moving both **removes** duplicates instead of adding one — the workspace lock
already carried tray-icon 0.24.2 + muda 0.19.3 for the Tauri side, so muda 0.17.1
and tray-icon 0.21.3 drop out of the tree entirely (net −49 lines in `Cargo.lock`).

No bridge source change was needed. `windows-sys` still resolves as the comment in
`Cargo.toml` describes: muda 0.19 and tray-icon 0.24 both still pull 0.60.2.

Verified locally:
- `cargo clippy -p tyutool-bridge --all-targets -- -D warnings` — clean
- `cargo test -p tyutool-bridge` — all pass
- `cargo fmt --all --check` — clean