### PR TITLE
build(config): drop the deprecated tsconfig `baseUrl`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "preserve",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
Unblocks #185 (typescript 5.6.3 → 6.0.3).

`baseUrl` is deprecated in TypeScript 6.0 and raises a hard `TS5101` there, which
is the *only* thing failing on #185. That error is **config-level**, so `vue-tsc`
aborts before type-checking anything — the one-line failure on #185 tells you
nothing about whether `src/` compiles under 6.0.

I checked that separately: with `typescript@6.0.3` installed and this line removed,
all four frontend gates pass with zero type errors —
`pnpm run lint`, `pnpm run typecheck:scripts`, `pnpm run test:coverage`,
`pnpm run build`.

**Why remove it rather than set `"ignoreDeprecations": "6.0"`** — the latter only
defers the same work to TypeScript 7.0, where the option is removed outright.

**Why nothing breaks:** the only non-relative import form in the repo is `@/*`,
which comes from `paths`, and `paths` has not needed `baseUrl` since TypeScript
4.4 — entries resolve relative to the tsconfig instead. (`grep` finds no
`from "src/..."`-style imports.) The Vite and vitest `@` aliases are configured
independently in `vite.config.ts` / `vitest.config.ts` and are untouched.

This commit is deliberately on its own branch rather than pushed onto the
Dependabot branch, so #185 stays a pure version bump and Dependabot keeps
managing it. It is also valid on the current 5.6.3 — verified locally, full gate
green before the bump.