### PR TITLE
ci(ram-loader): make the Gitee publish opt-in until it is fixed

### DIFF
--- a/.github/workflows/release-ram-loader.yml
+++ b/.github/workflows/release-ram-loader.yml
@@ -11,6 +11,15 @@ name: Release ram-loader
 # See assets/ram-loader/README.md.
 on:
   workflow_dispatch:
+    inputs:
+      publish_gitee:
+        description: >-
+          Also publish to the Gitee mirror. Off by default: creating the
+          `ram-loader` release on Gitee currently fails with HTTP 400
+          "创建标签失败" because no valid `target_commitish` is configured
+          (see the Gitee steps below). Turn this on once that is fixed.
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -72,7 +81,15 @@ jobs:
           echo "upload manifest (clobber): ram-loader.json"
           gh release upload "$TAG" ram-loader.json --clobber
 
+      # Both Gitee steps are opt-in while the mirror publish is broken. The release
+      # creation fails with HTTP 400 "创建标签失败：ram-loader": the publisher script
+      # falls back to `target_commitish = <tag>` when GITEE_TARGET_COMMITISH is unset,
+      # and that ref does not exist on Gitee — it is the very tag being created. Set an
+      # Actions variable GITEE_TARGET_COMMITISH to a real Gitee branch (e.g. `master`)
+      # and re-enable, rather than leaving these steps to fail the whole run and take
+      # the CDN artifact down with them.
       - name: Generate Gitee manifest
+        if: ${{ inputs.publish_gitee }}
         env:
           GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
           GITEE_USER: ${{ secrets.GITEE_USER }}
@@ -102,6 +119,7 @@ jobs:
             pnpm exec tsx scripts/generate-ram-loader-manifest.ts
 
       - name: Publish to Gitee release
+        if: ${{ inputs.publish_gitee }}
         env:
           GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
           GITEE_USER: ${{ secrets.GITEE_USER }}


### PR DESCRIPTION
The 2026-09-02 `Release ram-loader` dispatch ([run 33587946243](https://github.com/tuya/tyutool/actions/runs/33587946243)) published to GitHub correctly and then failed on **Publish to Gitee release**:

```
Gitee release lookup returned no id for tag ram-loader; creating release.
Create Gitee release failed: HTTP 400
{ "message": "创建标签失败：ram-loader" }
```

### Cause

`scripts/publish-firmware-assets-gitee.sh:93` does

```bash
TGT="${GITEE_TARGET_COMMITISH:-$TAG}"
```

and that line is only reached inside the `HTTP_CODE == 404` branch — i.e. **only when the release and its tag do not exist yet**. So defaulting `target_commitish` to the tag name asks Gitee to cut the tag from a ref that is, by construction, the very tag being created. It can never succeed on a first publish.

The workflow feeds that variable from `${{ vars.GITEE_TARGET_COMMITISH }}`, which is not configured on this repo (`gh api repos/tuya/tyutool/actions/variables` returns nothing), so the fallback is what ran. The script's own comment at line 16 already says to pass a branch name in this case — nothing ever did.

### Why gate it rather than leave it failing

The Gitee step sits before *Generate CDN manifest* and *Upload the CDN bundle*, so its failure also cost the run its `ram-loader-cdn` artifact — one unconfigured mirror took out the other. With this change a dispatch publishes GitHub + produces the CDN bundle, and the disabled mirror is explicit instead of a tolerated red run.

### Current state of the mirrors

`ram_loader::MANIFEST_MIRRORS` is GitHub → Gitee → Tuya CDN. GitHub is fully published (both bins + `ram-loader.json`, digests match the pinned `RamLoaderRef`s). **Gitee and the CDN are both empty**, so there is currently no working mirror for users who cannot reach GitHub. This is meant to be temporary.

### To re-enable

Set an Actions variable `GITEE_TARGET_COMMITISH` to a branch that exists on the Gitee mirror — `master` (its default), `refactor/v3`, `open_cli` or `release/v2` — then dispatch with `publish_gitee` ticked.

### Out of scope

`release-auth-firmware` also fails on its Gitee step, but for an unrelated reason and not touched here: `验证失败：文件大小已超出仓库附件配额：1 GB`.