### PR TITLE
fix(beken): restore the ZG25Q64B flash table entry dropped in c697d46

### DIFF
--- a/crates/tyutool-core/src/plugins/beken/flash_table.rs
+++ b/crates/tyutool-core/src/plugins/beken/flash_table.rs
@@ -517,6 +517,16 @@ static FLASH_TABLE: &[FlashParams] = &[
         block_size: 64 * KB,
         wp: wp2(SR12_READ, SR12_WRITE_SINGLE, 0x407c, 0x0007),
     },
+    // ── ZG ─────────────────────────────────────────
+    FlashParams {
+        mid: 0x1760cd,
+        name: "ZG25Q64B",
+        vendor: "ZG",
+        total_size: 64 * MB / 8,
+        sector_size: 4 * KB,
+        block_size: 64 * KB,
+        wp: wp2(SR12_READ, SR12_WRITE, 0x0038, 0x0038),
+    },
 ];
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -582,5 +592,22 @@ mod tests {
         assert_eq!(p.mid, 0xABCDEF);
         assert_eq!(p.total_size, 2 * 1024 * 1024);
         assert!(p.wp.is_none());
+    }
+
+    #[test]
+    fn lookup_zg25q64b() {
+        let p = lookup(0x1760cd).unwrap();
+        assert_eq!(p.name, "ZG25Q64B");
+        assert_eq!(p.vendor, "ZG");
+        assert_eq!(p.total_size, 8 * 1024 * 1024); // 64 Mbit = 8 MiB
+        assert_eq!(p.sector_size, 4096);
+        assert_eq!(p.block_size, 65536);
+        let wp = p.wp.unwrap();
+        assert_eq!(wp.sr_bytes, 2);
+        assert_eq!(wp.read_sr_cmds, &[0x05, 0x35]);
+        assert_eq!(wp.write_sr_cmds, &[0x01, 0x31]);
+        assert_eq!(wp.protect_mask, 0x0038);
+        assert_eq!(wp.unprotect_value, 0x0000);
+        assert_eq!(wp.protect_value, 0x0038);
     }
 }


### PR DESCRIPTION
## Problem

A T5AI board with a Ziguang ZG25Q64B flash (MID `0x1760cd`) fails to flash on v3.2.9. From the session log:

```
Flash MID: 0x1760cd not in table — using fallback (2048 KiB)
no WP config — skipping unprotect
64K erase at 0x00000000 VERIFY FAILED: CRC=0x79686d39 expected_blank=0x0eab98f5
4K fallback erase at 0x00000000 VERIFY FAILED: CRC=0x79686d39 expected_blank=0x0eab98f5
```

The erase command is ack'd with status 0, but the CRC of the first 4K never changes — across the 64K erase, the 4K fallback, and three retries. The flash's BP protect bits are never cleared because the unknown MID falls back to no-WP params, so `unprotect_flash` is skipped entirely.

## Root cause

The entry was added in 128d51d (2026-06-05, WP config derived from a vendor-tool USB capture) and accidentally deleted 11 days later by the broad refactor c697d46 — its message doesn't mention the removal, and the `flash_table.rs` diff there is exactly this entry plus its test.

## Fix

Restore both verbatim from 128d51d:

- `FLASH_TABLE` entry: MID `0x1760cd`, ZG25Q64B, 8 MiB, `wp2(SR12_READ, SR12_WRITE, 0x0038, 0x0038)`
- `lookup_zg25q64b` unit test

This also fixes the size detection: the fallback guessed 2 MiB, while the part is 8 MiB.

## Verification

- `cargo test -p tyutool-core flash_table` — 5/5 pass (incl. restored test)
- `cargo fmt --all --check` clean
- `cargo clippy -p tyutool-core --all-targets -- -D warnings` clean

Pending: re-flash the affected board with a build containing this fix to confirm erase verify passes.